### PR TITLE
[QA-2299] IBM kmodule thin and agent slim

### DIFF
--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -77,7 +77,7 @@ function help {
     echo " -np : if provided, do not enable the Prometheus collector.  Defaults to enabling Prometheus collector"
     echo " -sn : if provided, name of the sysdig instance (optional)"
     echo " -op : if provided, perform the installation using the OpenShift command line"
-    echo " -as : if provided, use agent-slim (this is the default agent). Note: this option is deprecated"
+    echo " -as : if provided, use agent-slim (this is the default agent). Note: this option is not required"
     echo " -af : if provided, use agent-full instead of agent-slim"
     echo " -r  : if provided, will remove the sysdig agent's daemonset, configmap, clusterrolebinding,"
     echo "       serviceacccount and secret from the specified namespace"
@@ -560,7 +560,7 @@ case ${key} in
         ;;
     -as|--agent-slim)
         AGENT_FULL=0
-        echo "Using --agent-slim option is deprecated, please stop using it as it can be removed soon"
+        echo "Using --agent-slim option (this is the default option). Note: this option is not required"
         ;;
     -aws|--aws)
         AWS=1

--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -62,7 +62,7 @@ function help {
     echo "Usage: $(basename ${0}) -a | --access_key <value> [-t | --tags <value>] [-c | --collector <value>] \ "
     echo "                [-cp | --collector_port <value>] [-s | --secure <value>] [-cc | --check_certificate <value>] \ "
     echo "                [-ns | --namespace | --project <value>] [-ac | --additional_conf <value>] [-np | --no-prometheus] \ "
-    echo "                [-sn | --sysdig_instance_name <value>] [-op | --openshift] [-af | --agent-full] \ "
+    echo "                [-sn | --sysdig_instance_name <value>] [-op | --openshift] [-af | --agent-full] [-as | --agent-slim] \ "
     echo "                [-ia | --imageanalyzer ] [-am | --analysismanager <value>] [-ds | --dockersocket <value>] [-cs | --crisocket <value>] [-cv | --customvolume <value>] \ "
     echo "                [-av | --agent-version <value>] [ -r | --remove ] [ -aws | --aws ] [-h | --help]"
     echo ""
@@ -77,6 +77,7 @@ function help {
     echo " -np : if provided, do not enable the Prometheus collector.  Defaults to enabling Prometheus collector"
     echo " -sn : if provided, name of the sysdig instance (optional)"
     echo " -op : if provided, perform the installation using the OpenShift command line"
+    echo " -as : if provided, use agent-slim (this is the default agent). Note: this option is deprecated, please stop using it as it can be removed soon"
     echo " -af : if provided, use agent-full instead of agent-slim"
     echo " -r  : if provided, will remove the sysdig agent's daemonset, configmap, clusterrolebinding,"
     echo "       serviceacccount and secret from the specified namespace"
@@ -553,6 +554,10 @@ case ${key} in
         ;;
     -af|--agent-full)
         AGENT_FULL=1
+        ;;
+    -as|--agent-slim)
+        AGENT_FULL=0
+        echo "Using agent-slim option is deprecated, please stop using it as it can be removed soon"
         ;;
     -aws|--aws)
         AWS=1

