### PR TITLE
Parameter parsing with getopts was failing a macOS

### DIFF
--- a/SSO/Google_Oauth/README.md
+++ b/SSO/Google_Oauth/README.md
@@ -1,0 +1,30 @@
+# Configure Google OAUTH
+
+Remember to fill out your environment URL and the Monitor or Secure API token at `../env.sh`. Depending on which API token you choose, the script will configure the settings for one or the other product.
+
+## Examples
+
+Show command help
+
+```
+./google_oauth_config.sh --help
+```
+
+Get current configuration
+
+```
+./google_oauth_config.sh
+```
+
+Configure some settings
+
+```
+./google_oauth_config.sh --set --clientid "foobar.apps.googleusercontent.com" --clientsecret "foobar" -r "https://sysdig.example.org:443/api/oauth/google/auth" --alloweddomains "[\"yourdomain.com\"]"
+
+```
+
+Delete current settings:
+
+```
+./google_oauth_config.sh --delete
+```

--- a/SSO/Google_Oauth/README.md
+++ b/SSO/Google_Oauth/README.md
@@ -7,7 +7,7 @@ Remember to fill out your environment URL and the Monitor or Secure API token at
 Show command help
 
 ```
-./google_oauth_config.sh --help
+./google_oauth_config.sh -h
 ```
 
 Get current configuration
@@ -19,12 +19,12 @@ Get current configuration
 Configure some settings
 
 ```
-./google_oauth_config.sh --set --clientid "foobar.apps.googleusercontent.com" --clientsecret "foobar" -r "https://sysdig.example.org:443/api/oauth/google/auth" --alloweddomains "[\"yourdomain.com\"]"
+./google_oauth_config.sh -s -i foobar.apps.googleusercontent.com -e foobar -r https://sysdig.example.org:443/api/oauth/google/auth -a yourdomain.com,yourdomain.org
 
 ```
 
 Delete current settings:
 
 ```
-./google_oauth_config.sh --delete
+./google_oauth_config.sh -d
 ```

--- a/SSO/Google_Oauth/google_oauth_config.sh
+++ b/SSO/Google_Oauth/google_oauth_config.sh
@@ -12,7 +12,7 @@ CLIENT_SECRET=""
 ALLOWED_DOMAINS=""
 REDIRECT_URL=""
 SSO_KEYWORD="google-oauth"
-SCRIPT_NAME=`basename "$0"`
+SCRIPT_NAME=`basename "${0}"`
 
 function print_usage() {
   echo "Usage: ./${SCRIPT_NAME} [OPTIONS]"
@@ -34,7 +34,7 @@ function print_usage() {
 }
 
 function check_provider_variables() {
-  if [ -z "$CLIENT_ID" -o -z "$CLIENT_SECRET" ] ; then
+  if [ -z "${CLIENT_ID}" -o -z "${CLIENT_SECRET}" ] ; then
     echo "To change settings, you must enter values for Client ID, and Client Secret"
     echo
     print_usage
@@ -45,15 +45,14 @@ function set_settings() {
   check_provider_variables
   get_settings_id
   PARSED_DOMAINS="["
-  for i in $(echo $ALLOWED_DOMAINS | tr "," "\n")
-  do
-      PARSED_DOMAINS="$PARSED_DOMAINS\"$i\","
+  for i in $(echo ${ALLOWED_DOMAINS} | tr "," "\n") ; do
+      PARSED_DOMAINS="${PARSED_DOMAINS}\"${i}\","
   done
   ALLOWED_DOMAINS="${PARSED_DOMAINS%?}]"
 
-  if [ -z "$SETTINGS_ID" ] ; then
-    curl $CURL_OPTS \
-      -H "Authorization: Bearer $API_TOKEN" \
+  if [[ -z "${SETTINGS_ID}" ]] ; then
+    curl ${CURL_OPTS} \
+      -H "Authorization: Bearer ${API_TOKEN}" \
       -H "Content-Type: application/json" \
       -X POST \
       -d '{
@@ -64,67 +63,66 @@ function set_settings() {
             "allowedDomains": '"${ALLOWED_DOMAINS}"',
             "clientId":"'"${CLIENT_ID}"'",
             "clientSecret":"'"${CLIENT_SECRET}"'"}}}' \
-      $SETTINGS_ENDPOINT | ${JSON_FILTER}
+      ${SETTINGS_ENDPOINT} | ${JSON_FILTER}
   else
     get_settings_version
-    curl $CURL_OPTS \
-      -H "Authorization: Bearer $API_TOKEN" \
+    curl ${CURL_OPTS} \
+      -H "Authorization: Bearer ${API_TOKEN}" \
       -H "Content-Type: application/json" \
       -X PUT \
       -d '{
         "authenticationSettings": {
           "type": "'"${SSO_KEYWORD}"'",
-          "version": "'"$VERSION"'",
+          "version": "'"${VERSION}"'",
           "settings": {
             "redirectUrl":"'"${REDIRECT_URL}"'",
             "allowedDomains":'"${ALLOWED_DOMAINS}"',
             "clientId":"'"${CLIENT_ID}"'",
             "clientSecret":"'"${CLIENT_SECRET}"'"}}}' \
-      $SETTINGS_ENDPOINT/$SETTINGS_ID | ${JSON_FILTER}
+      ${SETTINGS_ENDPOINT}/${SETTINGS_ID} | ${JSON_FILTER}
   fi
   set_as_active_setting
 }
 
 eval "set -- $(getopt sdhi:e:a:r: "$@")"
