### PR TITLE
apiserver metrics scrape enablement

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
@@ -61,3 +61,7 @@ rules:
   - get
   - list
   - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get


### PR DESCRIPTION
Add resource in clusterrole to access kubernetes apiserver metrics endpoint using serviceaccount token.
This metrics offer information about apiserver requests, latency, etcd cache, etc.