### PR TITLE
SSPROD-4497 Env update for containerd support for the Node Image Analyzer

### DIFF
--- a/agent_deploy/kubernetes/sysdig-image-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-image-analyzer-daemonset.yaml
@@ -105,6 +105,12 @@ spec:
               name: sysdig-image-analyzer
               key: cri_socket_path
               optional: true
+        - name: CONTAINERD_SOCKET_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: sysdig-image-analyzer
+              key: containerd_socket_path
+              optional: true
         - name: AM_COLLECTOR_ENDPOINT
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Newer versions of the image analyzer support containerd, this change allows the containerd socket to be configured from the configmap as well.