### PR TITLE
SSPROD-5067 - Update agent mounts.

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -46,12 +46,21 @@ spec:
       - name: usr-vol
         hostPath:
           path: /usr
+      # Linux bench requires /var/lib, /var/log, /var/tmp and /var/run
+      # We need to mount these subdirs seperately, i.e we can't simply mount /var, as
+      # /var/run is symlinked to /run on the host, so we mount /run to /var/run in the agent.
+      - name: vartmp-vol
+        hostPath:
+          path: /var/tmp
+      - name: varlog-vol
+        hostPath:
+          path: /var/log
+      - name: varlib-vol
+        hostPath:
+          path: /var/lib
       - name: run-vol
         hostPath:
-          path: /run
-      - name: var-vol
-        hostPath:
-          path: /var
+          path: /var/run
       - name: home-vol
         hostPath:
           path: /home
@@ -135,10 +144,17 @@ spec:
         - mountPath: /host/usr
           name: usr-vol
           readOnly: true
-        - mountPath: /host/run
+        - mountPath: /host/var/run
           name: run-vol
-        - mountPath: /host/var
-          name: var-vol
+        - mountPath: /host/var/log
+          name: varlog-vol
+          readOnly: true
+        - mountPath: /host/var/lib
+          name: varlib-vol
+          readOnly: true
+        - mountPath: /host/var/tmp
+          name: vartmp-vol
+          readOnly: true
         - mountPath: /host/home
           name: home-vol
           readOnly: true

--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -37,18 +37,36 @@ spec:
       - name: boot-vol
         hostPath:
           path: /boot
-      - name: modules-vol
+      - name: lib-vol
         hostPath:
-          path: /lib/modules
+          path: /lib
+      - name: lib64-vol
+        hostPath:
+          path: /lib64
       - name: usr-vol
         hostPath:
           path: /usr
       - name: run-vol
         hostPath:
           path: /run
-      - name: varrun-vol
+      - name: var-vol
         hostPath:
-          path: /var/run
+          path: /var
+      - name: home-vol
+        hostPath:
+          path: /home
+      - name: bin-vol
+        hostPath:
+          path: /bin
+      - name: sbin-vol
+        hostPath:
+          path: /sbin
+      - name: tmp-vol
+        hostPath:
+          path: /tmp
+      - name: etc-vol
+        hostPath:
+          path: /etc
       # Uncomment these lines if you'd like to map /root/ from the
       # host into the container. This can be useful to map
       # /root/.sysdig to pick up custom kernel modules.
@@ -108,16 +126,34 @@ spec:
         - mountPath: /host/boot
           name: boot-vol
           readOnly: true
-        - mountPath: /host/lib/modules
-          name: modules-vol
+        - mountPath: /host/lib
+          name: lib-vol
+          readOnly: true
+        - mountPath: /host/lib64
+          name: lib64-vol
           readOnly: true
         - mountPath: /host/usr
           name: usr-vol
           readOnly: true
         - mountPath: /host/run
           name: run-vol
-        - mountPath: /host/var/run
-          name: varrun-vol
+        - mountPath: /host/var
+          name: var-vol
+        - mountPath: /host/home
+          name: home-vol
+          readOnly: true
+        - mountPath: /host/bin
+          name: bin-vol
+          readOnly: true
+        - mountPath: /host/sbin
+          name: sbin-vol
+          readOnly: true
+        - mountPath: /host/tmp
+          name: tmp-vol
+          readOnly: true
+        - mountPath: /host/etc
+          name: etc-vol
+          readOnly: true
         - mountPath: /dev/shm
           name: dshm
         - mountPath: /opt/draios/etc/kubernetes/config

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -42,12 +42,21 @@ spec:
       - name: usr-vol
         hostPath:
           path: /usr
+      # Linux bench requires /var/lib, /var/log, /var/tmp and /var/run
+      # We need to mount these subdirs seperately, i.e we can't simply mount /var, as
+      # /var/run is symlinked to /run on the host, so we mount /run to /var/run in the agent.
+      - name: vartmp-vol
+        hostPath:
+          path: /var/tmp
+      - name: varlog-vol
+        hostPath:
+          path: /var/log
+      - name: varlib-vol
+        hostPath:
+          path: /var/lib
       - name: run-vol
         hostPath:
-          path: /run
-      - name: var-vol
-        hostPath:
-          path: /var
+          path: /var/run
       - name: home-vol
         hostPath:
           path: /home
@@ -143,10 +152,17 @@ spec:
         - mountPath: /host/usr
           name: usr-vol
           readOnly: true
-        - mountPath: /host/run
+        - mountPath: /host/var/run
           name: run-vol
-        - mountPath: /host/var
-          name: var-vol
+        - mountPath: /host/var/log
+          name: varlog-vol
+          readOnly: true
+        - mountPath: /host/var/lib
+          name: varlib-vol
+          readOnly: true
+        - mountPath: /host/var/tmp
+          name: vartmp-vol
+          readOnly: true
         - mountPath: /host/home
           name: home-vol
           readOnly: true

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -33,18 +33,36 @@ spec:
       - name: boot-vol
         hostPath:
           path: /boot
-      - name: modules-vol
+      - name: lib-vol
         hostPath:
-          path: /lib/modules
+          path: /lib
+      - name: lib64-vol
+        hostPath:
+          path: /lib64
       - name: usr-vol
         hostPath:
           path: /usr
       - name: run-vol
         hostPath:
           path: /run
-      - name: varrun-vol
+      - name: var-vol
         hostPath:
-          path: /var/run
+          path: /var
+      - name: home-vol
+        hostPath:
+          path: /home
+      - name: bin-vol
+        hostPath:
+          path: /bin
+      - name: sbin-vol
+        hostPath:
+          path: /sbin
+      - name: tmp-vol
+        hostPath:
+          path: /tmp
+      - name: etc-vol
+        hostPath:
+          path: /etc
       - name: sysdig-agent-config
         configMap:
           name: sysdig-agent
@@ -113,12 +131,42 @@ spec:
         - mountPath: /host/proc
           name: proc-vol
           readOnly: true
+        - mountPath: /host/boot
+          name: boot-vol
+          readOnly: true
+        - mountPath: /host/lib
+          name: lib-vol
+          readOnly: true
+        - mountPath: /host/lib64
+          name: lib64-vol
+          readOnly: true
+        - mountPath: /host/usr
+          name: usr-vol
+          readOnly: true
         - mountPath: /host/run
           name: run-vol
-        - mountPath: /host/var/run
-          name: varrun-vol
+        - mountPath: /host/var
+          name: var-vol
+        - mountPath: /host/home
+          name: home-vol
+          readOnly: true
+        - mountPath: /host/bin
+          name: bin-vol
+          readOnly: true
+        - mountPath: /host/sbin
+          name: sbin-vol
+          readOnly: true
+        - mountPath: /host/tmp
+          name: tmp-vol
+          readOnly: true
+        - mountPath: /host/etc
+          name: etc-vol
+          readOnly: true
         - mountPath: /dev/shm
           name: dshm
+        - mountPath: /host/etc
+          name: etc-vol
+          readOnly: true
         - mountPath: /opt/draios/etc/kubernetes/config
           name: sysdig-agent-config
         - mountPath: /opt/draios/etc/kubernetes/secrets


### PR DESCRIPTION
Update agent mounts to support https://github.com/draios/agent/pull/2212 (Same changes as https://github.com/draios/installer/pull/817)

Note: I only updated the v2 daemonsets, do I need to update the v1 as well?