### PR TITLE
Docs to enable k8s audit for agent + minikube/kops

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-configmap.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-configmap.yaml
@@ -24,3 +24,6 @@ data:
     #######################################
     # new_k8s: true
     # k8s_cluster_name: production
+    security:
+      k8s_audit_server_url: 0.0.0.0
+      k8s_audit_server_port: 7765

--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -42,6 +42,12 @@ spec:
       - name: varrun-vol
         hostPath:
           path: /var/run
+      # Uncomment these lines if you'd like to map /root/ from the
+      # host into the container. This can be useful to map
+      # /root/.sysdig to pick up custom kernel modules.
+      #- name: host-root-vol
+      #  hostPath:
+      #    path: /root
       - name: sysdig-agent-config
         configMap:
           name: sysdig-agent
@@ -110,3 +116,8 @@ spec:
         - mountPath: /host/etc/os-release
           name: osrel
           readOnly: true
+        # Uncomment these lines if you'd like to map /root/ from the
+        # host into the container. This can be useful to map
+        # /root/.sysdig to pick up custom kernel modules.
+        #- mountPath: /root
+        #  name: host-root-vol

--- a/agent_deploy/kubernetes/sysdig-agent-service.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-service.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: sysdig-agent
+  labels:
+    app: sysdig-agent
+spec:
+  selector:
+     app: sysdig-agent
+  ports:
+  - protocol: TCP
+    port: 8765
+    targetPort: 7765

