### PR TITLE
[SMAGENT-1039] Use a 5s pod termination grace period

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
@@ -46,6 +46,7 @@ spec:
           key: node-role.kubernetes.io/master
       ### OPTIONAL: If using OpenShift or Kubernetes RBAC you need to uncomment the following line
       # serviceAccount: sysdig-agent
+      terminationGracePeriodSeconds: 5
       containers:
       - name: sysdig-agent
         image: sysdig/agent

--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -50,6 +50,7 @@ spec:
           key: node-role.kubernetes.io/master
       ### OPTIONAL: If using OpenShift or Kubernetes RBAC you need to uncomment the following line
       # serviceAccount: sysdig-agent
+      terminationGracePeriodSeconds: 5
       containers:
       - name: sysdig-agent
         image: sysdig/agent

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
@@ -46,6 +46,7 @@ spec:
           key: node-role.kubernetes.io/master
       ### OPTIONAL: If using OpenShift or Kubernetes RBAC you need to uncomment the following line
       # serviceAccount: sysdig-agent
+      terminationGracePeriodSeconds: 5
       initContainers:
       - name: sysdig-agent-kmodule
         image: sysdig/agent-kmodule

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -49,6 +49,7 @@ spec:
           key: node-role.kubernetes.io/master
       ### OPTIONAL: If using OpenShift or Kubernetes RBAC you need to uncomment the following line
       # serviceAccount: sysdig-agent
+      terminationGracePeriodSeconds: 5
       initContainers:
       - name: sysdig-agent-kmodule
         image: sysdig/agent-kmodule

--- a/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
+++ b/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
@@ -46,6 +46,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       serviceAccount: sysdig-agent
+      terminationGracePeriodSeconds: 5
       containers:
       - name: sysdig-agent
         image: registry.connect.redhat.com/sysdig/agent:latest


### PR DESCRIPTION
If the pod fails to terminate quickly, it will continue to use the probe
module and prevent a new agent pod from starting up successfully. The
default grace period is 30s, and we lower it to 5s to prevent data gaps.