### PR TITLE
fixed copying IKS pull secrets from default namespace

### DIFF
--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -289,7 +289,7 @@ function install_k8s_agent {
             SECRET_NAME=$(echo ${default_secret} | sed "s/default-/$NAMESPACE-/g")
 
             echo "Processing ${default_secret} as ${SECRET_NAME}"
-            kubectl get secret ${default_secret} -n default -o yaml --export | sed "s/name: default-/name: $NAMESPACE-/g" | kubectl -n $NAMESPACE apply -f -
+            kubectl get secret ${default_secret} -n default -o yaml | sed -e "s/name: default-/name: $NAMESPACE-/g" -e "s/namespace: default/namespace: $NAMESPACE/g" | kubectl apply -f -
 
             echo "${INDENT}- name: $SECRET_NAME" >> $DAEMONSET_FILE
         done


### PR DESCRIPTION
The `--export` flag was [deprecated](https://github.com/kubernetes/kubernetes/pull/73787) a long time ago and it is officially removed in [v1.19.0](https://kubernetes.io/docs/setup/release/notes/#changelog-since-v1-18-0).

The script currently fails for everyone using the latest stable kubectl:
```
$ curl -sL https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh | bash -s -- -a 17477b91-899d-4c4f-b3e9-665e0902eb07 -c ingest.private.us-south.monitoring.cloud.ibm.com -ac 'sysdig_capture_enabled: false'
* Detecting operating system
* Downloading Sysdig cluster role yaml
* Downloading Sysdig config map yaml
* Downloading Sysdig daemonset v2 yaml
* Downloading Sysdig agent-slim daemonset v2 yaml
* Creating namespace: ibm-observe
* Creating sysdig-agent serviceaccount in namespace: ibm-observe
* Creating sysdig-agent clusterrole and binding
clusterrole.rbac.authorization.k8s.io/sysdig-agent unchanged
* Creating sysdig-agent secret using the ACCESS_KEY provided
* Retreiving the IKS Cluster ID and Cluster Name
* Setting cluster name as sysdig-debug/btbkvhmd0at8rdvotuh0/admin
* Setting ibm.containers-kubernetes.cluster.id btbkvhmd0at8rdvotuh0
* Updating agent configmap and applying to cluster
* Setting tags
* Setting collector endpoint
* Adding additional configuration to dragent.yaml
* Enabling Prometheus
Processing all-icr-io as all-icr-io
Error: unknown flag: --export
See 'kubectl get --help' for usage.
error: no objects passed to apply
```

The changes included in this PR fix the failing installation:
```
curl -sL https://raw.githubusercontent.com/attiss/sysdig-cloud-scripts/iks-script-fix/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh | bash -s -- -a 17477b91-899d-4c4f-b3e9-665e0902eb07 -c ingest.private.us-south.monitoring.cloud.ibm.com -ac 'sysdig_capture_enabled: false'
* Detecting operating system
* Downloading Sysdig cluster role yaml
* Downloading Sysdig config map yaml
* Downloading Sysdig daemonset v2 yaml
* Downloading Sysdig agent-slim daemonset v2 yaml
* Creating namespace: ibm-observe
* Creating sysdig-agent serviceaccount in namespace: ibm-observe
* Creating sysdig-agent clusterrole and binding
clusterrole.rbac.authorization.k8s.io/sysdig-agent created
* Creating sysdig-agent secret using the ACCESS_KEY provided
* Retreiving the IKS Cluster ID and Cluster Name
* Setting cluster name as sysdig-debug/btbkvhmd0at8rdvotuh0/admin
* Setting ibm.containers-kubernetes.cluster.id btbkvhmd0at8rdvotuh0
* Updating agent configmap and applying to cluster
* Setting tags
* Setting collector endpoint
* Adding additional configuration to dragent.yaml
* Enabling Prometheus
Processing all-icr-io as all-icr-io
secret/all-icr-io created
Processing default-icr-io as ibm-observe-icr-io
secret/ibm-observe-icr-io created
configmap/sysdig-agent created
* Deploying the sysdig agent
daemonset.apps/sysdig-agent created
```