### PR TITLE
Fix dnsPolicy for example daemonset

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -43,6 +43,7 @@ spec:
         secret:
           secretName: sysdig-agent
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       tolerations:
         - effect: NoSchedule


### PR DESCRIPTION
This dnsPolicy makes the sysdig pods be configured with the right resolver configuration, so that one can use service dns addresses in the appchecks.