### PR TITLE
Add dnsPolicy to sysdig agent in OpenShift

### DIFF
--- a/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
+++ b/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
@@ -43,6 +43,7 @@ spec:
         secret:
           secretName: sysdig-agent
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       serviceAccount: sysdig-agent
       containers:


### PR DESCRIPTION
Synchronize dnsPolicy from Kubernetes with OpenShift manifest.