### PR TITLE
Changed the check from looking for the log file to the running file f…

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
@@ -63,7 +63,7 @@ spec:
             memory: 1024Mi
         readinessProbe:
           exec:
-            command: [ "test", "-e", "/opt/draios/logs/draios.log" ]
+            command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
         env:
         ### REQUIRED: replace with your Sysdig Platform access key

--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -67,7 +67,7 @@ spec:
             memory: 1024Mi
         readinessProbe:
           exec:
-            command: [ "test", "-e", "/opt/draios/logs/draios.log" ]
+            command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
         volumeMounts:
         - mountPath: /host/var/run/docker.sock

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
@@ -87,7 +87,7 @@ spec:
             memory: 1024Mi
         readinessProbe:
           exec:
-            command: [ "test", "-e", "/opt/draios/logs/draios.log" ]
+            command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
         env:
         ### REQUIRED: replace with your Sysdig Platform access key

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -90,7 +90,7 @@ spec:
             memory: 1024Mi
         readinessProbe:
           exec:
-            command: [ "test", "-e", "/opt/draios/logs/draios.log" ]
+            command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
         volumeMounts:
         - mountPath: /host/var/run/docker.sock

--- a/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
+++ b/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
@@ -63,7 +63,7 @@ spec:
             memory: 1024Mi
         readinessProbe:
           exec:
-            command: [ "test", "-e", "/opt/draios/logs/draios.log" ]
+            command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
         volumeMounts:
         - mountPath: /host/var/run/docker.sock


### PR DESCRIPTION
…or the readiness check because some customers disable log files in favor of using stdout into 3rd party solutions such as ElasticSearch and Splunk.