### PR TITLE
Add Prometheus collection by default

### DIFF
--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -5,60 +5,60 @@
 set -e
 
 function install_curl_deb {
-	export DEBIAN_FRONTEND=noninteractive
+    export DEBIAN_FRONTEND=noninteractive
 
-	if ! hash curl > /dev/null 2>&1; then
-		echo "* Installing curl"
+    if ! hash curl > /dev/null 2>&1; then
+        echo "* Installing curl"
         $CMD_PREF apt-get update
-		$CMD_PREF apt-get -qq -y install curl < /dev/null
-	fi
+        $CMD_PREF apt-get -qq -y install curl < /dev/null
+    fi
 }
 
 function install_curl_rpm {
-	if ! hash curl > /dev/null 2>&1; then
-		echo "* Installing curl"
-		$CMD_PREF yum -q -y install curl
-	fi
+    if ! hash curl > /dev/null 2>&1; then
+        echo "* Installing curl"
+        $CMD_PREF yum -q -y install curl
+    fi
 }
 
 function download_yamls {
-	echo "* Downloading Sysdig cluster role yaml"
-	curl -s -o /tmp/sysdig-agent-clusterrole.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
-	echo "* Downloading Sysdig config map yaml"
-	curl -s -o /tmp/sysdig-agent-configmap.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-configmap.yaml
-	echo "* Downloading Sysdig daemonset v2 yaml"
-	curl -s -o /tmp/sysdig-agent-daemonset-v2.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+    echo "* Downloading Sysdig cluster role yaml"
+    curl -s -o /tmp/sysdig-agent-clusterrole.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
+    echo "* Downloading Sysdig config map yaml"
+    curl -s -o /tmp/sysdig-agent-configmap.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-configmap.yaml
+    echo "* Downloading Sysdig daemonset v2 yaml"
+    curl -s -o /tmp/sysdig-agent-daemonset-v2.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
 }
 
 function unsupported {
-	echo "Unsupported operating system. Try using the the manual installation instructions"
-	exit 1	
+    echo "Unsupported operating system. Try using the the manual installation instructions"
+    exit 1
 }
 
 function help {
-	echo "Usage: $(basename ${0}) -a | --access_key <value> [-t | --tags <value>] [-c | --collector <value>] \ "
-	echo "                [-cp | --collector_port <value>] [-s | --secure <value>] [-cc | --check_certificate] \ "
-	echo "                [-ns | --namespace <value>] [-ac | --additional_conf <value>] [-h | --help]"
-	echo ""
-	echo " -a  : secret access key, as shown in Sysdig Monitor"
-	echo " -t  : list of tags for this host (ie. \"role:webserver,location:europe\", \"role:webserver\" or \"webserver\")"
-	echo " -c  : collector IP for Sysdig Monitor"
-	echo " -cp : collector port [default 6443]"
-	echo " -s  : use a secure SSL/TLS connection to send metrics to the collector (default: true)"
-	echo " -cc : disable strong SSL certificate check (default: true)"
-	echo " -ac : if provided, the additional configuration will be appended to agent configuration file"
-	echo " -ns : If provided, will be the namespace used to deploy the agent. Defaults to ibm-observe"
-	echo " -h  : print this usage and exit"
-	echo
-	exit 1
+    echo "Usage: $(basename ${0}) -a | --access_key <value> [-t | --tags <value>] [-c | --collector <value>] \ "
+    echo "                [-cp | --collector_port <value>] [-s | --secure <value>] [-cc | --check_certificate] \ "
+    echo "                [-ns | --namespace <value>] [-ac | --additional_conf <value>] [-h | --help]"
+    echo ""
+    echo " -a  : secret access key, as shown in Sysdig Monitor"
+    echo " -t  : list of tags for this host (ie. \"role:webserver,location:europe\", \"role:webserver\" or \"webserver\")"
+    echo " -c  : collector IP for Sysdig Monitor"
+    echo " -cp : collector port [default 6443]"
+    echo " -s  : use a secure SSL/TLS connection to send metrics to the collector (default: true)"
+    echo " -cc : disable strong SSL certificate check (default: true)"
+    echo " -ac : if provided, the additional configuration will be appended to agent configuration file"
+    echo " -ns : If provided, will be the namespace used to deploy the agent. Defaults to ibm-observe"
+    echo " -h  : print this usage and exit"
+    echo
+    exit 1
 }
 
 function is_valid_value {
-	if [[ ${1} == -* ]] || [[ ${1} == --* ]] || [[ -z ${1} ]]; then
-		return 1
-	else
-		return 0
-	fi
+    if [[ ${1} == -* ]] || [[ ${1} == --* ]] || [[ -z ${1} ]]; then
+        return 1
+    else
+        return 0
+    fi
 }
 
 function create_namespace {
@@ -185,8 +185,8 @@ function install_k8s_agent {
 }
 
 if [[ ${#} -eq 0 ]]; then
-	echo "ERROR: Sysdig Access Key & Collector are mandatory, use -h | --help for $(basename ${0}) Usage"
-	exit 1
+    echo "ERROR: Sysdig Access Key & Collector are mandatory, use -h | --help for $(basename ${0}) Usage"
+    exit 1
 fi
 
 # Setting the default value for NAMESPACE to be ibm-observe
@@ -294,13 +294,13 @@ fi
 
 if [ -z $ACCESS_KEY  ]; then
     echo "ERROR: Sysdig Access Key argument is mandatory, use -h | --help for $(basename ${0}) Usage"
-	exit 1
+    exit 1
 fi
 
 
 if [ -z $COLLECTOR ]; then
     echo "ERROR: Sysdig Collector argument is mandatory, use -h | --help for $(basename ${0}) Usage"
-	exit 1
+    exit 1
 fi
 
 echo "* Detecting operating system"
@@ -308,85 +308,85 @@ echo "* Detecting operating system"
 ARCH=$(uname -m)
 PLATFORM=$(uname)
 if [[ ! $ARCH = *86 ]] && [ ! $ARCH = "x86_64" ] && [ ! $ARCH = "s390x" ]; then
-	unsupported
+    unsupported
 fi
 
 if [ -f /etc/debian_version ]; then
-	if [ -f /etc/lsb-release ]; then
-		. /etc/lsb-release
-		DISTRO=$DISTRIB_ID
-		VERSION=${DISTRIB_RELEASE%%.*}
-	else
-		DISTRO="Debian"
-		VERSION=$(cat /etc/debian_version | cut -d'.' -f1)
-	fi
+    if [ -f /etc/lsb-release ]; then
+        . /etc/lsb-release
+        DISTRO=$DISTRIB_ID
+        VERSION=${DISTRIB_RELEASE%%.*}
+    else
+        DISTRO="Debian"
+        VERSION=$(cat /etc/debian_version | cut -d'.' -f1)
+    fi
 
-	case "$DISTRO" in
+    case "$DISTRO" in
 
-		"Ubuntu")
-			if [ $VERSION -ge 10 ]; then
-				install_curl_deb
-			else
-				unsupported
-			fi
-			;;
+        "Ubuntu")
+            if [ $VERSION -ge 10 ]; then
+                install_curl_deb
+            else
+                unsupported
+            fi
+            ;;
 
-		"LinuxMint")
-			if [ $VERSION -ge 9 ]; then
-				install_curl_deb
-			else
-				unsupported
-			fi
-			;;
+        "LinuxMint")
+            if [ $VERSION -ge 9 ]; then
+                install_curl_deb
+            else
+                unsupported
+            fi
+            ;;
 
