### PR TITLE
Fix for deprecated kubectl get --export

### DIFF
--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -289,7 +289,7 @@ function install_k8s_agent {
             SECRET_NAME=$(echo ${default_secret} | sed "s/default-/$NAMESPACE-/g")
 
             echo "Processing ${default_secret} as ${SECRET_NAME}"
-            kubectl get secret ${default_secret} -n default -o yaml | sed -e "s/name: default-/name: $NAMESPACE-/g" -e "s/namespace: default/namespace: $NAMESPACE/g" | kubectl apply -f -
+            kubectl get secret ${default_secret} -n default -o json | jq "del(.metadata.namespace,.metadata.resourceVersion,.metadata.uid) | .metadata.creationTimestamp=null | .metadata.name|=\"${SECRET_NAME}\"" | kubectl apply -n ${NAMESPACE} -f -
 
             echo "${INDENT}- name: $SECRET_NAME" >> $DAEMONSET_FILE
         done

--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -289,7 +289,7 @@ function install_k8s_agent {
             SECRET_NAME=$(echo ${default_secret} | sed "s/default-/$NAMESPACE-/g")
 
             echo "Processing ${default_secret} as ${SECRET_NAME}"
-            kubectl get secret ${default_secret} -n default -o yaml --export | sed "s/name: default-/name: $NAMESPACE-/g" | kubectl -n $NAMESPACE apply -f -
+            kubectl get secret ${default_secret} -n default -o yaml | sed -e "s/name: default-/name: $NAMESPACE-/g" -e "s/namespace: default/namespace: $NAMESPACE/g" | kubectl apply -f -
 
             echo "${INDENT}- name: $SECRET_NAME" >> $DAEMONSET_FILE
         done


### PR DESCRIPTION
https://github.com/draios/sysdig-cloud-scripts/pull/127
https://github.com/draios/sysdig-cloud-scripts/issues/120

```shell
...
Processing all-icr-io as all-icr-io
secret/all-icr-io created
Processing default-icr-io as ibm-observe-icr-io
secret/ibm-observe-icr-io created
configmap/sysdig-agent created
* Deploying the sysdig agent
daemonset.apps/sysdig-agent created


sysdig-agent-gkrxx   1/1     Running   0          2m20s
sysdig-agent-l78qv   1/1     Running   0          2m20s
sysdig-agent-sb646   1/1     Running   0          2m20s
sysdig-agent-zg2sw   1/1     Running   0          2m20s


all-icr-io                 kubernetes.io/dockerconfigjson        1      4m18s
default-token-7t5zv        kubernetes.io/service-account-token   3      4m59s
ibm-observe-icr-io         kubernetes.io/dockerconfigjson        1      4m17s
sysdig-agent               Opaque                                1      4m20s
sysdig-agent-token-g668d   kubernetes.io/service-account-token   3      4m59s
```