### PR TITLE
Adding RBAC example, option to run on masters

### DIFF
--- a/agent_deploy/kubernetes/sysdig-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-daemonset.yaml
@@ -1,9 +1,10 @@
 #Use this sysdig.yaml when Daemon Sets are enabled on Kubernetes (minimum version 1.1.1). Otherwise use the RC method.
 
 apiVersion: extensions/v1beta1
-kind: DaemonSet                     
+kind: DaemonSet
 metadata:
   name: sysdig-agent
+  namespace: kube-system
   labels:
     app: sysdig-agent
 spec:
@@ -36,11 +37,15 @@ spec:
           path: /usr
       hostNetwork: true
       hostPID: true
- #    serviceAccount: sysdigcloud                           #OPTIONAL - OpenShift service account for OpenShift
+#      serviceAccount: sysdigcloud                           #OPTIONAL - OpenShift service account for OpenShift
+#      serviceAccountName: sysdig-agent                      #OPTIONAL - For when RBAC is enabled
+#      tolerations:                                          #OPTIONAL - To enable running on masters
+#      - operator: "Exists"                                  #OPTIONAL - To enable running on masters
+#        effect: "NoSchedule"                                #OPTIONAL - To enable running on masters
       containers:
       - name: sysdig-agent
         image: sysdig/agent
-#        imagePullPolicy: Always                            #OPTIONAL - Always pull the latest container image tag 
+#        imagePullPolicy: Always                            #OPTIONAL - Always pull the latest container image tag
         securityContext:
          privileged: true
         env:
@@ -49,10 +54,10 @@ spec:
 #        - name: COLLECTOR_PORT                             #OPTIONAL - on-prem install only
 #          value: "6443"
 #        - name: TAGS                                       #OPTIONAL
-#          value: linux:ubuntu,dept:dev,local:nyc 
+#          value: linux:ubuntu,dept:dev,local:nyc
 #        - name: COLLECTOR                                  #OPTIONAL - on-prem install only
-#          value: 192.168.183.200 
-#        - name: SECURE                                     #OPTIONAL - on-prem install only       
+#          value: 192.168.183.200
+#        - name: SECURE                                     #OPTIONAL - on-prem install only
 #          value: "true"
 #        - name: CHECK_CERTIFICATE                          #OPTIONAL - on-prem install only
 #          value: "false"

--- a/agent_deploy/kubernetes/sysdig-rbac.yaml
+++ b/agent_deploy/kubernetes/sysdig-rbac.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sysdig-agent
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: sysdig-agent
+rules:
+- apiGroups:
+  - "extensions"
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  - pods
+  - replicationcontrollers
+  - services
+  - events
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - /healthz
+  - /healthz/*
+  verbs:
+  - get
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: sysdig-agent
+subjects:
+  - kind: ServiceAccount
+    namespace: kube-system
+    name: sysdig-agent
+roleRef:
+  kind: ClusterRole
+  name: sysdig-agent
+  apiGroup: rbac.authorization.k8s.io

--- a/agent_deploy/kubernetes/sysdig-rbac.yaml
+++ b/agent_deploy/kubernetes/sysdig-rbac.yaml
@@ -22,6 +22,9 @@ rules:
   - services
   - events
   - ingresses
+  - deployments
+  - daemonsets
+  - replicasets
   verbs:
   - get
   - list


### PR DESCRIPTION
- Adding example RBAC YAML file as the example in the [instructions](https://support.sysdig.com/hc/en-us/articles/206770633) is out of date (API versions have changed)
- Moving daemonset to `kube-system` namespace. It belongs there.
- Adding optional example in order to have the daemonset run on master instances.

In the future, you should write a helm chart 🙂