### PR TITLE
Revert "add optional app_check to sysdig-agent configmap"

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-configmap.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-configmap.yaml
@@ -4,18 +4,6 @@ metadata:
   name: sysdig-agent
 data:
   dragent.yaml: |
-    app_checks:
-      ## If enabling elasticsearch auth, uncomment and update the block below
-      # - name: elasticsearch
-      #   check_module: elastic
-      #   pattern:
-      #     port: 9200
-      #     comm: java
-      #   conf:
-      #     url: https://sysdigcloud-elasticsearch:9200
-      #     username: readonly
-      #     password: <change_me>
-      #     ssl_verify: false
     configmap: true
     ### Agent tags
     # tags: linux:ubuntu,dept:dev,local:nyc


### PR DESCRIPTION
Reverts draios/sysdig-cloud-scripts#72

I'll add this information to this doc page instead: https://sysdigdocs.atlassian.net/wiki/spaces/Monitor/pages/204931201/Elasticsearch