### PR TITLE
Remove k8s audit options from sample configmap

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-configmap.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-configmap.yaml
@@ -25,6 +25,3 @@ data:
     #######################################
     # new_k8s: true
     # k8s_cluster_name: production
-    security:
-      k8s_audit_server_url: 0.0.0.0
-      k8s_audit_server_port: 7765


### PR DESCRIPTION
These values are alredy the defaults and don't need to be specifically
configured.