--- a/k8s_audit_config/README.md
+++ b/k8s_audit_config/README.md
@@ -1,0 +1,62 @@
+# Introduction
+
+This page describes how to get K8s Audit Logging working with the Sysdig Agent. For now, we'll describe how to enable audit logging in k8s 1.11, where the audit configuration needs to be directly provided to the api server. In 1.13 there is a different mechanism that allows audit confguration to be managed like other k8s objects, but these instructions are for 1.11.
+
+The main steps are:
+
+1. Determine if your K8s variant supports audit logging
+1. Deploy the Sysdig Agent to your K8s cluster
+1. Define your audit policy and webhook configuration
+1. Restart the API Server to enable Audit Logging
+1. Observe K8s audit events at the Sysdig Agent
+
+## Determine if your K8s variant supports audit logging
+
+K8s Audit Logging is a relatively new feature, and in k8s 1.11 requires modifying the apiserver configuration. As a result, not every K8s Variant exposes the necessary configuration options to enable and configure audit logging. These instructions have been verified to work with the following K8s Variants:
+
+* Minikube (>= 0.33.1) with the default virtualbox driver.
+* Kops (>= 1.11.0) using AWS.
+
+## Deploy Sysdig Agent to your K8s cluster
+
+Follow the [Agent Installation Instructions for Kubernetes](https://sysdigdocs.atlassian.net/wiki/x/uQB3Cw) to create a Sysdig Agent service account, service, configmap, and daemonset.
+
+## Define your audit policy and webhook configuration
+
+The files in this directory can be used to configure k8s audit logging. The relevant files are:
+
+* [audit-policy.yaml](./audit-policy.yaml): The k8s audit log configuration we recommend that is compatible with the default k8s audit rules published by Sysdig.
+* [webhook-config.yaml.in](./webhook-config.yaml.in): A (templated) webhook configuration that sends audit events to an ip associated with the Sysdig Agent service, port 8765. It is templated in that the *actual* ip is defined in an environment variable `AGENT_SERVICE_CLUSTERIP`, which can be plugged in using a program like `envsubst`.
+
+Run the following to fill in the template file with the ClusterIP ip address you created with the `sysdig-agent` service above. Although services like `sysdig-agent.default.svc.cluster.local` can not be resolved from the kube-apiserver container within the minikube vm (they're run as pods but not *really* a part of the cluster), the ClusterIPs associated with those services are routable.
+
+```
+AGENT_SERVICE_CLUSTERIP=$(kubectl get service sysdig-agent -o=jsonpath={.spec.clusterIP}) envsubst < webhook-config.yaml.in > webhook-config.yaml
+```
+
+## Restart the API Server to enable Audit Logging
+
+A script [enable-k8s-audit.sh](./enable-k8s-audit.sh) performs the necessary steps of enabling audit log support for the apiserver, including copying the audit policy/webhook files to the apiserver machine, modifying the apiserver command line to add `--audit-log-path`, `--audit-policy-file`, etc. arguments, etc. (For minikube, ideally you'd be able to pass all these options directly on the `minikube start` command line, but manual patching is necessary. See [this issue](https://github.com/kubernetes/minikube/issues/2741) for more details.)
+
+It is run as `bash ./enable-k8s-audit.sh <variant>`. `<variant>` can be one of the following:
+
+* "minikube"
+* "kops"
+
+When running with variant="kops", you must either modify the script to specify the kops apiserver hostname or set it via the environment: `APISERVER_HOST=api.my-kops-cluster.com bash ./enable-k8s-audit.sh kops`
+
+Its output looks like this:
+
+```
+$ bash enable-k8s-audit.sh minikube
+***Copying audit policy/webhook files to apiserver...
+audit-policy.yaml                                                                           100% 2519     1.2MB/s   00:00
+webhook-config.yaml                                                                         100%  248   362.0KB/s   00:00
+apiserver-config.patch.sh                                                                   100% 1190     1.2MB/s   00:00
+***Modifying k8s apiserver config (will result in apiserver restarting)...
+***Done!
+$
+```
+## Observe K8s audit events at Sysdig Agent
+
+K8s audit events will then be routed to the Sysdig Agent daemonset within the cluster, which you can observe via the Sysdig Secure Policy Events tab.

--- a/k8s_audit_config/README.md
+++ b/k8s_audit_config/README.md
@@ -36,7 +36,9 @@ AGENT_SERVICE_CLUSTERIP=$(kubectl get service sysdig-agent -o=jsonpath={.spec.cl
 
 ## Restart the API Server to enable Audit Logging
 
-A script [enable-k8s-audit.sh](./enable-k8s-audit.sh) performs the necessary steps of enabling audit log support for the apiserver, including copying the audit policy/webhook files to the apiserver machine, modifying the apiserver command line to add `--audit-log-path`, `--audit-policy-file`, etc. arguments, etc. (For minikube, ideally you'd be able to pass all these options directly on the `minikube start` command line, but manual patching is necessary. See [this issue](https://github.com/kubernetes/minikube/issues/2741) for more details.)
+A script [enable-k8s-audit.sh](./enable-k8s-audit.sh) performs the necessary steps of enabling audit log support for the apiserver, including copying the audit policy/webhook files to the apiserver machine, modifying the apiserver command line to add `--audit-log-path`, `--audit-policy-file`, etc. arguments, etc. This will result in the API Server restarting, as any change to kube-apiserver.yaml triggers a restart.
+
+For minikube, ideally you'd be able to pass options like `--audit-log-path`, etc. directly on the `minikube start` command line, but manual patching is necessary. See [this issue](https://github.com/kubernetes/minikube/issues/2741) for more details.
 
 It is run as `bash ./enable-k8s-audit.sh <variant>`. `<variant>` can be one of the following:
 

--- a/k8s_audit_config/README.md
+++ b/k8s_audit_config/README.md
@@ -28,7 +28,7 @@ Follow the [Agent Installation Instructions for Kubernetes](https://sysdigdocs.a
 The files in this directory can be used to configure k8s audit logging. The relevant files are:
 
 * [audit-policy.yaml](./audit-policy.yaml): The k8s audit log configuration we recommend that is compatible with the default k8s audit rules published by Sysdig.
-* [webhook-config.yaml.in](./webhook-config.yaml.in): A (templated) webhook configuration that sends audit events to an ip associated with the Sysdig Agent service, port 8765. It is templated in that the *actual* ip is defined in an environment variable `AGENT_SERVICE_CLUSTERIP`, which can be plugged in using a program like `envsubst`.
+* [webhook-config.yaml.in](./webhook-config.yaml.in): A (templated) webhook configuration that sends audit events to an ip associated with the Sysdig Agent service, port 7765. It is templated in that the *actual* ip is defined in an environment variable `AGENT_SERVICE_CLUSTERIP`, which can be plugged in using a program like `envsubst`.
 
 Run the following to fill in the template file with the ClusterIP ip address you created with the `sysdig-agent` service above. Although services like `sysdig-agent.default.svc.cluster.local` can not be resolved from the kube-apiserver container within the minikube vm (they're run as pods but not *really* a part of the cluster), the ClusterIPs associated with those services are routable.
 
@@ -47,7 +47,7 @@ It is run as `bash ./enable-k8s-audit.sh <variant>`. `<variant>` can be one of t
 * "minikube"
 * "kops"
 
-When running with variant="kops", you must either modify the script to specify the kops apiserver hostname or set it via the environment: `APISERVER_HOST=api.my-kops-cluster.com bash ./enable-k8s-audit.sh kops`
+When running with variant="kops", the api server hostname will be derived from the current kubectl context name, adding an "api." prefix. If you want to use a different api server hostname, you must either modify the script to specify the kops apiserver hostname or set it via the environment: `APISERVER_HOST=api.my-kops-cluster.com bash ./enable-k8s-audit.sh kops`
 
 Its output looks like this:
 

--- a/k8s_audit_config/README.md
+++ b/k8s_audit_config/README.md
@@ -33,7 +33,7 @@ The files in this directory can be used to configure k8s audit logging. The rele
 Run the following to fill in the template file with the ClusterIP ip address you created with the `sysdig-agent` service above. Although services like `sysdig-agent.default.svc.cluster.local` can not be resolved from the kube-apiserver container within the minikube vm (they're run as pods but not *really* a part of the cluster), the ClusterIPs associated with those services are routable.
 
 ```
-AGENT_SERVICE_CLUSTERIP=$(kubectl get service sysdig-agent -o=jsonpath={.spec.clusterIP}) envsubst < webhook-config.yaml.in > webhook-config.yaml
+AGENT_SERVICE_CLUSTERIP=$(kubectl get service sysdig-agent -o=jsonpath={.spec.clusterIP} -n sysdig-agent) envsubst < webhook-config.yaml.in > webhook-config.yaml
 ```
 
 ## Restart the API Server to enable Audit Logging
@@ -67,7 +67,7 @@ $
 When using dynamic audit sinks, you need to create an Audit Sink object that directs audit events to the sysdig agent service. A template file [audit-sink.yaml.in](./audit-sink.yaml.in) in this directory can be used to create the sink. Like the audit policy file above, it must be filled in using the ClusterIP address of the sysdig-agent service, using a command line:
 
 ```
-AGENT_SERVICE_CLUSTERIP=$(kubectl get service sysdig-agent -o=jsonpath={.spec.clusterIP}) envsubst < audit-sink.yaml.in > audit-sink.yaml
+AGENT_SERVICE_CLUSTERIP=$(kubectl get service sysdig-agent -o=jsonpath={.spec.clusterIP} -n sysdig-agent) envsubst < audit-sink.yaml.in > audit-sink.yaml
 ```
 
 Then you can create it via: `kubectl apply -f audit-sink.yaml -n sysdig-agent`.

--- a/k8s_audit_config/README.md
+++ b/k8s_audit_config/README.md
@@ -2,6 +2,8 @@
 
 This page describes how to get K8s Audit Logging working with the Sysdig Agent. For now, we'll describe how to enable audit logging in k8s 1.11, where the audit configuration needs to be directly provided to the api server. In 1.13 there is a different mechanism that allows audit confguration to be managed like other k8s objects, but these instructions are for 1.11.
 
+These instructions assume that the K8s cluster has *no* audit configuration or logging in place, and are adding configuration to route audit log messages only to the sysdig agent.
+
 The main steps are:
 
 1. Determine if your K8s variant supports audit logging

--- a/k8s_audit_config/README.md
+++ b/k8s_audit_config/README.md
@@ -61,6 +61,17 @@ apiserver-config.patch.sh                                                       
 ***Done!
 $
 ```
+
+## (Dynamic only) Create an Audit Sink Pointing to the Agent Service
+
+When using dynamic audit sinks, you need to create an Audit Sink object that directs audit events to the sysdig agent service. A template file [audit-sink.yaml.in](./audit-sink.yaml.in) in this directory can be used to create the sink. Like the audit policy file above, it must be filled in using the ClusterIP address of the sysdig-agent service, using a command line:
+
+```
+AGENT_SERVICE_CLUSTERIP=$(kubectl get service sysdig-agent -o=jsonpath={.spec.clusterIP}) envsubst < audit-sink.yaml.in > audit-sink.yaml
+```
+
+Then you can create it via: `kubectl apply -f audit-sink.yaml -n sysdig-agent`.
+
 ## Observe K8s audit events at Sysdig Agent
 
 K8s audit events will then be routed to the Sysdig Agent daemonset within the cluster, which you can observe via the Sysdig Secure Policy Events tab.

--- a/k8s_audit_config/apiserver-config.patch.sh
+++ b/k8s_audit_config/apiserver-config.patch.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+IFS=''
+
+FILENAME=${1:-/etc/kubernetes/manifests/kube-apiserver.yaml}
+VARIANT=${2:-minikube}
+
+if grep audit-webhook-config-file $FILENAME ; then
+    echo audit-webhook patch already applied
+    exit 0
+fi
+
+TMPFILE="/tmp/kube-apiserver.yaml.patched"
+rm -f "$TMPFILE"
+
+APISERVER_PREFIX="    -"
+APISERVER_LINE="- kube-apiserver"
+
+if [ $VARIANT == "kops" ]; then
+    APISERVER_PREFIX="     "
+    APISERVER_LINE="/usr/local/bin/kube-apiserver"
+fi
+
+while read LINE
+do
+    echo "$LINE" >> "$TMPFILE"
+    case "$LINE" in
+        *$APISERVER_LINE*)
+            echo "$APISERVER_PREFIX --audit-log-path=/var/lib/k8s_audit/audit.log" >> "$TMPFILE"
+            echo "$APISERVER_PREFIX --audit-policy-file=/var/lib/k8s_audit/audit-policy.yaml" >> "$TMPFILE"
+            echo "$APISERVER_PREFIX --audit-webhook-config-file=/var/lib/k8s_audit/webhook-config.yaml" >> "$TMPFILE"
+            echo "$APISERVER_PREFIX --audit-webhook-batch-max-wait=5s" >> "$TMPFILE"
+            ;;
+        *"volumeMounts:"*)
+            echo "    - mountPath: /var/lib/k8s_audit/" >> "$TMPFILE"
+            echo "      name: data" >> "$TMPFILE"
+            ;;
+        *"volumes:"*)
+            echo "  - hostPath:" >> "$TMPFILE"
+            echo "      path: /var/lib/k8s_audit" >> "$TMPFILE"
+            echo "    name: data" >> "$TMPFILE"
+            ;;
+
+    esac
+done < "$FILENAME"
+
+cp "$FILENAME" "/tmp/kube-apiserver.yaml.original"
+cp "$TMPFILE" "$FILENAME"
+

--- a/k8s_audit_config/apiserver-config.patch.sh
+++ b/k8s_audit_config/apiserver-config.patch.sh
@@ -1,13 +1,23 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 IFS=''
 
 FILENAME=${1:-/etc/kubernetes/manifests/kube-apiserver.yaml}
 VARIANT=${2:-minikube}
+AUDIT_TYPE=${3:-static}
 
-if grep audit-webhook-config-file $FILENAME ; then
-    echo audit-webhook patch already applied
-    exit 0
+if [ "$AUDIT_TYPE" == "static" ]; then
+    if grep audit-webhook-config-file "$FILENAME" ; then
+	echo audit-webhook patch already applied
+	exit 0
+    fi
+else
+    if grep audit-dynamic-configuration "$FILENAME" ; then
+	echo audit-dynamic-configuration patch already applied
+	exit 0
+    fi
 fi
 
 TMPFILE="/tmp/kube-apiserver.yaml.patched"
@@ -16,29 +26,42 @@ rm -f "$TMPFILE"
 APISERVER_PREFIX="    -"
 APISERVER_LINE="- kube-apiserver"
 
-if [ $VARIANT == "kops" ]; then
+if [ "$VARIANT" == "kops" ]; then
     APISERVER_PREFIX="     "
     APISERVER_LINE="/usr/local/bin/kube-apiserver"
 fi
 
-while read LINE
+while read -r LINE
 do
     echo "$LINE" >> "$TMPFILE"
     case "$LINE" in
         *$APISERVER_LINE*)
-            echo "$APISERVER_PREFIX --audit-log-path=/var/lib/k8s_audit/audit.log" >> "$TMPFILE"
-            echo "$APISERVER_PREFIX --audit-policy-file=/var/lib/k8s_audit/audit-policy.yaml" >> "$TMPFILE"
-            echo "$APISERVER_PREFIX --audit-webhook-config-file=/var/lib/k8s_audit/webhook-config.yaml" >> "$TMPFILE"
-            echo "$APISERVER_PREFIX --audit-webhook-batch-max-wait=5s" >> "$TMPFILE"
+	    if [[ ($AUDIT_TYPE == "static" || $AUDIT_TYPE == "dynamic+log") ]]; then
+		echo "$APISERVER_PREFIX --audit-log-path=/var/lib/k8s_audit/audit.log" >> "$TMPFILE"
+		echo "$APISERVER_PREFIX --audit-policy-file=/var/lib/k8s_audit/audit-policy.yaml" >> "$TMPFILE"
+		if [[ $AUDIT_TYPE == "static" ]]; then
+		    echo "$APISERVER_PREFIX --audit-webhook-config-file=/var/lib/k8s_audit/webhook-config.yaml" >> "$TMPFILE"
+		    echo "$APISERVER_PREFIX --audit-webhook-batch-max-wait=5s" >> "$TMPFILE"
+		fi
+	    fi
+	    if [[ ($AUDIT_TYPE == "dynamic" || $AUDIT_TYPE == "dynamic+log") ]]; then
+		echo "$APISERVER_PREFIX --audit-dynamic-configuration" >> "$TMPFILE"
+		echo "$APISERVER_PREFIX --feature-gates=DynamicAuditing=true" >> "$TMPFILE"
+		echo "$APISERVER_PREFIX --runtime-config=auditregistration.k8s.io/v1alpha1=true" >> "$TMPFILE"
+	    fi
             ;;
         *"volumeMounts:"*)
-            echo "    - mountPath: /var/lib/k8s_audit/" >> "$TMPFILE"
-            echo "      name: data" >> "$TMPFILE"
+	    if [[ ($AUDIT_TYPE == "static" || $AUDIT_TYPE == "dynamic+log") ]]; then
+		echo "    - mountPath: /var/lib/k8s_audit/" >> "$TMPFILE"
+		echo "      name: data" >> "$TMPFILE"
+	    fi
             ;;
         *"volumes:"*)
-            echo "  - hostPath:" >> "$TMPFILE"
-            echo "      path: /var/lib/k8s_audit" >> "$TMPFILE"
-            echo "    name: data" >> "$TMPFILE"
+	    if [[ ($AUDIT_TYPE == "static" || $AUDIT_TYPE == "dynamic+log") ]]; then
+		echo "  - hostPath:" >> "$TMPFILE"
+		echo "      path: /var/lib/k8s_audit" >> "$TMPFILE"
+		echo "    name: data" >> "$TMPFILE"
+	    fi
             ;;
 
     esac

--- a/k8s_audit_config/audit-policy.yaml
+++ b/k8s_audit_config/audit-policy.yaml
@@ -1,0 +1,76 @@
+apiVersion: audit.k8s.io/v1beta1 # This is required.
+kind: Policy
+# Don't generate audit events for all requests in RequestReceived stage.
+omitStages:
+  - "RequestReceived"
+rules:
+  # Log pod changes at RequestResponse level
+  - level: RequestResponse
+    resources:
+    - group: ""
+      # Resource "pods" doesn't match requests to any subresource of pods,
+      # which is consistent with the RBAC policy.
+      resources: ["pods", "deployments"]
+
+  - level: RequestResponse
+    resources:
+    - group: "rbac.authorization.k8s.io"
+      # Resource "pods" doesn't match requests to any subresource of pods,
+      # which is consistent with the RBAC policy.
+      resources: ["clusterroles", "clusterrolebindings"]
+
+  # Log "pods/log", "pods/status" at Metadata level
+  - level: Metadata
+    resources:
+    - group: ""
+      resources: ["pods/log", "pods/status"]
+
+  # Don't log requests to a configmap called "controller-leader"
+  - level: None
+    resources:
+    - group: ""
+      resources: ["configmaps"]
+      resourceNames: ["controller-leader"]
+
+  # Don't log watch requests by the "system:kube-proxy" on endpoints or services
+  - level: None
+    users: ["system:kube-proxy"]
+    verbs: ["watch"]
+    resources:
+    - group: "" # core API group
+      resources: ["endpoints", "services"]
+
+  # Don't log authenticated requests to certain non-resource URL paths.
+  - level: None
+    userGroups: ["system:authenticated"]
+    nonResourceURLs:
+    - "/api*" # Wildcard matching.
+    - "/version"
+
+  # Log the request body of configmap changes in kube-system.
+  - level: Request
+    resources:
+    - group: "" # core API group
+      resources: ["configmaps"]
+    # This rule only applies to resources in the "kube-system" namespace.
+    # The empty string "" can be used to select non-namespaced resources.
+    namespaces: ["kube-system"]
+
+  # Log configmap and secret changes in all other namespaces at the RequestResponse level.
+  - level: RequestResponse
+    resources:
+    - group: "" # core API group
+      resources: ["secrets", "configmaps"]
+
+  # Log all other resources in core and extensions at the Request level.
+  - level: Request
+    resources:
+    - group: "" # core API group
+    - group: "extensions" # Version of group should NOT be included.
+
+  # A catch-all rule to log all other requests at the Metadata level.
+  - level: Metadata
+    # Long-running requests like watches that fall under this rule will not
+    # generate an audit event in RequestReceived.
+    omitStages:
+      - "RequestReceived"

--- a/k8s_audit_config/audit-sink.yaml.in
+++ b/k8s_audit_config/audit-sink.yaml.in
@@ -13,4 +13,4 @@ spec:
       qps: 10
       burst: 15
     clientConfig:
-      url: "http://100.70.25.98:7765/k8s_audit"
+      url: "http://$AGENT_SERVICE_CLUSTERIP:7765/k8s_audit"

--- a/k8s_audit_config/audit-sink.yaml.in
+++ b/k8s_audit_config/audit-sink.yaml.in
@@ -1,7 +1,7 @@
 apiVersion: auditregistration.k8s.io/v1alpha1
 kind: AuditSink
 metadata:
-  name: sysdig-agent-audit-sink
+  name: sysdig-agent
 spec:
   policy:
     level: RequestResponse

--- a/k8s_audit_config/audit-sink.yaml.in
+++ b/k8s_audit_config/audit-sink.yaml.in
@@ -1,0 +1,16 @@
+apiVersion: auditregistration.k8s.io/v1alpha1
+kind: AuditSink
+metadata:
+  name: sysdig-agent-audit-sink
+spec:
+  policy:
+    level: RequestResponse
+    stages:
+      - ResponseComplete
+      - ResponseStarted
+  webhook:
+    throttle:
+      qps: 10
+      burst: 15
+    clientConfig:
+      url: "http://100.70.25.98:7765/k8s_audit"

--- a/k8s_audit_config/enable-k8s-audit.sh
+++ b/k8s_audit_config/enable-k8s-audit.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+VARIANT=${1:-minikube}
+
+if [ $VARIANT == "minikube" ]; then
+    APISERVER_HOST=$(minikube ip)
+    SSH_KEY=$(minikube ssh-key)
+    SSH_USER=docker
+    MANIFEST="/etc/kubernetes/manifests/kube-apiserver.yaml"
+fi
+
+if [ $VARIANT == "kops" ]; then
+#    APISERVER_HOST=api.your-kops-cluster-name.com
+    SSH_KEY=~/.ssh/id_rsa
+    SSH_USER=admin
+    MANIFEST=/etc/kubernetes/manifests/kube-apiserver.manifest
+
+    if [ -z "${APISERVER_HOST+xxx}" ]; then
+	echo "***You must specify APISERVER_HOST with the name of your kops api server"
+	exit 1
+    fi
+fi
+
+echo "***Copying audit policy/webhook files to apiserver..."
+ssh -i $SSH_KEY $SSH_USER@$APISERVER_HOST "sudo mkdir -p /var/lib/k8s_audit && sudo chown $SSH_USER /var/lib/k8s_audit"
+scp -i $SSH_KEY audit-policy.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
+scp -i $SSH_KEY webhook-config.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
+scp -i $SSH_KEY apiserver-config.patch.sh $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
+
+echo "***Modifying k8s apiserver config (will result in apiserver restarting)..."
+
+ssh -i $SSH_KEY $SSH_USER@$APISERVER_HOST "sudo bash /var/lib/k8s_audit/apiserver-config.patch.sh $MANIFEST $VARIANT"
+
+echo "***Done!"

--- a/k8s_audit_config/enable-k8s-audit.sh
+++ b/k8s_audit_config/enable-k8s-audit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euxo pipefail
 
 VARIANT=${1:-minikube}
 AUDIT_TYPE=${2:-dynamic+log}
@@ -13,7 +13,11 @@ if [ "$VARIANT" == "minikube" ]; then
 fi
 
 if [ "$VARIANT" == "kops" ]; then
-    # APISERVER_HOST=api.your-kops-cluster-name.com
+
+    if [ -z ${APISERVER_HOST+x} ]; then
+	APISERVER_HOST=api.$(kubectl config current-context)
+    fi
+
     SSH_KEY=~/.ssh/id_rsa
     SSH_USER="admin"
     MANIFEST=/etc/kubernetes/manifests/kube-apiserver.manifest

--- a/k8s_audit_config/enable-k8s-audit.sh
+++ b/k8s_audit_config/enable-k8s-audit.sh
@@ -1,20 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
 VARIANT=${1:-minikube}
+AUDIT_TYPE=${2:-dynamic+log}
 
-if [ $VARIANT == "minikube" ]; then
+if [ "$VARIANT" == "minikube" ]; then
     APISERVER_HOST=$(minikube ip)
     SSH_KEY=$(minikube ssh-key)
-    SSH_USER=docker
+    SSH_USER="docker"
     MANIFEST="/etc/kubernetes/manifests/kube-apiserver.yaml"
 fi
 
-if [ $VARIANT == "kops" ]; then
-#    APISERVER_HOST=api.your-kops-cluster-name.com
+if [ "$VARIANT" == "kops" ]; then
+    # APISERVER_HOST=api.your-kops-cluster-name.com
     SSH_KEY=~/.ssh/id_rsa
-    SSH_USER=admin
+    SSH_USER="admin"
     MANIFEST=/etc/kubernetes/manifests/kube-apiserver.manifest
 
     if [ -z "${APISERVER_HOST+xxx}" ]; then
@@ -23,14 +24,23 @@ if [ $VARIANT == "kops" ]; then
     fi
 fi
 
-echo "***Copying audit policy/webhook files to apiserver..."
-ssh -i $SSH_KEY $SSH_USER@$APISERVER_HOST "sudo mkdir -p /var/lib/k8s_audit && sudo chown $SSH_USER /var/lib/k8s_audit"
-scp -i $SSH_KEY audit-policy.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
-scp -i $SSH_KEY webhook-config.yaml $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
-scp -i $SSH_KEY apiserver-config.patch.sh $SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit
+echo "***Copying apiserver config patch script to apiserver..."
+ssh -i $SSH_KEY "$SSH_USER@$APISERVER_HOST" "sudo mkdir -p /var/lib/k8s_audit && sudo chown $SSH_USER /var/lib/k8s_audit"
+scp -i $SSH_KEY apiserver-config.patch.sh "$SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit"
+
+if [ "$AUDIT_TYPE" == "static" ]; then
+    echo "***Copying audit policy/webhook files to apiserver..."
+    scp -i $SSH_KEY audit-policy.yaml "$SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit"
+    scp -i $SSH_KEY webhook-config.yaml "$SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit"
+fi
+
+if [ "$AUDIT_TYPE" == "dynamic+log" ]; then
+    echo "***Copying audit policy file to apiserver..."
+    scp -i $SSH_KEY audit-policy.yaml "$SSH_USER@$APISERVER_HOST:/var/lib/k8s_audit"
+fi
 
 echo "***Modifying k8s apiserver config (will result in apiserver restarting)..."
 
-ssh -i $SSH_KEY $SSH_USER@$APISERVER_HOST "sudo bash /var/lib/k8s_audit/apiserver-config.patch.sh $MANIFEST $VARIANT"
+ssh -i $SSH_KEY "$SSH_USER@$APISERVER_HOST" "sudo bash /var/lib/k8s_audit/apiserver-config.patch.sh $MANIFEST $VARIANT $AUDIT_TYPE"
 
 echo "***Done!"

--- a/k8s_audit_config/webhook-config.yaml.in
+++ b/k8s_audit_config/webhook-config.yaml.in
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: falco
+  cluster:
+    server: http://$AGENT_SERVICE_CLUSTERIP:8765/k8s_audit
+contexts:
+- context:
+    cluster: falco
+    user: ""
+  name: default-context
+current-context: default-context
+preferences: {}
+users: []

--- a/k8s_audit_config/webhook-config.yaml.in
+++ b/k8s_audit_config/webhook-config.yaml.in
@@ -3,7 +3,7 @@ kind: Config
 clusters:
 - name: falco
   cluster:
-    server: http://$AGENT_SERVICE_CLUSTERIP:8765/k8s_audit
+    server: http://$AGENT_SERVICE_CLUSTERIP:7765/k8s_audit
 contexts:
 - context:
     cluster: falco


### PR DESCRIPTION
Copied from the falco instructions, these instructions show how to
enable k8s audit logging for the sysdig agent and minikube/kops.