--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -299,10 +299,12 @@ function install_k8s_agent {
       kubectl apply -f $IA_CONFIG_FILE --namespace=$NAMESPACE
     fi
 
-    if [ ! -z "$AGENT_FULL" ]; then
+    if [ $AGENT_FULL -eq 1 ]; then
+        echo "Full agent selected "
         DAEMONSET_FILE="/tmp/sysdig-agent-daemonset-v2.yaml"
         AGENT_STRING="agent"
     else
+        echo "Slim agent selected "
         DAEMONSET_FILE="/tmp/sysdig-kmod-thin-agent-slim-daemonset.yaml"
         AGENT_STRING="agent-slim"
     fi
@@ -450,6 +452,7 @@ OPENSHIFT=0
 INSTALL_ANALYZER=0
 AGENT_VERSION="latest"
 AWS=0
+AGENT_FULL=0
 
 while [[ ${#} > 0 ]]
 do
@@ -557,7 +560,7 @@ case ${key} in
         ;;
     -as|--agent-slim)
         AGENT_FULL=0
-        echo "Using agent-slim option is deprecated, please stop using it as it can be removed soon"
+        echo "Using --agent-slim option is deprecated, please stop using it as it can be removed soon"
         ;;
     -aws|--aws)
         AWS=1

--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -38,11 +38,8 @@ function download_yamls {
     curl -s -o /tmp/sysdig-agent-configmap.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-configmap.yaml
     echo "* Downloading Sysdig daemonset v2 yaml"
     curl -s -o /tmp/sysdig-agent-daemonset-v2.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
-    echo "* Downloading Sysdig agent-slim daemonset v2 yaml"
-    curl -s -o /tmp/sysdig-agent-slim-daemonset-v2.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
     echo "* Downloading Sysdig kmod-thin-agent-slim daemonset"
-    curl -s -o /tmp/sysdig-kmod-thin-agent-slim-daemonset.yaml.bak https://raw.githubusercontent.com/0snug0/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
-
+    curl -s -o /tmp/sysdig-kmod-thin-agent-slim-daemonset.yaml https://raw.githubusercontent.com/0snug0/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
     if [ $INSTALL_ANALYZER -eq 1 ]; then
       echo "* Downloading Sysdig Image Analyzer config map yaml"
       curl -H 'Cache-Control: no-cache' -s -o /tmp/sysdig-image-analyzer-configmap.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-image-analyzer-configmap.yaml
@@ -80,7 +77,7 @@ function help {
     echo " -np : if provided, do not enable the Prometheus collector.  Defaults to enabling Prometheus collector"
     echo " -sn : if provided, name of the sysdig instance (optional)"
     echo " -op : if provided, perform the installation using the OpenShift command line"
-    echo " -af : if provided, use agent-full install of slim-agent"
+    echo " -af : if provided, use agent-full instead of agent-slim"
     echo " -r  : if provided, will remove the sysdig agent's daemonset, configmap, clusterrolebinding,"
     echo "       serviceacccount and secret from the specified namespace"
     echo " -ia : if provided, will install the Node Image Analyzer"
@@ -301,12 +298,12 @@ function install_k8s_agent {
       kubectl apply -f $IA_CONFIG_FILE --namespace=$NAMESPACE
     fi
 
-    AGENT_STRING="agent"
     if [ ! -z "$AGENT_FULL" ]; then
         DAEMONSET_FILE="/tmp/sysdig-agent-daemonset-v2.yaml"
         AGENT_STRING="agent"
     else
         DAEMONSET_FILE="/tmp/sysdig-kmod-thin-agent-slim-daemonset.yaml"
+        AGENT_STRING="agent-slim"
     fi
 
     # -i.bak argument used for compatibility between mac (-i '') and linux (simply -i)

--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -39,7 +39,7 @@ function download_yamls {
     echo "* Downloading Sysdig daemonset v2 yaml"
     curl -s -o /tmp/sysdig-agent-daemonset-v2.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
     echo "* Downloading Sysdig kmod-thin-agent-slim daemonset"
-    curl -s -o /tmp/sysdig-kmod-thin-agent-slim-daemonset.yaml https://raw.githubusercontent.com/0snug0/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+    curl -s -o /tmp/sysdig-kmod-thin-agent-slim-daemonset.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
     if [ $INSTALL_ANALYZER -eq 1 ]; then
       echo "* Downloading Sysdig Image Analyzer config map yaml"
       curl -H 'Cache-Control: no-cache' -s -o /tmp/sysdig-image-analyzer-configmap.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-image-analyzer-configmap.yaml

--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -77,7 +77,7 @@ function help {
     echo " -np : if provided, do not enable the Prometheus collector.  Defaults to enabling Prometheus collector"
     echo " -sn : if provided, name of the sysdig instance (optional)"
     echo " -op : if provided, perform the installation using the OpenShift command line"
-    echo " -as : if provided, use agent-slim (this is the default agent). Note: this option is deprecated, please stop using it as it can be removed soon"
+    echo " -as : if provided, use agent-slim (this is the default agent). Note: this option is deprecated"
     echo " -af : if provided, use agent-full instead of agent-slim"
     echo " -r  : if provided, will remove the sysdig agent's daemonset, configmap, clusterrolebinding,"
     echo "       serviceacccount and secret from the specified namespace"

--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -40,6 +40,9 @@ function download_yamls {
     curl -s -o /tmp/sysdig-agent-daemonset-v2.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
     echo "* Downloading Sysdig agent-slim daemonset v2 yaml"
     curl -s -o /tmp/sysdig-agent-slim-daemonset-v2.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+    echo "* Downloading Sysdig kmod-thin-agent-slim daemonset"
+    curl -s -o /tmp/sysdig-kmod-thin-agent-slim-daemonset.yaml.bak https://raw.githubusercontent.com/0snug0/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+
     if [ $INSTALL_ANALYZER -eq 1 ]; then
       echo "* Downloading Sysdig Image Analyzer config map yaml"
       curl -H 'Cache-Control: no-cache' -s -o /tmp/sysdig-image-analyzer-configmap.yaml https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-image-analyzer-configmap.yaml
@@ -62,7 +65,7 @@ function help {
     echo "Usage: $(basename ${0}) -a | --access_key <value> [-t | --tags <value>] [-c | --collector <value>] \ "
     echo "                [-cp | --collector_port <value>] [-s | --secure <value>] [-cc | --check_certificate <value>] \ "
     echo "                [-ns | --namespace | --project <value>] [-ac | --additional_conf <value>] [-np | --no-prometheus] \ "
-    echo "                [-sn | --sysdig_instance_name <value>] [-op | --openshift] [-as | --agent-slim] \ "
+    echo "                [-sn | --sysdig_instance_name <value>] [-op | --openshift] [-af | --agent-full] \ "
     echo "                [-ia | --imageanalyzer ] [-am | --analysismanager <value>] [-ds | --dockersocket <value>] [-cs | --crisocket <value>] [-cv | --customvolume <value>] \ "
     echo "                [-av | --agent-version <value>] [ -r | --remove ] [ -aws | --aws ] [-h | --help]"
     echo ""
@@ -77,7 +80,7 @@ function help {
     echo " -np : if provided, do not enable the Prometheus collector.  Defaults to enabling Prometheus collector"
     echo " -sn : if provided, name of the sysdig instance (optional)"
     echo " -op : if provided, perform the installation using the OpenShift command line"
-    echo " -as : if provided, use agent-slim and agent-kmodule with the daemonset"
+    echo " -af : if provided, use agent-full install of slim-agent"
     echo " -r  : if provided, will remove the sysdig agent's daemonset, configmap, clusterrolebinding,"
     echo "       serviceacccount and secret from the specified namespace"
     echo " -ia : if provided, will install the Node Image Analyzer"
@@ -299,11 +302,11 @@ function install_k8s_agent {
     fi
 
     AGENT_STRING="agent"
-    if [ ! -z "$AGENT_SLIM" ]; then
-        DAEMONSET_FILE="/tmp/sysdig-agent-slim-daemonset-v2.yaml"
-        AGENT_STRING="agent-slim"
-    else
+    if [ ! -z "$AGENT_FULL" ]; then
         DAEMONSET_FILE="/tmp/sysdig-agent-daemonset-v2.yaml"
+        AGENT_STRING="agent"
+    else
+        DAEMONSET_FILE="/tmp/sysdig-kmod-thin-agent-slim-daemonset.yaml"
     fi
 
     # -i.bak argument used for compatibility between mac (-i '') and linux (simply -i)
@@ -551,8 +554,8 @@ case ${key} in
     -op|--openshift)
         OPENSHIFT=1
         ;;
-    -as|--agent-slim)
-        AGENT_SLIM=1
+    -af|--agent-full)
+        AGENT_FULL=1
         ;;
     -aws|--aws)
         AWS=1

--- a/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
@@ -70,6 +70,7 @@ spec:
             cpu: 1000m
             memory: 512Mi
           limits:
+            cpu: 1000m
             memory: 512Mi
         volumeMounts:
         - mountPath: /etc/modprobe.d

--- a/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
@@ -1,0 +1,134 @@
+### WARNING: this file is supported from Sysdig Agent 0.80.0
+# apiVersion: extensions/v1beta1  # If you are in Kubernetes version 1.8 or less please use this line instead of the following one
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sysdig-agent
+  labels:
+    app: sysdig-agent
+spec:
+  selector:
+    matchLabels:
+      app: sysdig-agent
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: sysdig-agent
+    spec:
+      volumes:
+      - name: modprobe-d
+        hostPath:
+          path: /etc/modprobe.d
+### uncomment for minikube
+#      - name: etc-version
+#        hostPath:
+#          path: /etc/VERSION
+#          type: FileOrCreate
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      - name: dev-vol
+        hostPath:
+          path: /dev
+      - name: proc-vol
+        hostPath:
+          path: /proc
+      - name: boot-vol
+        hostPath:
+          path: /boot
+      - name: modules-vol
+        hostPath:
+          path: /lib/modules
+      - name: usr-vol
+        hostPath:
+          path: /usr
+      - name: run-vol
+        hostPath:
+          path: /run
+      - name: varrun-vol
+        hostPath:
+          path: /var/run
+      - name: sysdig-agent-config
+        configMap:
+          name: sysdig-agent
+          optional: true
+      - name: sysdig-agent-secrets
+        secret:
+          secretName: sysdig-agent
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      # The following line is necessary for RBAC
+      serviceAccount: sysdig-agent
+      terminationGracePeriodSeconds: 5
+      initContainers:
+      - name: sysdig-agent-kmodule
+        image: quay.io/sysdig/agent-kmodule-thin
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 384Mi
+          limits:
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /etc/modprobe.d
+          name: modprobe-d
+          readOnly: true
+### uncomment for minikube
+#        - mountPath: /host/etc/VERSION
+#          name: etc-version
+#          readOnly: true
+        - mountPath: /host/boot
+          name: boot-vol
+          readOnly: true
+        - mountPath: /host/lib/modules
+          name: modules-vol
+          readOnly: true
+        - mountPath: /host/usr
+          name: usr-vol
+          readOnly: true
+      containers:
+      - name: sysdig-agent
+        # WARNING: the agent-slim release is currently dependent on the above
+        # initContainer and thus only functions correctly in a kubernetes cluster
+        image: quay.io/sysdig/agent-slim
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          # Resources needed are subjective to the actual workload.
+          # Please refer to Sysdig Support for more info.
+          requests:
+            cpu: 600m
+            memory: 512Mi
+          limits:
+            cpu: 2000m
+            memory: 1536Mi
+        readinessProbe:
+          exec:
+            command: [ "test", "-e", "/opt/draios/logs/running" ]
+          initialDelaySeconds: 10
+        volumeMounts:
+        - mountPath: /host/dev
+          name: dev-vol
+          readOnly: false
+        - mountPath: /host/proc
+          name: proc-vol
+          readOnly: true
+        - mountPath: /host/run
+          name: run-vol
+        - mountPath: /host/var/run
+          name: varrun-vol
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /opt/draios/etc/kubernetes/config
+          name: sysdig-agent-config
+        - mountPath: /opt/draios/etc/kubernetes/secrets
+          name: sysdig-agent-secrets

--- a/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
@@ -1,5 +1,4 @@
-### WARNING: this file is supported from Sysdig Agent 0.80.0
-# apiVersion: extensions/v1beta1  # If you are in Kubernetes version 1.8 or less please use this line instead of the following one
+### WARNING: this file is supported from Sysdig Agent 11.0.0
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -74,7 +73,7 @@ spec:
         resources:
           requests:
             cpu: 1000m
-            memory: 384Mi
+            memory: 512Mi
           limits:
             memory: 512Mi
         volumeMounts:
@@ -110,7 +109,7 @@ spec:
             memory: 512Mi
           limits:
             cpu: 2000m
-            memory: 1536Mi
+            memory: 3072Mi
         readinessProbe:
           exec:
             command: [ "test", "-e", "/opt/draios/logs/running" ]

--- a/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
@@ -20,11 +20,6 @@ spec:
       - name: modprobe-d
         hostPath:
           path: /etc/modprobe.d
-### uncomment for minikube
-#      - name: etc-version
-#        hostPath:
-#          path: /etc/VERSION
-#          type: FileOrCreate
       - name: dshm
         emptyDir:
           medium: Memory
@@ -80,10 +75,6 @@ spec:
         - mountPath: /etc/modprobe.d
           name: modprobe-d
           readOnly: true
-### uncomment for minikube
-#        - mountPath: /host/etc/VERSION
-#          name: etc-version
-#          readOnly: true
         - mountPath: /host/boot
           name: boot-vol
           readOnly: true


### PR DESCRIPTION
Daemonset and install agent script for IBM. Two possible options:
  - By default: kmodule thin + agent slim
  - Agent Full: Full agent

It's based on first step provided by @0snug0, and comments from his first PR  https://github.com/draios/sysdig-cloud-scripts/pull/147
