### PR TITLE
Mount whole /run and /var/run inside agent containers [SMAGENT-1209]

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
@@ -21,9 +21,6 @@ spec:
       - name: dshm
         emptyDir:
           medium: Memory
-      - name: docker-sock
-        hostPath:
-          path: /var/run/docker.sock
       - name: dev-vol
         hostPath:
           path: /dev
@@ -39,6 +36,12 @@ spec:
       - name: usr-vol
         hostPath:
           path: /usr
+      - name: run-vol
+        hostPath:
+          path: /run
+      - name: varrun-vol
+        hostPath:
+          path: /var/run
       hostNetwork: true
       hostPID: true
       tolerations:
@@ -89,9 +92,6 @@ spec:
         #     new_k8s: true
         #     k8s_cluster_name: production
         volumeMounts:
-        - mountPath: /host/var/run/docker.sock
-          name: docker-sock
-          readOnly: false
         - mountPath: /host/dev
           name: dev-vol
           readOnly: false
@@ -107,5 +107,9 @@ spec:
         - mountPath: /host/usr
           name: usr-vol
           readOnly: true
+        - mountPath: /host/run
+          name: run-vol
+        - mountPath: /host/var/run
+          name: varrun-vol
         - mountPath: /dev/shm
           name: dshm

--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -17,9 +17,6 @@ spec:
       - name: dshm
         emptyDir:
           medium: Memory
-      - name: docker-sock
-        hostPath:
-          path: /var/run/docker.sock
       - name: dev-vol
         hostPath:
           path: /dev
@@ -35,6 +32,12 @@ spec:
       - name: usr-vol
         hostPath:
           path: /usr
+      - name: run-vol
+        hostPath:
+          path: /run
+      - name: varrun-vol
+        hostPath:
+          path: /var/run
       - name: sysdig-agent-config
         configMap:
           name: sysdig-agent
@@ -70,9 +73,6 @@ spec:
             command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
         volumeMounts:
-        - mountPath: /host/var/run/docker.sock
-          name: docker-sock
-          readOnly: false
         - mountPath: /host/dev
           name: dev-vol
           readOnly: false
@@ -88,6 +88,10 @@ spec:
         - mountPath: /host/usr
           name: usr-vol
           readOnly: true
+        - mountPath: /host/run
+          name: run-vol
+        - mountPath: /host/var/run
+          name: varrun-vol
         - mountPath: /dev/shm
           name: dshm
         - mountPath: /opt/draios/etc/kubernetes/config

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
@@ -21,9 +21,6 @@ spec:
       - name: dshm
         emptyDir:
           medium: Memory
-      - name: docker-sock
-        hostPath:
-          path: /var/run/docker.sock
       - name: dev-vol
         hostPath:
           path: /dev
@@ -39,6 +36,12 @@ spec:
       - name: usr-vol
         hostPath:
           path: /usr
+      - name: run-vol
+        hostPath:
+          path: /run
+      - name: varrun-vol
+        hostPath:
+          path: /var/run
       hostNetwork: true
       hostPID: true
       tolerations:
@@ -113,14 +116,15 @@ spec:
         #     new_k8s: true
         #     k8s_cluster_name: production
         volumeMounts:
-        - mountPath: /host/var/run/docker.sock
-          name: docker-sock
-          readOnly: false
         - mountPath: /host/dev
           name: dev-vol
           readOnly: false
         - mountPath: /host/proc
           name: proc-vol
           readOnly: true
+        - mountPath: /host/run
+          name: run-vol
+        - mountPath: /host/var/run
+          name: varrun-vol
         - mountPath: /dev/shm
           name: dshm

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -17,9 +17,6 @@ spec:
       - name: dshm
         emptyDir:
           medium: Memory
-      - name: docker-sock
-        hostPath:
-          path: /var/run/docker.sock
       - name: dev-vol
         hostPath:
           path: /dev
@@ -35,6 +32,12 @@ spec:
       - name: usr-vol
         hostPath:
           path: /usr
+      - name: run-vol
+        hostPath:
+          path: /run
+      - name: varrun-vol
+        hostPath:
+          path: /var/run
       - name: sysdig-agent-config
         configMap:
           name: sysdig-agent
@@ -93,15 +96,16 @@ spec:
             command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
         volumeMounts:
-        - mountPath: /host/var/run/docker.sock
-          name: docker-sock
-          readOnly: false
         - mountPath: /host/dev
           name: dev-vol
           readOnly: false
         - mountPath: /host/proc
           name: proc-vol
           readOnly: true
+        - mountPath: /host/run
+          name: run-vol
+        - mountPath: /host/var/run
+          name: varrun-vol
         - mountPath: /dev/shm
           name: dshm
         - mountPath: /opt/draios/etc/kubernetes/config


### PR DESCRIPTION
We need this to access the CRI socket, when present.