### PR TITLE
Add deploy with kustomize

### DIFF
--- a/agent_deploy/kustomize/clusterrole.yaml
+++ b/agent_deploy/kustomize/clusterrole.yaml
@@ -1,0 +1,63 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sysdig-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - replicationcontrollers
+  - services
+  - events
+  - limitranges
+  - namespaces
+  - nodes
+  - resourcequotas
+  - persistentvolumes
+  - persistentvolumeclaims
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - ingresses
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch

--- a/agent_deploy/kustomize/configmap.yaml
+++ b/agent_deploy/kustomize/configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sysdig-agent
+data:
+  dragent.yaml: |
+    configmap: true
+    ### Agent tags
+    # tags: linux:ubuntu,dept:dev,local:nyc
+
+    #### Sysdig Software related config ####
+
+    # Sysdig collector address
+    # collector: 192.168.1.1
+
+    # Collector TCP port
+    # collector_port: 6666
+
+    # Whether collector accepts ssl
+    # ssl: true
+
+    # collector certificate validation
+    # ssl_verify_certificate: true
+
+    #######################################
+    # new_k8s: true
+    # k8s_cluster_name: production

--- a/agent_deploy/kustomize/daemonset.yaml
+++ b/agent_deploy/kustomize/daemonset.yaml
@@ -1,0 +1,113 @@
+### WARNING: this file is supported from Sysdig Agent 0.80.0
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: sysdig-agent
+  labels:
+    app: sysdig-agent
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: sysdig-agent
+    spec:
+      volumes:
+      - name: osrel
+        hostPath:
+          path: /etc/os-release
+          type: FileOrCreate
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      - name: dev-vol
+        hostPath:
+          path: /dev
+      - name: proc-vol
+        hostPath:
+          path: /proc
+      - name: boot-vol
+        hostPath:
+          path: /boot
+      - name: modules-vol
+        hostPath:
+          path: /lib/modules
+      - name: usr-vol
+        hostPath:
+          path: /usr
+      - name: run-vol
+        hostPath:
+          path: /run
+      - name: varrun-vol
+        hostPath:
+          path: /var/run
+      - name: sysdig-agent-config
+        configMap:
+          name: sysdig-agent
+          optional: true
+      - name: sysdig-agent-secrets
+        secret:
+          secretName: sysdig-agent
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      hostPID: true
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      # The following line is necessary for RBAC
+      serviceAccount: sysdig-agent
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: sysdig-agent
+        image: sysdig/agent:0.90.3
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          # Resources needed are subjective to the actual workload.
+          # Please refer to Sysdig Support for more info.
+          requests:
+            cpu: 600m
+            memory: 512Mi
+          limits:
+            cpu: 2000m
+            memory: 1536Mi
+        readinessProbe:
+          exec:
+            command: [ "test", "-e", "/opt/draios/logs/running" ]
+          initialDelaySeconds: 10
+        # This section is for eBPF support. Please refer to Sysdig Support before
+        # uncommenting, as eBPF is recommended for only a few configurations.
+        #env:
+        #  - name: SYSDIG_BPF_PROBE
+        #    value: ""
+        volumeMounts:
+        - mountPath: /host/dev
+          name: dev-vol
+          readOnly: false
+        - mountPath: /host/proc
+          name: proc-vol
+          readOnly: true
+        - mountPath: /host/boot
+          name: boot-vol
+          readOnly: true
+        - mountPath: /host/lib/modules
+          name: modules-vol
+          readOnly: true
+        - mountPath: /host/usr
+          name: usr-vol
+          readOnly: true
+        - mountPath: /host/run
+          name: run-vol
+        - mountPath: /host/var/run
+          name: varrun-vol
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /opt/draios/etc/kubernetes/config
+          name: sysdig-agent-config
+        - mountPath: /opt/draios/etc/kubernetes/secrets
+          name: sysdig-agent-secrets
+        - mountPath: /host/etc/os-release
+          name: osrel
+          readOnly: true

--- a/agent_deploy/kustomize/kustomization.yaml
+++ b/agent_deploy/kustomize/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sysdig-agent
+resources:
+- namespace.yaml
+- clusterrole.yaml
+- rolebinding.yaml
+- serviceaccount.yaml
+- configmap.yaml
+- daemonset-v2.yaml

--- a/agent_deploy/kustomize/namespace.yaml
+++ b/agent_deploy/kustomize/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sysdig-agent

--- a/agent_deploy/kustomize/rolebinding.yaml
+++ b/agent_deploy/kustomize/rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: sysdig-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sysdig-agent
+subjects:
+  - kind: ServiceAccount
+    name: sysdig-agent

--- a/agent_deploy/kustomize/serviceaccount.yaml
+++ b/agent_deploy/kustomize/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sysdig-agent


### PR DESCRIPTION
I was deploying sysdig in a Kubernetes cluster with version > 1.14.0 and in this version [Kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) is part of kubectl. The deployment gets considerably easier than what is described in the [docs](https://sysdigdocs.atlassian.net/wiki/spaces/Platform/pages/256475253/Kubernetes+Agent+Installation+Steps), after creating the secret I just run 1 command:

```
kubectl apply -f ./kustomize
```

And I get sysdig-agent running in my cluster =). I'm already using this and it seems to be working fine, probably needs refinement but I thought that perhaps you may find it useful.