### PR TITLE
adding modprobe.d mounting to all daemonsets

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
@@ -18,6 +18,9 @@ spec:
         app: sysdig-agent
     spec:
       volumes:
+      - name: modprobe-d
+        hostPath:
+          path: /etc/modprobe.d
       - name: dshm
         emptyDir:
           medium: Memory
@@ -90,6 +93,9 @@ spec:
         #     new_k8s: true
         #     k8s_cluster_name: production
         volumeMounts:
+        - mountPath: /etc/modprobe.d
+          name: modprobe-d
+          readOnly: true
         - mountPath: /host/dev
           name: dev-vol
           readOnly: false

--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -18,6 +18,9 @@ spec:
         app: sysdig-agent
     spec:
       volumes:
+      - name: modprobe-d
+        hostPath:
+          path: /etc/modprobe.d
       - name: osrel
         hostPath:
           path: /etc/os-release
@@ -93,6 +96,9 @@ spec:
         #  - name: SYSDIG_BPF_PROBE
         #    value: ""
         volumeMounts:
+        - mountPath: /etc/modprobe.d
+          name: modprobe-d
+          readOnly: true
         - mountPath: /host/dev
           name: dev-vol
           readOnly: false

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
@@ -74,6 +74,9 @@ spec:
         - mountPath: /host/lib/modules
           name: modules-vol
           readOnly: true
+        - mountPath: /etc/modprobe.d
+          name: modprobe-d
+          readOnly: true
         - mountPath: /host/usr
           name: usr-vol
           readOnly: true
@@ -117,9 +120,6 @@ spec:
         #     new_k8s: true
         #     k8s_cluster_name: production
         volumeMounts:
-        - mountPath: /etc/modprobe.d
-          name: modprobe-d
-          readOnly: true
         - mountPath: /host/dev
           name: dev-vol
           readOnly: false

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
@@ -18,6 +18,9 @@ spec:
         app: sysdig-agent
     spec:
       volumes:
+      - name: modprobe-d
+        hostPath:
+          path: /etc/modprobe.d
       - name: dshm
         emptyDir:
           medium: Memory
@@ -114,6 +117,9 @@ spec:
         #     new_k8s: true
         #     k8s_cluster_name: production
         volumeMounts:
+        - mountPath: /etc/modprobe.d
+          name: modprobe-d
+          readOnly: true
         - mountPath: /host/dev
           name: dev-vol
           readOnly: false

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -73,6 +73,9 @@ spec:
           limits:
             memory: 512Mi
         volumeMounts:
+        - mountPath: /etc/modprobe.d
+          name: modprobe-d
+          readOnly: true
         - mountPath: /host/boot
           name: boot-vol
           readOnly: true
@@ -104,9 +107,6 @@ spec:
             command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
         volumeMounts:
-        - mountPath: /etc/modprobe.d
-          name: modprobe-d
-          readOnly: true
         - mountPath: /host/dev
           name: dev-vol
           readOnly: false

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -18,6 +18,9 @@ spec:
         app: sysdig-agent
     spec:
       volumes:
+      - name: modprobe-d
+        hostPath:
+          path: /etc/modprobe.d
       - name: dshm
         emptyDir:
           medium: Memory
@@ -101,6 +104,9 @@ spec:
             command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
         volumeMounts:
+        - mountPath: /etc/modprobe.d
+          name: modprobe-d
+          readOnly: true
         - mountPath: /host/dev
           name: dev-vol
           readOnly: false

--- a/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
+++ b/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
@@ -18,6 +18,9 @@ spec:
         app: sysdig-agent
     spec:
       volumes:
+      - name: modprobe-d
+        hostPath:
+          path: /etc/modprobe.d
       - name: dshm
         emptyDir:
           medium: Memory
@@ -71,6 +74,9 @@ spec:
             command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
         volumeMounts:
+        - mountPath: /etc/modprobe.d
+          name: modprobe-d
+          readOnly: true
         - mountPath: /host/var/run/docker.sock
           name: docker-sock
           readOnly: false


### PR DESCRIPTION
This mounts /etc/modprobe.d in all daemonsets to prevent dkms from ignoring blacklists on the host machine. 