### PR TITLE
Revert "[SMAGENT-1517] k8s: add configmaps and secrets to sysdig clusterrole"

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
@@ -16,8 +16,6 @@ rules:
   - resourcequotas
   - persistentvolumes
   - persistentvolumeclaims
-  - configmaps
-  - secrets
   verbs:
   - get
   - list

--- a/agent_deploy/openshift/sysdig-agent-clusterrole.yaml
+++ b/agent_deploy/openshift/sysdig-agent-clusterrole.yaml
@@ -16,8 +16,6 @@ rules:
   - resourcequotas
   - persistentvolumes
   - persistentvolumeclaims
-  - configmaps
-  - secrets
   verbs:
   - get
   - list


### PR DESCRIPTION
This reverts commit 35942a1024c90cd82d128ba49681772cdd4fdc8a.

Sysdig is no longer planning to add support for configmaps and secrets
in cointerface