### PR TITLE
[SMPROD-4274] Endpoints resource permission

### DIFF
--- a/agent_deploy/openshift/sysdig-agent-clusterrole.yaml
+++ b/agent_deploy/openshift/sysdig-agent-clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
   - resourcequotas
   - persistentvolumes
   - persistentvolumeclaims
+  - endpoints
   verbs:
   - get
   - list


### PR DESCRIPTION
Endpoints resource had been added some time ago in Cointerface.  Unless adding permission in sysdig-agent clusterrole, we can't access the resource

```
endpoints is forbidden: User "system:serviceaccount:sysdig-agent:sysdig-agent" cannot list resource "endpoints" in API group "" at the cluster scope