### PR TITLE
[SSPROD-5693] Fix bugs in the kops section

### DIFF
--- a/k8s_audit_config/enable-k8s-audit.sh
+++ b/k8s_audit_config/enable-k8s-audit.sh
@@ -133,7 +133,7 @@ elif [[ "$VARIANT" == "kops" ]]; then
     fi
 
     echo "Fetching current kops cluster configuration..."
-    kops get cluster -o yaml > cluster-current.yaml
+    kops get cluster $KOPS_CLUSTER_NAME -o yaml > cluster-current.yaml
 
     echo "Adding webhook configuration/audit policy to cluster configuration..."
 
@@ -159,7 +159,7 @@ $(cat audit-policy.yaml | sed -e 's/^/          /')
         auditWebhookConfigFile: /var/lib/k8s_audit/webhook-config.yaml
 EOF
 
-    yq m -a cluster-current.yaml merge.yaml > cluster.yaml
+    yq m -a=append cluster-current.yaml merge.yaml > cluster.yaml
 
     echo "Configuring kops with the new cluster configuration..."
     kops replace -f cluster.yaml


### PR DESCRIPTION
1. kops get cluster was not declaring the $KOPS_CLUSTER_NAME so it was grabbing ALL clusters which caused errors when trying to merge and apply
2. Fix bug with the yq command to merge the cluster-current.yaml and merge.yaml as we had to specify that we want to append