### PR TITLE
Add memdump options to k8s configs.

### DIFF
--- a/agent_deploy/google_gke/sysdig-gke_daemon-set-method/sysdig.jinja
+++ b/agent_deploy/google_gke/sysdig-gke_daemon-set-method/sysdig.jinja
@@ -18,6 +18,9 @@ resources:
             name: sysdig-agent
         spec:
           volumes:
+          - name: dshm
+            emptyDir:
+              medium: Memory
           - name: docker-sock
             hostPath:
              path: /var/run/docker.sock
@@ -78,3 +81,5 @@ resources:
             - mountPath: /host/usr
               name: usr-vol
               readOnly: true
+            - mountPath: /dev/shm
+              name: dshm

--- a/agent_deploy/kubernetes/sysdig-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-daemonset.yaml
@@ -13,6 +13,9 @@ spec:
         name: sysdig-agent
     spec:
       volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
       - name: docker-sock
         hostPath:
          path: /var/run/docker.sock
@@ -76,3 +79,5 @@ spec:
         - mountPath: /host/usr
           name: usr-vol
           readOnly: true
+        - mountPath: /dev/shm
+          name: dshm

--- a/agent_deploy/kubernetes/sysdig-rc.yaml
+++ b/agent_deploy/kubernetes/sysdig-rc.yaml
@@ -14,6 +14,9 @@ spec:
         name: sysdig-agent
     spec:
       volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
       - name: docker-sock
         hostPath:
          path: /var/run/docker.sock
@@ -78,3 +81,5 @@ spec:
         - mountPath: /host/usr
           name: usr-vol
           readOnly: true
+        - mountPath: /dev/shm
+          name: dshm


### PR DESCRIPTION
When back-in-time aka memdump is enabled, it requires a larger /dev/shm
filesystem than is normally provided in k8s. To work around this, in the
pod specification create a memory-backed volume and mount it to
/dev/shm.

This allows for having an agent configuration that is eventually
compatible with back-in-time captures so it doesn't have to be changed later.