-while [ $# -gt 0 ]
-do
-    case "$1" in
+while [[ $# -gt 0 ]] ; do
+    case "${1}" in
       (-s) SET=true ;;
       (-d) DELETE=true ;;
       (-h) HELP=true ;;
-      (-i) CLIENT_ID="$CLIENT_ID$2"; shift;;
-      (-e) CLIENT_SECRET="$CLIENT_SECRET$2"; shift;;
-      (-a) ALLOWED_DOMAINS="$ALLOWED_DOMAINS$2"; shift;;
-      (-r) REDIRECT_URL="$REDIRECT_URL$2"; shift;;
+      (-i) CLIENT_ID="${CLIENT_ID}$2"; shift;;
+      (-e) CLIENT_SECRET="${CLIENT_SECRET}$2"; shift;;
+      (-a) ALLOWED_DOMAINS="${ALLOWED_DOMAINS}$2"; shift;;
+      (-r) REDIRECT_URL="${ALLOWED_DOMAINS}$2"; shift;;
       (--) shift; break;;
-      (-*) echo "$0: error - unrecognized option $1" 1>&2; exit 1;;
+      (-*) echo "${0}: error - unrecognized option ${1}" 1>&2; exit 1;;
       (*)  break;;
     esac
     shift
 done
 
-if [ $HELP = true ] ; then
+if [[ $HELP = true ]] ; then
   print_usage
 fi
  
-if [ $# -gt 0 ] ; then
+if [[ $# -gt 0 ]] ; then
   echo "Excess command-line arguments detected. Exiting."
   echo
   print_usage
 fi
 
-if [ -e "$ENV" ] ; then
-  source "$ENV"
+if [[ -e "${ENV}" ]] ; then
+  source "${ENV}"
 else
-  echo "File not found: $ENV"
+  echo "File not found: ${ENV}"
   echo "See the Google Oauth documentation for details on populating this file with your settings"
   exit 1
 fi
 
-if [ -e "$UTILS" ] ; then
-  source "$UTILS"
+if [[ -e "${UTILS}" ]] ; then
+  source "${UTILS}"
 else
-  echo "File not found: $UTILS"
+  echo "File not found: ${UTILS}"
   echo "See the Google Oauth documentation for details on populating this file with your settings"
   exit 1
 fi
@@ -132,13 +130,13 @@ fi
 SETTINGS_ENDPOINT="${URL}/api/admin/auth/settings"
 ACTIVE_ENDPOINT="${URL}/api/auth/settings/active"
 
-if [ $SET = true ] ; then
-  if [ $DELETE = true ] ; then
+if [[ ${SET} = true ]] ; then
+  if [[ ${DELETE} = true ]] ; then
     print_usage
   fi
   set_settings
-elif [ $DELETE = true ] ; then
-  if [ $SET = true ] ; then
+elif [[ ${DELETE} = true ]] ; then
+  if [[ ${SET} = true ]] ; then
     print_usage
   fi
   delete_settings

--- a/SSO/LDAP/README.md
+++ b/SSO/LDAP/README.md
@@ -1,0 +1,30 @@
+# Configure LDAP auth
+
+Remember to fill out your environment URL and the Monitor or Secure API token at `../env.sh`. Depending on which API token you choose, the script will configure the settings for one or the other product.
+
+## Examples
+
+Show command help
+
+```
+./login_config.sh --help
+```
+
+Get current configuration
+
+```
+./login_config.sh
+```
+
+Configure some default LDAP login following existing example
+
+```
+./login_config.sh --set settings_login_simple.json
+
+```
+
+Delete current settings:
+
+```
+./login_config.sh --delete
+```

--- a/SSO/LDAP/README.md
+++ b/SSO/LDAP/README.md
@@ -7,7 +7,7 @@ Remember to fill out your environment URL and the Monitor or Secure API token at
 Show command help
 
 ```
-./login_config.sh --help
+./login_config.sh -h
 ```
 
 Get current configuration
@@ -19,12 +19,12 @@ Get current configuration
 Configure some default LDAP login following existing example
 
 ```
-./login_config.sh --set settings_login_simple.json
+./login_config.sh -s settings_login_simple.json
 
 ```
 
 Delete current settings:
 
 ```
-./login_config.sh --delete
+./login_config.sh -d
 ```

--- a/SSO/LDAP/login_config.sh
+++ b/SSO/LDAP/login_config.sh
@@ -9,7 +9,7 @@ SETTINGS_JSON=""
 DELETE=false
 HELP=false
 SSO_KEYWORD="ldap"
-SCRIPT_NAME=`basename "$0"`
+SCRIPT_NAME=`basename "${0}"`
 
 function print_usage() {
   echo "Usage: ./${SCRIPT_NAME} [OPTION]"
@@ -27,64 +27,63 @@ function print_usage() {
 
 function set_settings() {
   get_settings_id
-  if [ -z "$SETTINGS_ID" ] ; then
+  if [[ -z "${SETTINGS_ID}" ]] ; then
     sed -i "s/\"version\".*$/\"version\": 1,/" ${SETTINGS_JSON}
-    curl $CURL_OPTS \
-      -H "Authorization: Bearer $API_TOKEN" \
+    curl ${CURL_OPTS} \
+      -H "Authorization: Bearer ${API_TOKEN}" \
       -H "Content-Type: application/json" \
       -X POST \
-      -d @$SETTINGS_JSON \
-      $SETTINGS_ENDPOINT | ${JSON_FILTER}
+      -d @${SETTINGS_JSON} \
+      ${SETTINGS_ENDPOINT} | ${JSON_FILTER}
   else
     get_settings_version
     sed -i "s/\"version\".*$/\"version\": ${VERSION},/" ${SETTINGS_JSON}
     cat ${SETTINGS_JSON}
-    curl $CURL_OPTS \
-      -H "Authorization: Bearer $API_TOKEN" \
+    curl ${CURL_OPTS} \
+      -H "Authorization: Bearer ${API_TOKEN}" \
       -H "Content-Type: application/json" \
       -X PUT \
-      -d @$SETTINGS_JSON \
-      $SETTINGS_ENDPOINT/$SETTINGS_ID | ${JSON_FILTER}
+      -d @${SETTINGS_JSON} \
+      ${SETTINGS_ENDPOINT}/${SETTINGS_ID} | ${JSON_FILTER}
   fi
   set_as_active_setting
 }
 
 eval "set -- $(getopt dhs: "$@")"
-while [ $# -gt 0 ]
-do
-    case "$1" in
+while [[ $# -gt 0 ]] ; do
+    case "${1}" in
       (-d) DELETE=true ;;
       (-h) HELP=true ;;
-      (-s) SET=true; SETTINGS_JSON="$SETTINGS_JSON$2"; shift;;
+      (-s) SET=true; SETTINGS_JSON="${SETTINGS_JSON}${2}"; shift;;
       (--) shift; break;;
-      (-*) echo "$0: error - unrecognized option $1" 1>&2; exit 1;;
+      (-*) echo "${0}: error - unrecognized option ${1}" 1>&2; exit 1;;
       (*)  break;;
     esac
     shift
 done
 
-if [ $HELP = true ] ; then
+if [[ ${HELP} = true ]] ; then
   print_usage
 fi
  
-if [ $# -gt 0 ] ; then
+if [[ $# -gt 0 ]] ; then
   echo "Excess command-line arguments detected. Exiting."
   echo
   print_usage
 fi
 
-if [ -e "$ENV" ] ; then
-  source "$ENV"
+if [[ -e "${ENV}" ]] ; then
+  source "${ENV}"
 else
-  echo "File not found: $ENV"
+  echo "File not found: ${ENV}"
   echo "See the LDAP documentation for details on populating this file with your settings"
   exit 1
 fi
 
-if [ -e "$UTILS" ] ; then
-  source "$UTILS"
+if [[ -e "${UTILS}" ]] ; then
+  source "${UTILS}"
 else
-  echo "File not found: $UTILS"
+  echo "File not found: ${UTILS}"
   echo "See the LDAP documentation for details on populating this file with your settings"
   exit 1
 fi
@@ -92,13 +91,13 @@ fi
 SETTINGS_ENDPOINT="${URL}/api/admin/auth/settings"
 ACTIVE_ENDPOINT="${URL}/api/auth/settings/active"
 
-if [ $SET = true ] ; then
-  if [ $DELETE = true ] ; then
+if [[ ${SET} = true ]] ; then
+  if [[ ${DELETE} = true ]] ; then
     print_usage
   fi
   set_settings
-elif [ $DELETE = true ] ; then
-  if [ $SET = true ] ; then
+elif [[ ${DELETE} = true ]] ; then
+  if [[ ${SET} = true ]] ; then
     print_usage
   fi
   delete_settings

--- a/SSO/LDAP/login_config.sh
+++ b/SSO/LDAP/login_config.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-OPTS=`getopt -o s:dh --long set:,delete,help -n 'parse-options' -- "$@"`
-if [ $? != 0 ] ; then
-  echo "Failed parsing options." >&2
-  exit 1
-fi
-
 ENV="../env.sh"
 UTILS="../utils.sh"
 
@@ -17,8 +11,6 @@ HELP=false
 SSO_KEYWORD="ldap"
 SCRIPT_NAME=`basename "$0"`
 
-eval set -- "$OPTS"
-
 function print_usage() {
   echo "Usage: ./${SCRIPT_NAME} [OPTION]"
   echo
@@ -27,9 +19,9 @@ function print_usage() {
   echo "If no OPTION is specified, the current login config settings are printed"
   echo
   echo "Options:"
-  echo "  -s | --set  JSON_FILE   Set the current LDAP login config to the contents of JSON_FILE"
-  echo "  -d | --delete           Delete the current LDAP login config"
-  echo "  -h | --help             Print this Usage output"
+  echo "  -s JSON_FILE    Set the current LDAP login config to the contents of JSON_FILE"
+  echo "  -d              Delete the current LDAP login config"
+  echo "  -h              Print this Usage output"
   exit 1
 }
 
@@ -57,14 +49,18 @@ function set_settings() {
   set_as_active_setting
 }
 
-while true; do
-  case "$1" in
-    -s | --set ) SET=true; SETTINGS_JSON="$2"; shift; shift ;;
-    -d | --delete ) DELETE=true; shift ;;
-    -h | --help ) HELP=true; shift ;;
-    -- ) shift; break ;;
-    * ) break ;;
-  esac
+eval "set -- $(getopt dhs: "$@")"
+while [ $# -gt 0 ]
+do
+    case "$1" in
+      (-d) DELETE=true ;;
+      (-h) HELP=true ;;
+      (-s) SET=true; SETTINGS_JSON="$SETTINGS_JSON$2"; shift;;
+      (--) shift; break;;
+      (-*) echo "$0: error - unrecognized option $1" 1>&2; exit 1;;
+      (*)  break;;
+    esac
+    shift
 done
 
 if [ $HELP = true ] ; then

--- a/SSO/OpenID_Connect/README.md
+++ b/SSO/OpenID_Connect/README.md
@@ -1,0 +1,30 @@
+# Configure OpenID auth
+
+Remember to fill out your environment URL and the Monitor or Secure API token at `../env.sh`. Depending on which API token you choose, the script will configure the settings for one or the other product.
+
+## Examples
+
+Show command help
+
+```
+./oidc_config.sh --help
+```
+
+Get current configuration
+
+```
+./oidc_config.sh
+```
+
+Configure some settings
+
+```
+./oidc_config.sh --set --issuerurl https://foo.oktapreview.com --clientid foobar --clientsecret foobar
+
+```
+
+Delete current settings:
+
+```
+./oidc_config.sh --delete
+```

--- a/SSO/OpenID_Connect/README.md
+++ b/SSO/OpenID_Connect/README.md
@@ -7,7 +7,7 @@ Remember to fill out your environment URL and the Monitor or Secure API token at
 Show command help
 
 ```
-./oidc_config.sh --help
+./oidc_config.sh -h
 ```
 
 Get current configuration
@@ -19,12 +19,12 @@ Get current configuration
 Configure some settings
 
 ```
-./oidc_config.sh --set --issuerurl https://foo.oktapreview.com --clientid foobar --clientsecret foobar
+./oidc_config.sh -s -u https://foo.oktapreview.com -i foobar -e foobar
 
 ```
 
 Delete current settings:
 
 ```
-./oidc_config.sh --delete
+./oidc_config.sh -d
 ```

--- a/SSO/OpenID_Connect/oidc_config.sh
+++ b/SSO/OpenID_Connect/oidc_config.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-OPTS=`getopt -o su:i:e:m:dh --long set,issuerurl:,clientid:,clientsecret:,delete,help -n 'parse-options' -- "$@"`
-if [ $? != 0 ] ; then
-  echo "Failed parsing options." >&2
-  exit 1
-fi
-
 ENV="../env.sh"
 UTILS="../utils.sh"
 
@@ -19,8 +13,6 @@ CLIENT_SECRET=""
 SSO_KEYWORD="openid"
 SCRIPT_NAME=`basename "$0"`
 
-eval set -- "$OPTS"
-
 function print_usage() {
   echo "Usage: ./${SCRIPT_NAME} [OPTIONS]"
   echo
@@ -30,12 +22,12 @@ function print_usage() {
   echo
   echo "Options:"
 
-  echo "  -s | --set                 Set the current OpenID Connect login config"
-  echo "  -u | --issuerurl           Issuer URL from your OpenID Provider config"
-  echo "  -i | --clientid            Client ID from your OpenID Provider config"
-  echo "  -e | --clientsecret        Client Secret from your OpenID Provider config"
-  echo "  -d | --delete              Delete the current OpenID Connect login config"
-  echo "  -h | --help                Print this Usage output"
+  echo "  -s    Set the current OpenID Connect login config"
+  echo "  -u    Issuer URL from your OpenID Provider config"
+  echo "  -i    Client ID from your OpenID Provider config"
+  echo "  -e    Client Secret from your OpenID Provider config"
+  echo "  -d    Delete the current OpenID Connect login config"
+  echo "  -h    Print this Usage output"
   exit 1
 }
 
@@ -84,17 +76,21 @@ function set_settings() {
   set_as_active_setting
 }
 
-while true; do
-  case "$1" in
-    -s | --set ) SET=true; shift ;;
-    -u | --issuerurl ) ISSUER_URL="$2"; shift; shift ;;
-    -i | --clientid ) CLIENT_ID="$2"; shift; shift ;;
-    -e | --clientsecret ) CLIENT_SECRET="$2"; shift; shift ;;
-    -d | --delete ) DELETE=true; shift ;;
-    -h | --help ) HELP=true; shift ;;
-    -- ) shift; break ;;
-    * ) break ;;
-  esac
+eval "set -- $(getopt sdhu:i:e: "$@")"
+while [ $# -gt 0 ]
+do
+    case "$1" in
+      (-s) SET=true ;;
+      (-d) DELETE=true ;;
+      (-h) HELP=true ;;
+      (-u) ISSUER_URL="$ISSUER_URL$2"; shift;;
+      (-i) CLIENT_ID="$CLIENT_ID$2"; shift;;
+      (-e) CLIENT_SECRET="$CLIENT_SECRET$2"; shift;;
+      (--) shift; break;;
+      (-*) echo "$0: error - unrecognized option $1" 1>&2; exit 1;;
+      (*)  break;;
+    esac
+    shift
 done
 
 if [ $HELP = true ] ; then

--- a/SSO/OpenID_Connect/oidc_config.sh
+++ b/SSO/OpenID_Connect/oidc_config.sh
@@ -11,7 +11,7 @@ ISSUER_URL=""
 CLIENT_ID=""
 CLIENT_SECRET=""
 SSO_KEYWORD="openid"
-SCRIPT_NAME=`basename "$0"`
+SCRIPT_NAME=`basename "${0}"`
 
 function print_usage() {
   echo "Usage: ./${SCRIPT_NAME} [OPTIONS]"
@@ -32,7 +32,7 @@ function print_usage() {
 }
 
 function check_provider_variables() {
-  if [ -z "$ISSUER_URL" -o -z "$CLIENT_ID" -o -z "$CLIENT_SECRET" ] ; then
+  if [ -z "${ISSUER_URL}" -o -z "${CLIENT_ID}" -o -z "${CLIENT_SECRET}" ] ; then
     echo "To change settings, you must enter values for Issuer URL, Client ID, and Client Secret"
     echo
     print_usage
@@ -42,9 +42,9 @@ function check_provider_variables() {
 function set_settings() {
   check_provider_variables
   get_settings_id
-  if [ -z "$SETTINGS_ID" ] ; then
-    curl $CURL_OPTS \
-      -H "Authorization: Bearer $API_TOKEN" \
+  if [[ -z "${SETTINGS_ID}" ]] ; then
+    curl ${CURL_OPTS} \
+      -H "Authorization: Bearer ${API_TOKEN}" \
       -H "Content-Type: application/json" \
       -X POST \
       -d '{
@@ -55,66 +55,65 @@ function set_settings() {
             "clientId":"'"${CLIENT_ID}"'",
             "clientSecret":"'"${CLIENT_SECRET}"'",
             "metadataDiscovery":true}}}' \
-      $SETTINGS_ENDPOINT | ${JSON_FILTER}
+      ${SETTINGS_ENDPOINT} | ${JSON_FILTER}
   else
     get_settings_version
-    curl $CURL_OPTS \
-      -H "Authorization: Bearer $API_TOKEN" \
+    curl ${CURL_OPTS} \
+      -H "Authorization: Bearer ${API_TOKEN}" \
       -H "Content-Type: application/json" \
       -X PUT \
       -d '{
         "authenticationSettings": {
           "type": "'"${SSO_KEYWORD}"'",
-          "version": "'"$VERSION"'",
+          "version": "'"${VERSION}"'",
           "settings": {
             "issuer":"'"${ISSUER_URL}"'",
             "clientId":"'"${CLIENT_ID}"'",
             "clientSecret":"'"${CLIENT_SECRET}"'",
             "metadataDiscovery":true}}}' \
-      $SETTINGS_ENDPOINT/$SETTINGS_ID | ${JSON_FILTER}
+      ${SETTINGS_ENDPOINT}/${SETTINGS_ID} | ${JSON_FILTER}
   fi
   set_as_active_setting
 }
 
 eval "set -- $(getopt sdhu:i:e: "$@")"
-while [ $# -gt 0 ]
-do
-    case "$1" in
+while [[ $# -gt 0 ]] ; do
+    case "${1}" in
       (-s) SET=true ;;
       (-d) DELETE=true ;;
       (-h) HELP=true ;;
-      (-u) ISSUER_URL="$ISSUER_URL$2"; shift;;
-      (-i) CLIENT_ID="$CLIENT_ID$2"; shift;;
-      (-e) CLIENT_SECRET="$CLIENT_SECRET$2"; shift;;
+      (-u) ISSUER_URL="${ISSUER_URL}${2}"; shift;;
+      (-i) CLIENT_ID="${CLIENT_ID}${2}"; shift;;
+      (-e) CLIENT_SECRET="${CLIENT_SECRET}${2}"; shift;;
       (--) shift; break;;
-      (-*) echo "$0: error - unrecognized option $1" 1>&2; exit 1;;
+      (-*) echo "${0}: error - unrecognized option ${1}" 1>&2; exit 1;;
       (*)  break;;
     esac
     shift
 done
 
-if [ $HELP = true ] ; then
+if [[ ${HELP} = true ]] ; then
   print_usage
 fi
  
-if [ $# -gt 0 ] ; then
+if [[ $# -gt 0 ]] ; then
   echo "Excess command-line arguments detected. Exiting."
   echo
   print_usage
 fi
 
-if [ -e "$ENV" ] ; then
-  source "$ENV"
+if [[ -e "${ENV}" ]] ; then
+  source "${ENV}"
 else
-  echo "File not found: $ENV"
+  echo "File not found: ${ENV}"
   echo "See the OpenID Connect documentation for details on populating this file with your settings"
   exit 1
 fi
 
-if [ -e "$UTILS" ] ; then
-  source "$UTILS"
+if [[ -e "${UTILS}" ]] ; then
+  source "${UTILS}"
 else
-  echo "File not found: $UTILS"
+  echo "File not found: ${UTILS}"
   echo "See the OpenID Connect documentation for details on populating this file with your settings"
   exit 1
 fi
@@ -122,13 +121,13 @@ fi
 SETTINGS_ENDPOINT="${URL}/api/admin/auth/settings"
 ACTIVE_ENDPOINT="${URL}/api/auth/settings/active"
 
-if [ $SET = true ] ; then
-  if [ $DELETE = true ] ; then
+if [[ ${SET} = true ]] ; then
+  if [[ ${DELETE} = true ]] ; then
     print_usage
   fi
   set_settings
-elif [ $DELETE = true ] ; then
-  if [ $SET = true ] ; then
+elif [[ ${DELETE} = true ]] ; then
+  if [[ ${SET} = true ]] ; then
     print_usage
   fi
   delete_settings

--- a/SSO/README.md
+++ b/SSO/README.md
@@ -12,10 +12,10 @@ Probably you reached this repo coming from our documentation. If not, [this link
 ## How to run the scripts
 
 * Edit `env.sh` file with your onprem instance URL and the API_TOKEN of the "super user" obtained from Sysdig Monitor or Sysdig Secure product. Depending on which token you take, the auth settings will be applied to Monitor or Secure (the exception is LDAP, as its configuration affects both products in the same way).
-* Enter the auth type you want folder
+* Use the auth type of interest as the folder name (and take a look at the README file there)
 * Run the script
 
 ```
 cd SAML
-./saml_config.sh -h
+./saml_config.sh --help
 ```

--- a/SSO/README.md
+++ b/SSO/README.md
@@ -17,5 +17,5 @@ Probably you reached this repo coming from our documentation. If not, [this link
 
 ```
 cd SAML
-./saml_config.sh --help
+./saml_config.sh -h
 ```

--- a/SSO/SAML/README.md
+++ b/SSO/SAML/README.md
@@ -1,0 +1,35 @@
+# Configure SAML auth
+
+Remember to fill out your environment URL and the Monitor or Secure API token at `../env.sh`. Depending on which API token you choose, the script will configure the settings for one or the other product.
+
+## Examples
+
+Show command help
+
+```
+./saml_config.sh --help
+```
+
+Get current SAML configuration
+
+```
+./saml_config.sh
+```
+
+Set some OKTA settings
+
+```
+./saml_config.sh --set --idp okta --meta 'https://foo.oktapreview.com/app/bar/sso/saml/metadata'
+```
+
+Disable user autocreation after login succeeds at IDP
+
+```
+./saml_config.sh --set --nocreate --idp okta --meta 'https://foo.oktapreview.com/app/bar/sso/saml/metadata'
+```
+
+Delete current settings:
+
+```
+./saml_config.sh --delete
+```

--- a/SSO/SAML/README.md
+++ b/SSO/SAML/README.md
@@ -7,7 +7,7 @@ Remember to fill out your environment URL and the Monitor or Secure API token at
 Show command help
 
 ```
-./saml_config.sh --help
+./saml_config.sh -h
 ```
 
 Get current SAML configuration
@@ -19,17 +19,17 @@ Get current SAML configuration
 Set some OKTA settings
 
 ```
-./saml_config.sh --set --idp okta --meta 'https://foo.oktapreview.com/app/bar/sso/saml/metadata'
+./saml_config.sh -s -i okta -m 'https://foo.oktapreview.com/app/bar/sso/saml/metadata'
 ```
 
 Disable user autocreation after login succeeds at IDP
 
 ```
-./saml_config.sh --set --nocreate --idp okta --meta 'https://foo.oktapreview.com/app/bar/sso/saml/metadata'
+./saml_config.sh -s -n -i okta -m 'https://foo.oktapreview.com/app/bar/sso/saml/metadata'
 ```
 
 Delete current settings:
 
 ```
-./saml_config.sh --delete
+./saml_config.sh -d
 ```

--- a/SSO/SAML/saml_config.sh
+++ b/SSO/SAML/saml_config.sh
@@ -11,7 +11,7 @@ IDP=""
 AUTOCREATE=true
 METADATA_URL=""
 SSO_KEYWORD="saml"
-SCRIPT_NAME=`basename "$0"`
+SCRIPT_NAME=`basename "${0}"`
 
 function print_usage() {
   echo "Usage: ./${SCRIPT_NAME} [OPTIONS]"
@@ -32,18 +32,18 @@ function print_usage() {
 }
 
 function set_provider_variables() {
-  if [ -z "$IDP" ] ; then
+  if [[ -z "${IDP}" ]] ; then
     echo "IDP is unspecified. Contact Sysdig Support for assistance."
     echo
     print_usage
   fi
 
-  if [ $IDP = "okta" ] ; then
+  if [[ ${IDP} = "okta" ]] ; then
     SIGNED_ASSERTION="true"
     VALIDATE_SIGNATURE="true"
     VERIFY_DESTINATION="true"
     EMAIL_PARAM="email"
-  elif [ $IDP = "onelogin" ] ; then
+  elif [[ ${IDP} = "onelogin" ]] ; then
     SIGNED_ASSERTION="false"
     VALIDATE_SIGNATURE="true"
     VERIFY_DESTINATION="true"
@@ -53,7 +53,7 @@ function set_provider_variables() {
     exit 1
   fi
 
-  if [ -z "$METADATA_URL" ] ; then
+  if [[ -z "${METADATA_URL}" ]] ; then
     echo "Must specify a metadata URL (provided from IDP-side configuration)"
     echo
     print_usage
@@ -63,9 +63,9 @@ function set_provider_variables() {
 function set_settings() {
   set_provider_variables
   get_settings_id
-  if [ -z "$SETTINGS_ID" ] ; then
-    curl $CURL_OPTS \
-      -H "Authorization: Bearer $API_TOKEN" \
+  if [[ -z "${SETTINGS_ID}" ]] ; then
+    curl ${CURL_OPTS} \
+      -H "Authorization: Bearer ${API_TOKEN}" \
       -H "Content-Type: application/json" \
       -X POST \
       -d '{
@@ -79,17 +79,17 @@ function set_settings() {
             "verifyDestination": "'"${VERIFY_DESTINATION}"'",
             "emailParameter": "'"${EMAIL_PARAM}"'",
             "createUserOnLogin": "'"${AUTOCREATE}"'" }}}' \
-      $SETTINGS_ENDPOINT | ${JSON_FILTER}
+      ${SETTINGS_ENDPOINT} | ${JSON_FILTER}
   else
     get_settings_version
-    curl $CURL_OPTS \
-      -H "Authorization: Bearer $API_TOKEN" \
+    curl ${CURL_OPTS} \
+      -H "Authorization: Bearer ${API_TOKEN}" \
       -H "Content-Type: application/json" \
       -X PUT \
       -d '{
         "authenticationSettings": {
           "type": "'"${SSO_KEYWORD}"'",
-          "version": "'"$VERSION"'",
+          "version": "'"${VERSION}"'",
           "settings": {
             "metadataUrl": "'"${METADATA_URL}"'",
             "enabled": "'"true"'",
@@ -98,51 +98,50 @@ function set_settings() {
             "verifyDestination": "'"${VERIFY_DESTINATION}"'",
             "emailParameter": "'"${EMAIL_PARAM}"'",
             "createUserOnLogin": "'"${AUTOCREATE}"'" }}}' \
-      $SETTINGS_ENDPOINT/$SETTINGS_ID | ${JSON_FILTER}
+      ${SETTINGS_ENDPOINT}/${SETTINGS_ID} | ${JSON_FILTER}
   fi
   set_as_active_setting
 }
 
 
 eval "set -- $(getopt sdhni:m: "$@")"
-while [ $# -gt 0 ]
-do
-    case "$1" in
+while [[ $# -gt 0 ]] ; do
+    case "${1}" in
       (-s) SET=true ;;
       (-d) DELETE=true ;;
       (-h) HELP=true ;;
       (-n) AUTOCREATE="false" ;;
-      (-i) IDP="$IDP$2"; shift;;
-      (-m) METADATA_URL="$METADATA_URL$2"; shift;;
+      (-i) IDP="${IDP}${2}"; shift;;
+      (-m) METADATA_URL="${METADATA_URL}${2}"; shift;;
       (--) shift; break;;
-      (-*) echo "$0: error - unrecognized option $1" 1>&2; exit 1;;
+      (-*) echo "${0}: error - unrecognized option ${1}" 1>&2; exit 1;;
       (*)  break;;
     esac
     shift
 done
 
-if [ $HELP = true ] ; then
+if [[ ${HELP} = true ]] ; then
   print_usage
 fi
  
-if [ $# -gt 0 ] ; then
+if [[ $# -gt 0 ]] ; then
   echo "Excess command-line arguments detected. Exiting."
   echo
   print_usage
 fi
 
-if [ -e "$ENV" ] ; then
-  source "$ENV"
+if [[ -e "${ENV}" ]] ; then
+  source "${ENV}"
 else
-  echo "File not found: $ENV"
+  echo "File not found: ${ENV}"
   echo "See the SAML documentation for details on populating this file with your settings"
   exit 1
 fi
 
-if [ -e "$UTILS" ] ; then
-  source "$UTILS"
+if [[ -e "${UTILS}" ]] ; then
+  source "${UTILS}"
 else
-  echo "File not found: $UTILS"
+  echo "File not found: ${UTILS}"
   echo "See the SAML documentation for details on populating this file with your settings"
   exit 1
 fi
@@ -150,13 +149,13 @@ fi
 SETTINGS_ENDPOINT="${URL}/api/admin/auth/settings"
 ACTIVE_ENDPOINT="${URL}/api/auth/settings/active"
 
-if [ $SET = true ] ; then
-  if [ $DELETE = true ] ; then
+if [[ ${SET} = true ]] ; then
+  if [[ ${DELETE} = true ]] ; then
     print_usage
   fi
   set_settings
-elif [ $DELETE = true ] ; then
-  if [ $SET = true ] ; then
+elif [[ ${DELETE} = true ]] ; then
+  if [[ ${SET} = true ]] ; then
     print_usage
   fi
   delete_settings

--- a/SSO/utils.sh
+++ b/SSO/utils.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
 function get_settings_id() {
-  SETTINGS_ID=`curl $CURL_OPTS \
-    -H "Authorization: Bearer $API_TOKEN" \
+  SETTINGS_ID=`curl ${CURL_OPTS} \
+    -H "Authorization: Bearer ${API_TOKEN}" \
     -X GET \
     ${SETTINGS_ENDPOINT} | jq '.authenticationSettings | .[] | select(.type=="'"${SSO_KEYWORD}"'") | .id'`
 }
 
-# Should be run after get_settings_id so $SETTINGS_ID might by set
+# Should be run after get_settings_id so ${SETTINGS_ID} might by set
 function exit_if_no_settings_id() {
-  if [ -z "$SETTINGS_ID" ] ; then
+  if [[ -z "${SETTINGS_ID}" ]] ; then
     echo "No ${SSO_KEYWORD} settings are set"
     echo "Run for further info: ./${SCRIPT_NAME} -h"
     echo
@@ -18,33 +18,33 @@ function exit_if_no_settings_id() {
 }
 
 function get_active_settings_type() {
-  ACTIVE_SETTINGS_TYPE=`curl $CURL_OPTS \
-    -H "Authorization: Bearer $API_TOKEN" \
+  ACTIVE_SETTINGS_TYPE=`curl ${CURL_OPTS} \
+    -H "Authorization: Bearer ${API_TOKEN}" \
     -X GET \
-    $ACTIVE_ENDPOINT | jq '.activeSettings | .type'`
+    ${ACTIVE_ENDPOINT} | jq '.activeSettings | .type'`
 }
 
 function get_settings_version() {
-  VERSION=`curl $CURL_OPTS \
-    -H "Authorization: Bearer $API_TOKEN" \
+  VERSION=`curl ${CURL_OPTS} \
+    -H "Authorization: Bearer ${API_TOKEN}" \
     -X GET \
     ${SETTINGS_ENDPOINT} | jq '.authenticationSettings | .[] | select(.type=="'"${SSO_KEYWORD}"'") | .version'`
 }
 
 function set_as_active_setting() {
   get_settings_id
-  curl $CURL_OPTS \
-    -H "Authorization: Bearer $API_TOKEN" \
+  curl ${CURL_OPTS} \
+    -H "Authorization: Bearer ${API_TOKEN}" \
     -X PUT \
-    $ACTIVE_ENDPOINT/$SETTINGS_ID | ${JSON_FILTER}
+    ${ACTIVE_ENDPOINT}/${SETTINGS_ID} | ${JSON_FILTER}
 }
 
 function disable_current_sso_auth_if_needed() {
-  if [[ $ACTIVE_SETTINGS_TYPE == *$SSO_KEYWORD* ]]; then
-    curl $CURL_OPTS \
-      -H "Authorization: Bearer $API_TOKEN" \
+  if [[ ${ACTIVE_SETTINGS_TYPE} == *${SSO_KEYWORD}* ]]; then
+    curl ${CURL_OPTS} \
+      -H "Authorization: Bearer ${API_TOKEN}" \
       -X DELETE \
-      $ACTIVE_ENDPOINT | ${JSON_FILTER}
+      ${ACTIVE_ENDPOINT} | ${JSON_FILTER}
   fi
 }
 
@@ -54,10 +54,10 @@ function delete_settings() {
   get_active_settings_type
   disable_current_sso_auth_if_needed
 
-  curl $CURL_OPTS \
-    -H "Authorization: Bearer $API_TOKEN" \
+  curl ${CURL_OPTS} \
+    -H "Authorization: Bearer ${API_TOKEN}" \
     -X DELETE \
-    $SETTINGS_ENDPOINT/$SETTINGS_ID | ${JSON_FILTER}
+    ${SETTINGS_ENDPOINT}/${SETTINGS_ID} | ${JSON_FILTER}
 }
 
 function get_settings() {
@@ -65,14 +65,14 @@ function get_settings() {
   exit_if_no_settings_id
 
   get_active_settings_type
-  if [[ $ACTIVE_SETTINGS_TYPE == *$SSO_KEYWORD* ]]; then
+  if [[ ${ACTIVE_SETTINGS_TYPE} == *${SSO_KEYWORD}* ]]; then
     echo "${SSO_KEYWORD} is selected as auth method"
   else
     echo "${SSO_KEYWORD} is not selected as auth method"
   fi
 
-  curl $CURL_OPTS \
-    -H "Authorization: Bearer $API_TOKEN" \
+  curl ${CURL_OPTS} \
+    -H "Authorization: Bearer ${API_TOKEN}" \
     -X GET \
-    $SETTINGS_ENDPOINT/$SETTINGS_ID | ${JSON_FILTER}
+    ${SETTINGS_ENDPOINT}/${SETTINGS_ID} | ${JSON_FILTER}
 }


### PR DESCRIPTION
After jumping into a support call I realised these SSO scripts were not working for those users not using Linux. Because of `getopts` not installed by default at macOS and those differences about `getopt` between GNU and BSD, I decided to move backwards accepting only short parameters.

For this PR I'm taking the already approved (but not merged yet) https://github.com/draios/sysdig-cloud-scripts/pull/58 documentation improvement