### PR TITLE
Helper scripts for API-based LDAP config (NOT yet for merge!)

### DIFF
--- a/LDAP/README.md
+++ b/LDAP/README.md
@@ -1,0 +1,1 @@
+Helper scripts found here are for use with a new Sysdig platform feature that is currently undergoing beta testing.

--- a/LDAP/create_user
+++ b/LDAP/create_user
@@ -51,7 +51,7 @@ elif [ $SET = true ] ; then
   fi
   cat $SETTINGS_JSON | ${JSON_FILTER} > /dev/null 2>&1
   if [ $? -eq 0 ]; then
-    curl $CURL_VERBOSITY $CURL_INS \
+    curl $CURL_OPTS \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer $API_TOKEN" \
       -X POST \

--- a/LDAP/create_user
+++ b/LDAP/create_user
@@ -1,10 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-OPTS=`getopt -o s: --long set: -n 'parse-options' -- "$@"`
+OPTS=`getopt -o s:h --long set:,help -n 'parse-options' -- "$@"`
 ENV="./env.sh"
 
-HELP=false
 SET=false
 SETTINGS_JSON=""
 HELP=false
@@ -14,7 +13,7 @@ if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
 eval set -- "$OPTS"
 
 function print_usage() {
-  echo "Usage: ./user_create [OPTION]"
+  echo "Usage: ./create_user [OPTION]"
   echo
   echo "Create a user record in advance of their possible login via LDAP"
   echo

--- a/LDAP/create_user
+++ b/LDAP/create_user
@@ -1,14 +1,15 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
 OPTS=`getopt -o s:h --long set:,help -n 'parse-options' -- "$@"`
+if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
+
 ENV="./env.sh"
 
 SET=false
 SETTINGS_JSON=""
 HELP=false
 
-if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
 
 eval set -- "$OPTS"
 
@@ -50,7 +51,7 @@ elif [ $SET = true ] ; then
   fi
   cat $SETTINGS_JSON | ${JSON_FILTER} > /dev/null 2>&1
   if [ $? -eq 0 ]; then
-    curl -s $CURL_VERBOSITY $CURL_INS \
+    curl $CURL_VERBOSITY $CURL_INS \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer $API_TOKEN" \
       -X POST \

--- a/LDAP/create_user
+++ b/LDAP/create_user
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+OPTS=`getopt -o s: --long set: -n 'parse-options' -- "$@"`
+ENV="./env.sh"
+
+HELP=false
+SET=false
+SETTINGS_JSON=""
+HELP=false
+
+if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
+
+eval set -- "$OPTS"
+
+function print_usage() {
+  echo "Usage: ./user_create [OPTION]"
+  echo
+  echo "Create a user record in advance of their possible login via LDAP"
+  echo
+  echo "Options:"
+  echo "  -s | --set  JSON_FILE   Create the user described in the contents of JSON_FILE"
+  echo "  -h | --help             Print this Usage output"
+  exit 1
+}
+
+while true; do
+  case "$1" in
+    -s | --set ) SET=true; SETTINGS_JSON="$2"; shift; shift;;
+    -h | --help ) HELP=true; shift ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+if [ $# -gt 0 ] ; then
+  echo "Excess command-line arguments detected. Exiting."
+  echo
+  print_usage
+fi
+
+source $ENV
+
+if [ $HELP = true ] ; then
+  print_usage
+
+elif [ $SET = true ] ; then
+  if [ ! -e $SETTINGS_JSON ] ; then
+    echo "Settings file \"$SETTINGS_JSON\" does not exist. No user was created."
+  exit 1
+  fi
+  cat $SETTINGS_JSON | ${JSON_FILTER} > /dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    curl -s $CURL_VERBOSITY $CURL_INS \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer $API_TOKEN" \
+      -X POST \
+      -d @$SETTINGS_JSON \
+      $URL/api/admin/user
+    exit $?
+  else
+    echo "\"$SETTINGS_JSON\" contains invalid JSON. No user was created."
+    exit 1
+  fi
+
+else
+  print_usage
+fi

--- a/LDAP/env.sh
+++ b/LDAP/env.sh
@@ -23,8 +23,9 @@ export CURL_INS="-k"
 
 #
 # Change this to "-v" if you want curl to print verbose output, such as for debugging.
+# The "-s" keeps curl in silent mode to make outputs brief.
 #
-export CURL_VERBOSITY=""
+export CURL_VERBOSITY="-s"
 #export CURL_VERBOSITY="-v"
 
 #

--- a/LDAP/env.sh
+++ b/LDAP/env.sh
@@ -15,18 +15,22 @@ export API_TOKEN="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 export URL="https://10.0.0.1"
 
 #
-# Leave this set to "-k" to allow curl to connect to your Sysdig API even if a self-
-# signed certificate is in use (the default in a Sysdig software platform install).
+# Set options used in other scripts that invoke curl. We've set these to what we think
+# are sensible defaults:
 #
-export CURL_INS="-k"
-#export CURL_SEC=""
-
+# -s
+#    Silent mode, to make outputs brief. If you're debugging and want verbose outputs,
+#    you might want to change this to -v.
 #
-# Change this to "-v" if you want curl to print verbose output, such as for debugging.
-# The "-s" keeps curl in silent mode to make outputs brief.
+# -k
+#    Leave this set to "-k" to allow curl to connect to your Sysdig API even if a self-
+#    signed certificate is in use (the default in a Sysdig software platform install).
 #
-export CURL_VERBOSITY="-s"
-#export CURL_VERBOSITY="-v"
+# -w \n
+#    Print a newline after curl prints responses. This will make the Sysdig platform's
+#    JSON responses easier to read.
+#
+export CURL_OPTS="-s -k -w \n"
 
 #
 # If Python is installed on the host where you're running these helper scripts, this

--- a/LDAP/env.sh
+++ b/LDAP/env.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+#
+# Set this to the Sysdig Monitor API Token value shown in the Sysdig UI under
+# Settings->User Profile when logged in as the "Super" Admin User. For
+# information on locating this user, see the following article:
+#
+# https://support.sysdig.com/hc/en-us/articles/115004951443-Locating-the-Super-Admin-User
+#
+export API_TOKEN="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+#
+# Set this to the URL through which you access your Sysdig application UI.
+#
+export URL="https://10.0.0.1"
+
+#
+# Leave this set to "-k" to allow curl to connect to your Sysdig API even if a self-
+# signed certificate is in use (the default in a Sysdig software platform install).
+#
+export CURL_INS="-k"
+#export CURL_SEC=""
+
+#
+# Change this to "-v" if you want curl to print verbose output, such as for debugging.
+#
+export CURL_VERBOSITY=""
+#export CURL_VERBOSITY="-v"
+
+#
+# If Python is installed on the host where you're running these helper scripts, this
+# will enable some extra features like pretty printing of JSON output and checking if
+# JSON inputs are syntactically valid. If Python is not installed, it uses a no-op
+# "cat" instead and you'll get unformatted output and you'll get HTTP error codes
+# if you try to POST invalid JSON.
+#
+if hash python 2>/dev/null ; then
+  export JSON_FILTER="python -m json.tool"
+else
+  export JSON_FILTER="cat"
+fi

--- a/LDAP/login_config
+++ b/LDAP/login_config
@@ -59,7 +59,7 @@ elif [ $SET = true ] ; then
     fi
     cat $SETTINGS_JSON | ${JSON_FILTER} > /dev/null 2>&1
     if [ $? -eq 0 ]; then
-      curl $CURL_VERBOSITY $CURL_INS \
+      curl $CURL_OPTS \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $API_TOKEN" \
         -X POST \
@@ -76,7 +76,7 @@ elif [ $DELETE = true ] ; then
   if [ $SET = true ] ; then
     print_usage
   else
-    curl $CURL_VERBOSITY $CURL_INS \
+    curl $CURL_OPTS \
       -H "Authorization: Bearer $API_TOKEN" \
       -X DELETE \
       $URL/api/admin/ldap/settings
@@ -84,7 +84,7 @@ elif [ $DELETE = true ] ; then
   fi
 
 else
-  curl $CURL_VERBOSITY $CURL_INS \
+  curl $CURL_OPTS \
     -H "Authorization: Bearer $API_TOKEN" \
     -X GET \
     $URL/api/admin/ldap/settings | ${JSON_FILTER}

--- a/LDAP/login_config
+++ b/LDAP/login_config
@@ -1,7 +1,9 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
 OPTS=`getopt -o s:dh --long set:,delete,help -n 'parse-options' -- "$@"`
+if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
+
 ENV="./env.sh"
 
 SET=false
@@ -9,7 +11,6 @@ SETTINGS_JSON=""
 DELETE=false
 HELP=false
 
-if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
 
 eval set -- "$OPTS"
 
@@ -58,7 +59,7 @@ elif [ $SET = true ] ; then
     fi
     cat $SETTINGS_JSON | ${JSON_FILTER} > /dev/null 2>&1
     if [ $? -eq 0 ]; then
-      curl -s $CURL_VERBOSITY $CURL_INS \
+      curl $CURL_VERBOSITY $CURL_INS \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $API_TOKEN" \
         -X POST \
@@ -75,7 +76,7 @@ elif [ $DELETE = true ] ; then
   if [ $SET = true ] ; then
     print_usage
   else
-    curl -s $CURL_VERBOSITY $CURL_INS \
+    curl $CURL_VERBOSITY $CURL_INS \
       -H "Authorization: Bearer $API_TOKEN" \
       -X DELETE \
       $URL/api/admin/ldap/settings
@@ -83,7 +84,7 @@ elif [ $DELETE = true ] ; then
   fi
 
 else
-  curl -s $CURL_VERBOSITY $CURL_INS \
+  curl $CURL_VERBOSITY $CURL_INS \
     -H "Authorization: Bearer $API_TOKEN" \
     -X GET \
     $URL/api/admin/ldap/settings | ${JSON_FILTER}

--- a/LDAP/login_config
+++ b/LDAP/login_config
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -euo pipefail
+
+OPTS=`getopt -o s:dh --long set:,delete,help -n 'parse-options' -- "$@"`
+ENV="./env.sh"
+
+HELP=false
+SET=false
+SETTINGS_JSON=""
+DELETE=false
+HELP=false
+
+if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
+
+eval set -- "$OPTS"
+
+function print_usage() {
+  echo "Usage: ./login_config [OPTION]"
+  echo
+  echo "Affect LDAP login settings for your Sysdig software platform installation"
+  echo
+  echo "If no OPTION is specified, the current login config settings are printed"
+  echo
+  echo "Options:"
+  echo "  -s | --set  JSON_FILE   Set the current LDAP login config to the contents of JSON_FILE"
+  echo "  -d | --delete           Delete the current LDAP login config"
+  echo "  -h | --help             Print this Usage output"
+  exit 1
+}
+
+while true; do
+  case "$1" in
+    -s | --set ) SET=true; SETTINGS_JSON="$2"; shift; shift ;;
+    -d | --delete ) DELETE=true; shift ;;
+    -h | --help ) HELP=true; shift ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+if [ $# -gt 0 ] ; then
+  echo "Excess command-line arguments detected. Exiting."
+  echo
+  print_usage
+fi
+
+source $ENV
+
+if [ $HELP = true ] ; then
+  print_usage
+
+elif [ $SET = true ] ; then
+  if [ $DELETE = true ] ; then
+    print_usage
+  else
+    if [ ! -e $SETTINGS_JSON ] ; then
+      echo "Settings file \"$SETTINGS_JSON\" does not exist. No settings were changed."
+      exit 1
+    fi
+    cat $SETTINGS_JSON | ${JSON_FILTER} > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      curl -s $CURL_VERBOSITY $CURL_INS \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $API_TOKEN" \
+        -X POST \
+        -d @$SETTINGS_JSON \
+        $URL/api/admin/ldap/settings
+      exit $?
+    else
+      echo "\"$SETTINGS_JSON\" contains invalid JSON. No settings were changed."
+      exit 1
+    fi
+  fi
+
+elif [ $DELETE = true ] ; then
+  if [ $SET = true ] ; then
+    print_usage
+  else
+    curl -s $CURL_VERBOSITY $CURL_INS \
+      -H "Authorization: Bearer $API_TOKEN" \
+      -X DELETE \
+      $URL/api/admin/ldap/settings
+    exit $?
+  fi
+
+else
+  curl -s $CURL_VERBOSITY $CURL_INS \
+    -H "Authorization: Bearer $API_TOKEN" \
+    -X GET \
+    $URL/api/admin/ldap/settings | ${JSON_FILTER}
+  exit $?
+fi

--- a/LDAP/login_config
+++ b/LDAP/login_config
@@ -4,7 +4,6 @@ set -euo pipefail
 OPTS=`getopt -o s:dh --long set:,delete,help -n 'parse-options' -- "$@"`
 ENV="./env.sh"
 
-HELP=false
 SET=false
 SETTINGS_JSON=""
 DELETE=false

--- a/LDAP/mapping_config
+++ b/LDAP/mapping_config
@@ -53,9 +53,8 @@ fi
 source $ENV
 
 function force_sync() {
-  echo
   echo "Forcing sync"
-  curl $CURL_VERBOSITY $CURL_INS \
+  curl $CURL_OPTS \
     -H "Authorization: Bearer $API_TOKEN" \
     -X PUT \
     $URL/api/admin/ldap/syncLdap
@@ -75,7 +74,7 @@ elif [ $SET = true ] ; then
     fi
     cat $SETTINGS_JSON | ${JSON_FILTER} > /dev/null 2>&1
     if [ $? -eq 0 ]; then
-      curl $CURL_VERBOSITY $CURL_INS \
+      curl $CURL_OPTS \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $API_TOKEN" \
         -X POST \
@@ -100,7 +99,7 @@ elif [ $DELETE = true ] ; then
   if [ $SET = true -o $REPORT = true ] ; then
     print_usage
   else
-    curl $CURL_VERBOSITY $CURL_INS \
+    curl $CURL_OPTS \
       -H "Authorization: Bearer $API_TOKEN" \
       -X DELETE \
       $URL/api/admin/ldap/settings/sync
@@ -119,7 +118,7 @@ elif [ $REPORT = true ] ; then
   if [ $SET = true -o $DELETE = true -o $FORCESYNC = true ] ; then
     print_usage
   else
-    curl $CURL_VERBOSITY $CURL_INS \
+    curl $CURL_OPTS \
       -H "Authorization: Bearer $API_TOKEN" \
       -X GET \
       $URL/api/admin/ldap/syncReport | ${JSON_FILTER}
@@ -134,7 +133,7 @@ elif [ $FORCESYNC = true ] ; then
   fi
 
 else
-  curl $CURL_VERBOSITY $CURL_INS \
+  curl $CURL_OPTS \
     -H "Authorization: Bearer $API_TOKEN" \
     -X GET \
     $URL/api/admin/ldap/settings/sync | ${JSON_FILTER}

--- a/LDAP/mapping_config
+++ b/LDAP/mapping_config
@@ -1,7 +1,9 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
 OPTS=`getopt -o s:frdh --long set:,forcesync,report,delete,help -n 'parse-options' -- "$@"`
+if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
+
 ENV="./env.sh"
 
 SET=false
@@ -11,7 +13,6 @@ REPORT=false
 DELETE=false
 HELP=false
 
-if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
 
 eval set -- "$OPTS"
 
@@ -54,7 +55,7 @@ source $ENV
 function force_sync() {
   echo
   echo "Forcing sync"
-  curl -s $CURL_VERBOSITY $CURL_INS \
+  curl $CURL_VERBOSITY $CURL_INS \
     -H "Authorization: Bearer $API_TOKEN" \
     -X PUT \
     $URL/api/admin/ldap/syncLdap
@@ -74,7 +75,7 @@ elif [ $SET = true ] ; then
     fi
     cat $SETTINGS_JSON | ${JSON_FILTER} > /dev/null 2>&1
     if [ $? -eq 0 ]; then
-      curl -s $CURL_VERBOSITY $CURL_INS \
+      curl $CURL_VERBOSITY $CURL_INS \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $API_TOKEN" \
         -X POST \
@@ -99,7 +100,7 @@ elif [ $DELETE = true ] ; then
   if [ $SET = true -o $REPORT = true ] ; then
     print_usage
   else
-    curl -s $CURL_VERBOSITY $CURL_INS \
+    curl $CURL_VERBOSITY $CURL_INS \
       -H "Authorization: Bearer $API_TOKEN" \
       -X DELETE \
       $URL/api/admin/ldap/settings/sync
@@ -118,7 +119,7 @@ elif [ $REPORT = true ] ; then
   if [ $SET = true -o $DELETE = true -o $FORCESYNC = true ] ; then
     print_usage
   else
-    curl -s $CURL_VERBOSITY $CURL_INS \
+    curl $CURL_VERBOSITY $CURL_INS \
       -H "Authorization: Bearer $API_TOKEN" \
       -X GET \
       $URL/api/admin/ldap/syncReport | ${JSON_FILTER}
@@ -133,7 +134,7 @@ elif [ $FORCESYNC = true ] ; then
   fi
 
 else
-  curl -s $CURL_VERBOSITY $CURL_INS \
+  curl $CURL_VERBOSITY $CURL_INS \
     -H "Authorization: Bearer $API_TOKEN" \
     -X GET \
     $URL/api/admin/ldap/settings/sync | ${JSON_FILTER}

--- a/LDAP/mapping_config
+++ b/LDAP/mapping_config
@@ -4,7 +4,6 @@ set -euo pipefail
 OPTS=`getopt -o s:frdh --long set:,forcesync,report,delete,help -n 'parse-options' -- "$@"`
 ENV="./env.sh"
 
-HELP=false
 SET=false
 SETTINGS_JSON=""
 FORCESYNC=false

--- a/LDAP/mapping_config
+++ b/LDAP/mapping_config
@@ -1,0 +1,142 @@
+#!/bin/bash
+set -euo pipefail
+
+OPTS=`getopt -o s:frdh --long set:,forcesync,report,delete,help -n 'parse-options' -- "$@"`
+ENV="./env.sh"
+
+HELP=false
+SET=false
+SETTINGS_JSON=""
+FORCESYNC=false
+REPORT=false
+DELETE=false
+HELP=false
+
+if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
+
+eval set -- "$OPTS"
+
+function print_usage() {
+  echo "Usage: ./mapping_config [OPTION]"
+  echo
+  echo "Affect LDAP mapping settings for your Sysdig software platform installation"
+  echo
+  echo "If no OPTION is specified, the current mapping config settings are printed"
+  echo
+  echo "Options:"
+  echo "  -s | --set  JSON_FILE   Set the current LDAP mapping config to the contents of JSON_FILE"
+  echo "  -f | --forcesync        Force an immediate sync"
+  echo "  -r | --report           Print the report of the most recent sync operation"
+  echo "  -d | --delete           Delete the current LDAP mapping config"
+  echo "  -h | --help             Print this Usage output"
+  exit 1
+}
+
+while true; do
+  case "$1" in
+    -s | --set ) SET=true; SETTINGS_JSON="$2"; shift; shift ;;
+    -f | --forcesync ) FORCESYNC=true; shift ;;
+    -r | --report ) REPORT=true; shift ;;
+    -d | --delete ) DELETE=true; shift ;;
+    -h | --help ) HELP=true; shift ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+if [ $# -gt 0 ] ; then
+  echo "Excess command-line arguments detected. Exiting."
+  echo
+  print_usage
+fi
+
+source $ENV
+
+function force_sync() {
+  echo
+  echo "Forcing sync"
+  curl -s $CURL_VERBOSITY $CURL_INS \
+    -H "Authorization: Bearer $API_TOKEN" \
+    -X PUT \
+    $URL/api/admin/ldap/syncLdap
+  exit $?
+}
+
+if [ $HELP = true ] ; then
+  print_usage
+
+elif [ $SET = true ] ; then
+  if [ $DELETE = true -o $REPORT = true ] ; then
+    print_usage
+  else
+    if [ ! -e $SETTINGS_JSON ] ; then
+      echo "Settings file \"$SETTINGS_JSON\" does not exist. No settings were changed."
+      exit 1
+    fi
+    cat $SETTINGS_JSON | ${JSON_FILTER} > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      curl -s $CURL_VERBOSITY $CURL_INS \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $API_TOKEN" \
+        -X POST \
+        -d @$SETTINGS_JSON \
+        $URL/api/admin/ldap/settings/sync
+      if [ $? -eq 0 ] ; then
+        if [ $FORCESYNC = true ] ; then
+          force_sync
+        else
+          exit 0
+        fi
+      else
+        exit $?
+      fi
+    else
+      echo "\"$SETTINGS_JSON\" contains invalid JSON. No settings were changed."
+      exit 1
+    fi
+  fi
+
+elif [ $DELETE = true ] ; then
+  if [ $SET = true -o $REPORT = true ] ; then
+    print_usage
+  else
+    curl -s $CURL_VERBOSITY $CURL_INS \
+      -H "Authorization: Bearer $API_TOKEN" \
+      -X DELETE \
+      $URL/api/admin/ldap/settings/sync
+    if [ $? -eq 0 ] ; then
+      if [ $FORCESYNC = true ] ; then
+        force_sync
+      else
+        exit 0
+      fi
+    else
+      exit $?
+    fi
+  fi
+
+elif [ $REPORT = true ] ; then
+  if [ $SET = true -o $DELETE = true -o $FORCESYNC = true ] ; then
+    print_usage
+  else
+    curl -s $CURL_VERBOSITY $CURL_INS \
+      -H "Authorization: Bearer $API_TOKEN" \
+      -X GET \
+      $URL/api/admin/ldap/syncReport | ${JSON_FILTER}
+    exit $?
+  fi
+
+elif [ $FORCESYNC = true ] ; then
+  if [ $SET = true -o $DELETE = true -o $REPORT = true ] ; then
+    print_usage
+  else
+    force_sync
+  fi
+
+else
+  curl -s $CURL_VERBOSITY $CURL_INS \
+    -H "Authorization: Bearer $API_TOKEN" \
+    -X GET \
+    $URL/api/admin/ldap/settings/sync | ${JSON_FILTER}
+  exit $?
+fi

--- a/LDAP/settings_login_group.json
+++ b/LDAP/settings_login_group.json
@@ -1,0 +1,12 @@
+{
+  "loginConnectionSettings": {
+    "server": "ldap://172.16.0.1",
+    "rootDn": "dc=example,dc=local",
+    "managerDn": "cn=Administrator,cn=Users,dc=example,dc=local",
+    "managerPassword": "myMgrPassword"
+  },
+  "loginFilter": {
+    "searchBase": "cn=Users",
+    "searchFilter": "(&(memberOf=CN=Mars,OU=Planets,DC=example,DC=local)(objectClass=organizationalPerson)(sAMAccountName={0}))"
+  }
+}

--- a/LDAP/settings_login_group_deprecated.json
+++ b/LDAP/settings_login_group_deprecated.json
@@ -1,0 +1,15 @@
+{
+  "loginConnectionSettings": {
+    "server": "ldap://172.16.0.1",
+    "rootDn": "dc=example,dc=local",
+    "managerDn": "cn=Administrator,cn=Users,dc=example,dc=local",
+    "managerPassword": "myMgrPassword"
+  },
+  "loginFilter": {
+    "searchBase": "cn=Users",
+    "searchFilter": "(&(objectClass=organizationalPerson)(sAMAccountName={0}))",
+    "groupSearchBase": "ou=Planets",
+    "groupSearchFilter": "(&(cn=Mars)(objectclass=group))",
+    "groupMembershipFilter": ""
+  }
+}

--- a/LDAP/settings_login_simple.json
+++ b/LDAP/settings_login_simple.json
@@ -1,0 +1,12 @@
+{
+  "loginConnectionSettings": {
+    "server": "ldap://172.16.0.1",
+    "rootDn": "dc=example,dc=local",
+    "managerDn": "cn=Administrator,cn=Users,dc=example,dc=local",
+    "managerPassword": "myMgrPassword"
+  },
+  "loginFilter": {
+    "searchBase": "cn=Users",
+    "searchFilter": "(&(objectClass=organizationalPerson)(sAMAccountName={0}))"
+  }
+}

--- a/LDAP/settings_login_with_user_create.json
+++ b/LDAP/settings_login_with_user_create.json
@@ -1,0 +1,13 @@
+{
+  "loginConnectionSettings": {
+    "server": "ldap://172.16.0.1",
+    "rootDn": "dc=example,dc=local",
+    "managerDn": "cn=Administrator,cn=Users,dc=example,dc=local",
+    "managerPassword": "myMgrPassword"
+  },
+  "loginFilter": {
+    "searchBase": "cn=Users",
+    "searchFilter": "(&(objectClass=organizationalPerson)(sAMAccountName={0}))"
+  },
+  "allowApiUserCreation": true
+}

--- a/LDAP/settings_mapping_simple.json
+++ b/LDAP/settings_mapping_simple.json
@@ -1,0 +1,50 @@
+{
+    "ldapTeamMapping": [
+      {
+        "ldapFilterSettings": {
+          "searchFilter": "(&(objectClass=organizationalPerson)(memberOf=CN=Sysdig Viewers,CN=Users,DC=example,DC=local)(sAMAccountName=*))",
+          "searchBase": "cn=Users"
+        },
+        "teams": [
+          "Viewers"
+        ],
+        "teamRole": "ROLE_TEAM_READ",
+        "usernameAttribute": "sAMAccountName"
+      },
+      {
+        "ldapFilterSettings": {
+          "searchFilter": "(&(objectClass=organizationalPerson)(memberOf=CN=Sysdig Editors,CN=Users,DC=example,DC=local)(sAMAccountName=*))",
+          "searchBase": "cn=Users"
+        },
+        "teams": [
+          "Editors1",
+          "Editors2"
+        ],
+        "teamRole": "ROLE_TEAM_EDIT",
+        "usernameAttribute": "sAMAccountName"
+      },
+      {
+        "ldapFilterSettings": {
+          "searchFilter": "(&(objectClass=organizationalPerson)(givenName=Mary))",
+          "searchBase": "cn=Users"
+        },
+        "teams": [
+          "Mixed"
+        ],
+        "teamRole": "ROLE_TEAM_EDIT",
+        "usernameAttribute": "sAMAccountName"
+      },
+      {
+        "ldapFilterSettings": {
+          "searchFilter": "(&(objectClass=organizationalPerson)(sAMAccountName=jdoe))",
+          "searchBase": "cn=Users"
+        },
+        "teams": [
+          "Mixed"
+        ],
+        "teamRole": "ROLE_TEAM_READ",
+        "usernameAttribute": "sAMAccountName"
+      }
+    ],
+    "dryRun": true
+}

--- a/LDAP/settings_user_create.json
+++ b/LDAP/settings_user_create.json
@@ -1,0 +1,9 @@
+{
+  "username": "msmith",
+  "firstName": "Mary",
+  "lastName": "Smith",
+  "password": "notUsed",
+  "customer": {
+    "id": 1
+  }
+}

--- a/LDAP/verify_user
+++ b/LDAP/verify_user
@@ -1,14 +1,15 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
 OPTS=`getopt -o u:h --long user:,help -n 'parse-options' -- "$@"`
+if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
+
 ENV="./env.sh"
 
 USER_SPECIFIED=false
 USERNAME=""
 HELP=false
 
-if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
 
 eval set -- "$OPTS"
 
@@ -44,10 +45,16 @@ if [ $HELP = true ] ; then
   print_usage
 
 elif [ $USER_SPECIFIED = true ] ; then
-  curl -s $CURL_VERBOSITY $CURL_INS \
+  curl -f $CURL_VERBOSITY $CURL_INS \
     -H "Authorization: Bearer $API_TOKEN" \
     $URL/api/admin/ldap/settings/verify/"${USERNAME}"
-  exit $?
+  RET=$?
+  if [ ${RET} -ne 0 ] ; then
+    echo "Could not verify user \"${USERNAME}\". Check LDAP login config settings and/or system log."
+    exit $RET
+  else
+    exit 0
+  fi
 
 else
   print_usage

--- a/LDAP/verify_user
+++ b/LDAP/verify_user
@@ -45,7 +45,7 @@ if [ $HELP = true ] ; then
   print_usage
 
 elif [ $USER_SPECIFIED = true ] ; then
-  curl -f $CURL_VERBOSITY $CURL_INS \
+  curl -f $CURL_OPTS \
     -H "Authorization: Bearer $API_TOKEN" \
     $URL/api/admin/ldap/settings/verify/"${USERNAME}"
   RET=$?

--- a/LDAP/verify_user
+++ b/LDAP/verify_user
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+OPTS=`getopt -o u:h --long user:,help -n 'parse-options' -- "$@"`
+ENV="./env.sh"
+
+USER_SPECIFIED=false
+USERNAME=""
+HELP=false
+
+if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
+
+eval set -- "$OPTS"
+
+function print_usage() {
+  echo "Usage: ./verify_user -u USERNAME"
+  echo
+  echo "Verify a user could login via current LDAP Authentication configuration"
+  echo
+  echo "Options:"
+  echo "  -u | --user  USERNAME   Name of the directory user to query via LDAP"
+  echo "  -h | --help             Print this Usage output"
+  exit 1
+}
+
+while true; do
+  case "$1" in
+    -u | --user ) USER_SPECIFIED=true; USERNAME="$2"; shift; shift;;
+    -h | --help ) HELP=true; shift ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+if [ $# -gt 0 ] ; then
+  echo "Excess command-line arguments detected. Exiting."
+  echo
+  print_usage
+fi
+
+source $ENV
+
+if [ $HELP = true ] ; then
+  print_usage
+
+elif [ $USER_SPECIFIED = true ] ; then
+  curl -s $CURL_VERBOSITY $CURL_INS \
+    -H "Authorization: Bearer $API_TOKEN" \
+    $URL/api/admin/ldap/settings/verify/"${USERNAME}"
+  exit $?
+
+else
+  print_usage
+fi


### PR DESCRIPTION
The API-based LDAP config is about to go into beta. With that comes new public customer-facing docs:

https://sysdig.atlassian.net/wiki/spaces/LDAP/pages/324993203/LDAP+Authentication+Configuration
https://sysdig.atlassian.net/wiki/spaces/LDAP/pages/328040565/LDAP+Mapping+Configuration
https://sysdig.atlassian.net/wiki/spaces/LDAP/pages/336920741/General+LDAP+Tips

To make the API-based config more approachable, these docs link to the helper scripts in this PR. Since they're really just showcasing how to hit the API, perhaps they don't have to be perfect. However, given that customers have struggled in the past with some of our other API-configured features (e.g. SAML/OpenID) I've tried to make these as user-friendly and foolproof as possible. In addition to any obvious bugs you might spot, feel free to critique my bash technique.

Since the feature is going to be under controlled beta, I've got the docs pointing to the revs of these scripts in this branch, and am planning to keep it that way until the feature goes GA. When it goes GA, _that's_ when I'd plan to do the merge (and will update the README at the same time to point back to the doc links).
