### PR TITLE
fixed failing agent redeploy

### DIFF
--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -143,7 +143,7 @@ function install_k8s_agent {
         fi
     fi
     if [ $fail -eq 1 ]; then
-        if [[ "$outbinding" =~ "AlreadyExists" ]]; then
+        if [[ "$outbinding" =~ "AlreadyExists" || "$outbinding" =~ "already exists" ]]; then
             echo "$outbinding. Continuing..."
         else
             echo "$outbinding"
@@ -155,7 +155,7 @@ function install_k8s_agent {
     fail=0
     outsecret=$(kubectl create secret generic sysdig-agent --from-literal=access-key=$ACCESS_KEY --namespace=$NAMESPACE 2>&1) || { fail=1 && echo "kubectl create secret failed!"; }
     if [ $fail -eq 1 ]; then
-        if [[ "$outsecret" =~ "AlreadyExists" ]]; then
+        if [[ "$outsecret" =~ "AlreadyExists" || "$outsecret" =~ "already exists" ]]; then
             echo "$outsecret. Re-creating secret..."
             kubectl delete secrets sysdig-agent --namespace=$NAMESPACE 2>&1
             kubectl create secret generic sysdig-agent --from-literal=access-key=$ACCESS_KEY --namespace=$NAMESPACE 2>&1


### PR DESCRIPTION
This PR fixes the failing redeployment of Sysdig agents on IKS clusters.

---

<details>
<summary>Running the deployer script for the first time works fine.</summary>

```bash
$ ./install-agent-k8s.sh -a 7dde8cf6-4595-4967-ac04-6a0e577ce115 -c ingest.private.us-south.monitoring.cloud.ibm.com -ac 'sysdig_capture_enabled: false'
* Detecting operating system
* Downloading Sysdig cluster role yaml
* Downloading Sysdig config map yaml
* Downloading Sysdig daemonset v2 yaml
* Downloading Sysdig agent-slim daemonset v2 yaml
* Creating namespace: ibm-observe
* Creating sysdig-agent serviceaccount in namespace: ibm-observe
* Creating sysdig-agent clusterrole and binding
clusterrole.rbac.authorization.k8s.io/sysdig-agent created
* Creating sysdig-agent secret using the ACCESS_KEY provided
* Retreiving the IKS Cluster ID and Cluster Name
* Setting cluster name as r7-migration-demo-0/bthhm09d0715cgo25eog/admin
* Setting ibm.containers-kubernetes.cluster.id bthhm09d0715cgo25eog
* Updating agent configmap and applying to cluster
* Setting tags
* Setting collector endpoint
* Adding additional configuration to dragent.yaml
* Enabling Prometheus
Processing all-icr-io as all-icr-io
secret/all-icr-io created
Processing default-icr-io as ibm-observe-icr-io
secret/ibm-observe-icr-io created
configmap/sysdig-agent created
* Deploying the sysdig agent
daemonset.apps/sysdig-agent create
```

</details>

<details>
<summary>Running the deployer for the second time fails.</summary>

```bash
$ ./install-agent-k8s.sh -a 7dde8cf6-4595-4967-ac04-6a0e577ce115 -c ingest.private.us-south.monitoring.cloud.ibm.com -ac 'sysdig_capture_enabled: false'
* Detecting operating system
* Downloading Sysdig cluster role yaml
* Downloading Sysdig config map yaml
* Downloading Sysdig daemonset v2 yaml
* Downloading Sysdig agent-slim daemonset v2 yaml
* Creating namespace: ibm-observe
kubectl create namespace failed!
Error from server (AlreadyExists): namespaces "ibm-observe" already exists. Continuing...
* Creating sysdig-agent serviceaccount in namespace: ibm-observe
kubectl create serviceaccount failed!
Error from server (AlreadyExists): serviceaccounts "sysdig-agent" already exists. Continuing...
* Creating sysdig-agent clusterrole and binding
clusterrole.rbac.authorization.k8s.io/sysdig-agent unchanged
kubectl create clusterrolebinding failed!
error: failed to create clusterrolebinding: clusterrolebindings.rbac.authorization.k8s.io "sysdig-agent" already exists
```

</details>

---

<details>
<summary>Running the deployer with these fixes multiple times works fine.</summary>

```bash
$ ./install-agent-k8s.sh -a 7dde8cf6-4595-4967-ac04-6a0e577ce115 -c ingest.private.us-south.monitoring.cloud.ibm.com -ac 'sysdig_capture_enabled: false'
* Detecting operating system
* Downloading Sysdig cluster role yaml
* Downloading Sysdig config map yaml
* Downloading Sysdig daemonset v2 yaml
* Downloading Sysdig agent-slim daemonset v2 yaml
* Creating namespace: ibm-observe
kubectl create namespace failed!
Error from server (AlreadyExists): namespaces "ibm-observe" already exists. Continuing...
* Creating sysdig-agent serviceaccount in namespace: ibm-observe
kubectl create serviceaccount failed!
Error from server (AlreadyExists): serviceaccounts "sysdig-agent" already exists. Continuing...
* Creating sysdig-agent clusterrole and binding
clusterrole.rbac.authorization.k8s.io/sysdig-agent unchanged
kubectl create clusterrolebinding failed!
error: failed to create clusterrolebinding: clusterrolebindings.rbac.authorization.k8s.io "sysdig-agent" already exists. Continuing...
* Creating sysdig-agent secret using the ACCESS_KEY provided
kubectl create secret failed!
Error from server (AlreadyExists): secrets "sysdig-agent" already exists. Re-creating secret...
secret "sysdig-agent" deleted
secret/sysdig-agent created
* Retreiving the IKS Cluster ID and Cluster Name
* Setting cluster name as r7-migration-demo-0/bthhm09d0715cgo25eog/admin
* Setting ibm.containers-kubernetes.cluster.id bthhm09d0715cgo25eog
* Updating agent configmap and applying to cluster
* Setting tags
* Setting collector endpoint
* Adding additional configuration to dragent.yaml
* Enabling Prometheus
secret "ibm-observe-icr-io" deleted
secret "all-icr-io" deleted
Processing all-icr-io as all-icr-io
secret/all-icr-io created
Processing default-icr-io as ibm-observe-icr-io
secret/ibm-observe-icr-io created
configmap/sysdig-agent unchanged
* Deploying the sysdig agent
daemonset.apps/sysdig-agent configured
```

</details>

Tested using:
```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.0", GitCommit:"e19964183377d0ec2052d1f1fa930c4d7575bd50", GitTreeState:"clean", BuildDate:"2020-08-26T14:30:33Z", GoVersion:"go1.15", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.12+IKS", GitCommit:"d09005b98837bb6061c0f643a27383c02b003205", GitTreeState:"clean", BuildDate:"2020-09-16T21:47:16Z", GoVersion:"go1.13.15", Compiler:"gc", Platform:"linux/amd64"}
```