### PR TITLE
Improve SAML helper scripts

### DIFF
--- a/SAML/get_saml_config.sh
+++ b/SAML/get_saml_config.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+DEFAULT_SDC_API_URL='https://app.sysdigcloud.com'
+
+echo -n "Enter API URL [${DEFAULT_SDC_API_URL}]: "
+read SDC_API_URL
+if [ "z${SDC_API_URL}" = "z" ] ; then
+  SDC_API_URL=${DEFAULT_SDC_API_URL}
+fi
+
+API_TOKEN=""
+while [ "z${API_TOKEN}" = "z" ] ; do
+  echo -n "Enter Admin API Token (required): "
+  read API_TOKEN
+done
+
+CUSTOMER_ID=""
+while [ "z${CUSTOMER_ID}" = "z" ] ; do
+  echo -n "Enter Customer ID # (required): "
+  read CUSTOMER_ID
+done
+
+set -x
+
+curl -v -k ''"${SDC_API_URL}"'/api/admin/customer/'"${CUSTOMER_ID}"'/saml/' \
+     -H 'Authorization: Bearer '"${API_TOKEN}"''

--- a/SAML/set_saml_config.sh
+++ b/SAML/set_saml_config.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 DEFAULT_SDC_API_URL='https://app.sysdigcloud.com'
 DEFAULT_SIGNED_ASSERTION='true'
 DEFAULT_EMAIL_PARAM='email'
@@ -15,6 +15,7 @@ while [ "z${API_TOKEN}" = "z" ] ; do
   read API_TOKEN
 done
 
+METADATA_URL=""
 while [ "z${METADATA_URL}" = "z" ] ; do
   echo -n "Enter Metadata URL from IDP (required): "
   read METADATA_URL
@@ -40,7 +41,7 @@ fi
 
 set -x
 
-curl -XPOST -k -s ''"${SDC_API_URL}"'/api/admin/customer/'"${CUSTOMER_ID}"'/saml/' \
+curl -XPOST -v -k ''"${SDC_API_URL}"'/api/admin/customer/'"${CUSTOMER_ID}"'/saml/' \
            -H 'Content-Type: application/json; charset=UTF-8' \
            -H 'Accept: application/json, text/javascript, */*; q=0.01' \
            -H 'Authorization: Bearer '"${API_TOKEN}"'' \


### PR DESCRIPTION
- Point to `bash` so the `echo -n` works correctly on Mac
- Make separate scripts for setting and getting config
- Turn off the silent option and use verbose instead so we can have the docs tell them to look for 200 OK
