### PR TITLE
Modified delete switch to disable SAML as delete does not work.

### DIFF
--- a/SAML/saml_config.sh
+++ b/SAML/saml_config.sh
@@ -122,9 +122,12 @@ elif [ $DELETE = true ] ; then
     print_usage
   else
     curl $CURL_OPTS \
-      -H "Authorization: Bearer $API_TOKEN" \
-      -X DELETE \
-      "$APP_URL"
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $API_TOKEN" \
+        -X POST \
+        -d '{"metadataUrl": "'"${METADATA_URL}"'",
+        "enabled": "'"false"'" }' \
+        "$APP_URL" | ${JSON_FILTER}
     exit $?
   fi
 


### PR DESCRIPTION
Setting SAML's "enabled" flag to "false" disables and removes all of the config.