### PR TITLE
Version 1.0.0 of ks plugin drops support for cluster-get

### DIFF
--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -156,7 +156,7 @@ function install_k8s_agent {
         # Pull the cluster name using the cluster ID using ibmcloud ks
         # since the current-context is not a user-friendly value
         fail=0
-        CLUSTER_NAME=$(ibmcloud ks cluster-get "$IKS_CLUSTER_ID" --json | jq .name | tr -d '"') || { fail=1 && echo "Failed to get the cluster name"; }
+        CLUSTER_NAME=$(ibmcloud ks cluster get --cluster "$IKS_CLUSTER_ID" --json | jq .name | tr -d '"') || { fail=1 && echo "Failed to get the cluster name"; }
         if [ $fail -eq 1 ]; then
             echo "Failed to get the cluster name from the Cluster ID using ibmcloud ks - $CLUSTER_ID "
             echo "Attempting to retrieve the current-context for the cluster name"

--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -156,7 +156,7 @@ function install_k8s_agent {
         # Pull the cluster name using the cluster ID using ibmcloud ks
         # since the current-context is not a user-friendly value
         fail=0
-        CLUSTER_NAME=$(ibmcloud ks cluster get --cluster "$IKS_CLUSTER_ID" --json | jq .name | tr -d '"') || { fail=1 && echo "Failed to get the cluster name"; }
+        CLUSTER_NAME=$(ibmcloud ks cluster get --cluster "$IKS_CLUSTER_ID" --json | jq -r .name) || { fail=1 && echo "Failed to get the cluster name"; }
         if [ $fail -eq 1 ]; then
             echo "Failed to get the cluster name from the Cluster ID using ibmcloud ks - $CLUSTER_ID "
             echo "Attempting to retrieve the current-context for the cluster name"


### PR DESCRIPTION
This patches a problem with OpenShift clusters where the cluster name not parsed due to a change in the ibmcloud ks CLI behaviour.  The command `ibmcloud ks cluster-get <id>` has been removed and the correct command is `ibmcloud ks cluster get --cluster <id>`

