### PR TITLE
[SSPROD-4035] Extend Agent RBAC capabilities to fetch endpoints

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
@@ -9,6 +9,7 @@ rules:
   - pods
   - replicationcontrollers
   - services
+  - endpoints
   - events
   - limitranges
   - namespaces


### PR DESCRIPTION
This change modifies the Agent's Cluster Role in order to allow the
retrieval of Kubernetes endpoint.

Signed-off-by: Lorenzo David <lorenzo.david@sysdig.com>