### PR TITLE
Use quay.io registry for agent/slim-agent/node-image-analyzer

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: sysdig-agent
-        image: sysdig/agent
+        image: quay.io/sysdig/agent
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -73,7 +73,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: sysdig-agent
-        image: quay.io/sysdig/agent:latest
+        image: quay.io/sysdig/agent
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -73,7 +73,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: sysdig-agent
-        image: sysdig/agent
+        image: quay.io/sysdig/agent:latest
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
@@ -55,7 +55,7 @@ spec:
       terminationGracePeriodSeconds: 5
       initContainers:
       - name: sysdig-agent-kmodule
-        image: sysdig/agent-kmodule
+        image: quay.io/sysdig/agent-kmodule
         imagePullPolicy: Always
         securityContext:
           privileged: true
@@ -82,7 +82,7 @@ spec:
           readOnly: true
       containers:
       - name: sysdig-agent
-        image: sysdig/agent-slim
+        image: quay.io/sysdig/agent-slim
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -62,7 +62,7 @@ spec:
       terminationGracePeriodSeconds: 5
       initContainers:
       - name: sysdig-agent-kmodule
-        image: sysdig/agent-kmodule
+        image: quay.io/sysdig/agent-kmodule
         imagePullPolicy: Always
         securityContext:
           privileged: true
@@ -89,7 +89,7 @@ spec:
       - name: sysdig-agent
         # WARNING: the agent-slim release is currently dependent on the above
         # initContainer and thus only functions correctly in a kubernetes cluster 
-        image: sysdig/agent-slim
+        image: quay.io/sysdig/agent-slim
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/agent_deploy/kubernetes/sysdig-image-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-image-analyzer-daemonset.yaml
@@ -47,7 +47,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: sysdig-image-analyzer
-        image: quay.io/sysdig/node-image-analyzer:latest
+        image: quay.io/sysdig/node-image-analyzer
         securityContext:
           # The privileged flag is necessary for OCP 4.x and other Kubernetes setups that deny host filesystem access to
           # running containers by default regardless of volume mounts. In those cases, access to the CRI socket would fail.


### PR DESCRIPTION
This is in part of the effort to move all Sysdig images to quay.io.

The changes here are only for the Vanilla k8s sample files.  We are not touching the IBM or Openshift files.