### PR TITLE
Increase NIA memory limit to 1.5GB

### DIFF
--- a/agent_deploy/kubernetes/sysdig-image-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-image-analyzer-daemonset.yaml
@@ -56,7 +56,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 1024Mi
+            memory: 1536Mi
           requests:
             cpu: 250m
             memory: 512Mi


### PR DESCRIPTION
In some cases, depending on the image content, NIA may take more memory to perform analysis. While these cases are fairly rare in our experience it could be beneficial to increase the default memory limit to prevent the pods from getting OOM killed.