-		"Debian")
-			if [ $VERSION -ge 6 ]; then
-				install_curl_deb
-			elif [[ $VERSION == *sid* ]]; then
-				install_curl_deb
-			else
-				unsupported
-			fi
-			;;
+        "Debian")
+            if [ $VERSION -ge 6 ]; then
+                install_curl_deb
+            elif [[ $VERSION == *sid* ]]; then
+                install_curl_deb
+            else
+                unsupported
+            fi
+            ;;
 
-		*)
-			unsupported
-			;;
+        *)
+            unsupported
+            ;;
 
-	esac
+    esac
 
 elif [ -f /etc/system-release-cpe ]; then
-	DISTRO=$(cat /etc/system-release-cpe | cut -d':' -f3)
+    DISTRO=$(cat /etc/system-release-cpe | cut -d':' -f3)
 
-	VERSION=$(cat /etc/system-release-cpe | cut -d':' -f5 | cut -d'.' -f1 | sed 's/[^0-9]*//g')
+    VERSION=$(cat /etc/system-release-cpe | cut -d':' -f5 | cut -d'.' -f1 | sed 's/[^0-9]*//g')
 
-	case "$DISTRO" in
+    case "$DISTRO" in
 
-		"oracle" | "centos" | "redhat")
-			if [ $VERSION -ge 6 ]; then
-				install_curl_rpm
-			else
-				unsupported
-			fi
-			;;
+        "oracle" | "centos" | "redhat")
+            if [ $VERSION -ge 6 ]; then
+                install_curl_rpm
+            else
+                unsupported
+            fi
+            ;;
 
-		"fedoraproject")
-			if [ $VERSION -ge 13 ]; then
-				install_curl_rpm
-			else
-				unsupported
-			fi
-			;;
+        "fedoraproject")
+            if [ $VERSION -ge 13 ]; then
+                install_curl_rpm
+            else
+                unsupported
+            fi
+            ;;
 
-		*)
-			unsupported
-			;;
-	esac
+        *)
+            unsupported
+            ;;
+    esac
 
 elif [[ $uname -eq "Darwin" ]]; then
     install_curl_deb
 else
-	unsupported
+    unsupported
 fi
 
 download_yamls

--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -213,6 +213,8 @@ function remove_agent {
 
     echo "* Deleting the sysdig-agent secret"
     kubectl delete secret sysdig-agent --namespace=$NAMESPACE
+
+    set -e
 }
 
 

--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -304,6 +304,9 @@ case ${key} in
         fi
         shift
         ;;
+    -np|--no-prometheus)
+        ENABLE_PROMETHEUS=0
+        ;;
     -r|--remove)
         REMOVE_AGENT=1
         ;;


### PR DESCRIPTION
This PR : 
- fixes up the spacing inconsistency ( use spaces not tabs )
- enabled Prometheus by default with Kubernetes install ( `--no-prometheus` option to not enable )
- provides a `--remove` option to remove the Sysdig agent and dependencies from an installation