### PR TITLE
[SMAGENT-1697] Override the project's default node selector in openshift

### DIFF
--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -75,7 +75,7 @@ function create_namespace {
         out=$(kubectl create namespace $NAMESPACE 2>&1) || { fail=1 && echo "kubectl create namespace failed!"; }
     else
         echo "* Creating project: $NAMESPACE"
-        out=$(oc adm new-project $NAMESPACE --node-selector='app=sysdig-agent' 2>&1) || { fail=1 && echo "oc adm new-project failed!"; }
+        out=$(oc adm new-project $NAMESPACE --node-selector='' 2>&1) || { fail=1 && echo "oc adm new-project failed!"; }
         # Set the project to the namespace
         switch=$(oc project $NAMESPACE 2>&1)
     fi


### PR DESCRIPTION
The default selector prevents the agent from running on the master node. Modifying the selector is safer than setting `app=sysdig-agent` because other tools may also use the app label, and it's easier because we'll no longer need to label the nodes. This is the idiomatic way recommended by openshift. https://docs.openshift.com/container-platform/4.1/nodes/jobs/nodes-pods-daemonsets.html#nodes-pods-daemonsets-creating_nodes-pods-daemonsets