### PR TITLE
Update audit level to Metadata for secrets

### DIFF
--- a/k8s_audit_config/audit-policy.yaml
+++ b/k8s_audit_config/audit-policy.yaml
@@ -56,11 +56,17 @@ rules:
     # The empty string "" can be used to select non-namespaced resources.
     namespaces: ["kube-system"]
 
-  # Log configmap and secret changes in all other namespaces at the RequestResponse level.
+  # Log configmap changes in all other namespaces at the RequestResponse level.
   - level: RequestResponse
     resources:
     - group: "" # core API group
-      resources: ["secrets", "configmaps"]
+      resources: ["configmaps"]
+
+  # Log secret changes in all other namespaces at the Metadata level.
+  - level: Metadata
+    resources:
+    - group: "" # core API group
+      resources: ["secrets"]
 
   # Log all other resources in core and extensions at the Request level.
   - level: Request


### PR DESCRIPTION
Reflecting the changes in
https://github.com/falcosecurity/falco/pull/1153, this changes the
recommended audit policy to log secrets information at Metadata level,
which prevents the contents of secrets from being logged.