### PR TITLE
[SSPROD-4452] image analyzer: change the verify certificate variable name

### DIFF
--- a/agent_deploy/kubernetes/sysdig-image-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-image-analyzer-daemonset.yaml
@@ -117,11 +117,11 @@ spec:
               name: sysdig-image-analyzer
               key: collector_timeout
               optional: true
-        - name: CHECK_CERTIFICATE
+        - name: VERIFY_CERTIFICATE
           valueFrom:
             configMapKeyRef:
               name: sysdig-image-analyzer
-              key: check_certificate
+              key: ssl_verify_certificate
               optional: true
         - name: K8S_NODE_NAME
           valueFrom:


### PR DESCRIPTION
This makes the behavior of the variable to skip ssl cert verification consistent with the agent

When the corresponding PR on the Image Analyzer repo is merged we'll be able to update this, and then we can mirror this change on the installer script as well.