### PR TITLE
Add DaemonSet v3 because of K8S 1.16 release

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v3.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v3.yaml
@@ -1,0 +1,116 @@
+### WARNING: this file is supported from Sysdig Agent 0.80.0
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sysdig-agent
+  labels:
+    app: sysdig-agent
+spec:
+  selector:
+    matchLabels:
+      app: sysdig-agent
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: sysdig-agent
+    spec:
+      volumes:
+      - name: osrel
+        hostPath:
+          path: /etc/os-release
+          type: FileOrCreate
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      - name: dev-vol
+        hostPath:
+          path: /dev
+      - name: proc-vol
+        hostPath:
+          path: /proc
+      - name: boot-vol
+        hostPath:
+          path: /boot
+      - name: modules-vol
+        hostPath:
+          path: /lib/modules
+      - name: usr-vol
+        hostPath:
+          path: /usr
+      - name: run-vol
+        hostPath:
+          path: /run
+      - name: varrun-vol
+        hostPath:
+          path: /var/run
+      - name: sysdig-agent-config
+        configMap:
+          name: sysdig-agent
+          optional: true
+      - name: sysdig-agent-secrets
+        secret:
+          secretName: sysdig-agent
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      hostPID: true
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      # The following line is necessary for RBAC
+      serviceAccount: sysdig-agent
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: sysdig-agent
+        image: sysdig/agent
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          # Resources needed are subjective to the actual workload.
+          # Please refer to Sysdig Support for more info.
+          requests:
+            cpu: 600m
+            memory: 512Mi
+          limits:
+            cpu: 2000m
+            memory: 1536Mi
+        readinessProbe:
+          exec:
+            command: [ "test", "-e", "/opt/draios/logs/running" ]
+          initialDelaySeconds: 10
+        # This section is for eBPF support. Please refer to Sysdig Support before
+        # uncommenting, as eBPF is recommended for only a few configurations.
+        #env:
+        #  - name: SYSDIG_BPF_PROBE
+        #    value: ""
+        volumeMounts:
+        - mountPath: /host/dev
+          name: dev-vol
+          readOnly: false
+        - mountPath: /host/proc
+          name: proc-vol
+          readOnly: true
+        - mountPath: /host/boot
+          name: boot-vol
+          readOnly: true
+        - mountPath: /host/lib/modules
+          name: modules-vol
+          readOnly: true
+        - mountPath: /host/usr
+          name: usr-vol
+          readOnly: true
+        - mountPath: /host/run
+          name: run-vol
+        - mountPath: /host/var/run
+          name: varrun-vol
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /opt/draios/etc/kubernetes/config
+          name: sysdig-agent-config
+        - mountPath: /opt/draios/etc/kubernetes/secrets
+          name: sysdig-agent-secrets
+        - mountPath: /host/etc/os-release
+          name: osrel
+          readOnly: true

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v3.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v3.yaml
@@ -1,0 +1,118 @@
+## WARNING: this file is supported from Sysdig Agent 0.80.0
+apiVersion: app/v1
+kind: DaemonSet
+metadata:
+  name: sysdig-agent
+  labels:
+    app: sysdig-agent
+spec:
+  selector:
+    matchLabels:
+      app: sysdig-agent
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: sysdig-agent
+    spec:
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      - name: dev-vol
+        hostPath:
+          path: /dev
+      - name: proc-vol
+        hostPath:
+          path: /proc
+      - name: boot-vol
+        hostPath:
+          path: /boot
+      - name: modules-vol
+        hostPath:
+          path: /lib/modules
+      - name: usr-vol
+        hostPath:
+          path: /usr
+      - name: run-vol
+        hostPath:
+          path: /run
+      - name: varrun-vol
+        hostPath:
+          path: /var/run
+      - name: sysdig-agent-config
+        configMap:
+          name: sysdig-agent
+          optional: true
+      - name: sysdig-agent-secrets
+        secret:
+          secretName: sysdig-agent
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      # The following line is necessary for RBAC
+      serviceAccount: sysdig-agent
+      terminationGracePeriodSeconds: 5
+      initContainers:
+      - name: sysdig-agent-kmodule
+        image: sysdig/agent-kmodule
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 384Mi
+          limits:
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /host/boot
+          name: boot-vol
+          readOnly: true
+        - mountPath: /host/lib/modules
+          name: modules-vol
+          readOnly: true
+        - mountPath: /host/usr
+          name: usr-vol
+          readOnly: true
+      containers:
+      - name: sysdig-agent
+        # WARNING: the agent-slim release is currently dependent on the above
+        # initContainer and thus only functions correctly in a kubernetes cluster 
+        image: sysdig/agent-slim
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          # Resources needed are subjective to the actual workload.
+          # Please refer to Sysdig Support for more info.
+          requests:
+            cpu: 600m
+            memory: 512Mi
+          limits:
+            cpu: 2000m
+            memory: 1536Mi
+        readinessProbe:
+          exec:
+            command: [ "test", "-e", "/opt/draios/logs/running" ]
+          initialDelaySeconds: 10
+        volumeMounts:
+        - mountPath: /host/dev
+          name: dev-vol
+          readOnly: false
+        - mountPath: /host/proc
+          name: proc-vol
+          readOnly: true
+        - mountPath: /host/run
+          name: run-vol
+        - mountPath: /host/var/run
+          name: varrun-vol
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /opt/draios/etc/kubernetes/config
+          name: sysdig-agent-config
+        - mountPath: /opt/draios/etc/kubernetes/secrets
+          name: sysdig-agent-secrets


### PR DESCRIPTION
Deprecated APIs removed: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/