### PR TITLE
SSPROD-6639 Update Single Line Installer to use more generic Node Analyzer

### DIFF
--- a/agent_deploy/kubernetes/sysdig-benchmark-runner-configmap.yaml
+++ b/agent_deploy/kubernetes/sysdig-benchmark-runner-configmap.yaml
@@ -3,8 +3,6 @@ kind: ConfigMap
 metadata:
   name: sysdig-benchmark-runner
 data:
-  collector_endpoint: https://<API_ENDPOINT>:443
-  skip_tls: "true"
   debug: "false"
 
   # Optional:
@@ -14,3 +12,7 @@ data:
   # http_proxy: "http://proxy_server:8080"
   # https_proxy: "https://proxy_server:8080"
   # no_proxy: "127.0.0.1,localhost,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
+
+  # The endpoint to the Sysdig collector
+  # Required: yes
+  # collector_endpoint: https://<API_ENDPOINT>

--- a/agent_deploy/kubernetes/sysdig-benchmark-runner-configmap.yaml
+++ b/agent_deploy/kubernetes/sysdig-benchmark-runner-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sysdig-benchmark-runner
+data:
+  collector_endpoint: https://<API_ENDPOINT>:443
+  skip_tls: "true"
+  debug: "false"
+
+  # Optional:
+  # kubernetes_cluster_name: <Name of your cluster>
+
+  # Set and customize the following to enable proxy support
+  # http_proxy: "http://proxy_server:8080"
+  # https_proxy: "https://proxy_server:8080"
+  # no_proxy: "127.0.0.1,localhost,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"

--- a/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
@@ -215,7 +215,7 @@ spec:
               configMapKeyRef:
                 name: sysdig-benchmark-runner
                 key: collector_endpoint
-          - name: BACKEND_SKIP_TLS
+          - name: BACKEND_VERIFY_TLS
             valueFrom:
               configMapKeyRef:
                 name: sysdig-benchmark-runner

--- a/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
@@ -224,7 +224,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: sysdig-benchmark-runner
-                key: skip_tls
+                key: kubernetes_cluster_name
           - name: KUBERNETES_NODE_NAME
             valueFrom:
               fieldRef:

--- a/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
@@ -232,24 +232,24 @@ spec:
           - name: DEBUG
             valueFrom:
               configMapKeyRef:
-                name: sysdig-image-analyzer
+                name: sysdig-benchmark-runner
                 key: debug
                 optional: true
           - name: HTTP_PROXY
             valueFrom:
               configMapKeyRef:
                 key: http_proxy
-                name: sysdig-image-analyzer
+                name: sysdig-benchmark-runner
                 optional: true
           - name: HTTPS_PROXY
             valueFrom:
               configMapKeyRef:
                 key: https_proxy
-                name: sysdig-image-analyzer
+                name: sysdig-benchmark-runner
                 optional: true
           - name: NO_PROXY
             valueFrom:
               configMapKeyRef:
                 key: no_proxy
-                name: sysdig-image-analyzer
+                name: sysdig-benchmark-runner
                 optional: true

--- a/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
@@ -1,0 +1,255 @@
+# apiVersion: extensions/v1beta1  # If you are in Kubernetes version 1.8 or less please use this line instead of the following one
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sysdig-node-analyzer
+  labels:
+    app: sysdig-node-analyzer
+spec:
+  selector:
+    matchLabels:
+      app: sysdig-node-analyzer
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: sysdig-node-analyzer
+    spec:
+      volumes:
+      # Needed for cri-o image inspection.
+      # cri-o and especially OCP 4.x by default use containers/storage to handle images, and this makes sure that the
+      # analyzer has access to the configuration. This file is mounted read-only.
+      - name: etc-containers-storage-vol
+        hostPath:
+          path: /etc/containers/storage.conf
+      # Needed for cri-o image inspection.
+      # This is the directory where image data is stored by default when using cri-o and OCP 4.x and the analyzer
+      # uses it to get the data to scan. This directory must be mounted r/w because proper access to its files through
+      # the containers/storage library is always regulated with a lockfile.
+      - name: var-lib-containers-vol
+        hostPath:
+          path: /var/lib/containers
+      # Needed for socket access
+      - name: varrun-vol
+        hostPath:
+          path: /var/run
+      # Add custom volume here
+      - name: sysdig-image-analyzer-config
+        configMap:
+          name: sysdig-image-analyzer
+          optional: true
+      # Needed to run Benchmarks. This mount is read-only.
+      # Benchmarks include numerous checks that run tests against config files in the host filesystem. There are also
+      # checks that test various host configurations such as loaded modules and ebnabled security features.
+      - name: root-vol
+        hostPath:
+          path: /
+      # Needed to run Benchmarks. This mount is read-write.
+      # Benchmarks are executed on the host, and to do sothe benchmarking binaries are copied onto the host filesystem
+      # temporarily.
+      - name: tmp-vol
+        hostPath:
+          path: /tmp
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      # The following line is necessary for RBAC
+      serviceAccount: sysdig-agent
+      terminationGracePeriodSeconds: 5
+      # Use the Host Network Namespace.
+      # This is required by the Benchmark container to determine the hostname and host mac
+      hostNetwork: true
+      # Use the Host PID namespace.
+      # This is required for Kubernetes benchmarks, as they contain tests that check Kubernetes processes running on
+      # the host
+      hostPID: true
+      containers:
+      - name: sysdig-image-analyzer
+        image: quay.io/sysdig/node-image-analyzer
+        securityContext:
+          # The privileged flag is necessary for OCP 4.x and other Kubernetes setups that deny host filesystem access to
+          # running containers by default regardless of volume mounts. In those cases, access to the CRI socket would fail.
+          privileged: true
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1536Mi
+          requests:
+            cpu: 250m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /var/run
+          name: varrun-vol
+        - mountPath: /etc/containers/storage.conf
+          name: etc-containers-storage-vol
+          readOnly: true
+        - mountPath: /var/lib/containers
+          name: var-lib-containers-vol
+        # Add custom volume mount here
+        env:
+        - name: ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: sysdig-agent
+              key: access-key
+        - name: IMAGE_PERIOD
+          valueFrom:
+            configMapKeyRef:
+              name: sysdig-image-analyzer
+              key: image_period
+              optional: true
+        - name: IMAGE_CACHE_TTL
+          valueFrom:
+            configMapKeyRef:
+              name: sysdig-image-analyzer
+              key: image_cache_ttl
+              optional: true
+        - name: REPORT_PERIOD
+          valueFrom:
+            configMapKeyRef:
+              name: sysdig-image-analyzer
+              key: report_period
+              optional: true
+        - name: DOCKER_SOCKET_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: sysdig-image-analyzer
+              key: docker_socket_path
+              optional: true
+        - name: CRI_SOCKET_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: sysdig-image-analyzer
+              key: cri_socket_path
+              optional: true
+        - name: CONTAINERD_SOCKET_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: sysdig-image-analyzer
+              key: containerd_socket_path
+              optional: true
+        - name: AM_COLLECTOR_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: sysdig-image-analyzer
+              key: collector_endpoint
+              optional: true
+        - name: AM_COLLECTOR_TIMEOUT
+          valueFrom:
+            configMapKeyRef:
+              name: sysdig-image-analyzer
+              key: collector_timeout
+              optional: true
+        - name: VERIFY_CERTIFICATE
+          valueFrom:
+            configMapKeyRef:
+              name: sysdig-image-analyzer
+              key: ssl_verify_certificate
+              optional: true
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: DEBUG
+          valueFrom:
+            configMapKeyRef:
+              name: sysdig-image-analyzer
+              key: debug
+              optional: true
+        - name: HTTP_PROXY
+          valueFrom:
+            configMapKeyRef:
+              key: http_proxy
+              name: sysdig-image-analyzer
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            configMapKeyRef:
+              key: https_proxy
+              name: sysdig-image-analyzer
+              optional: true
+        - name: NO_PROXY
+          valueFrom:
+            configMapKeyRef:
+              key: no_proxy
+              name: sysdig-image-analyzer
+              optional: true
+      - name: sysdig-benchmark-runner
+        image: quay.io/sysdig/compliance-benchmark-runner
+        imagePullPolicy: Always
+        securityContext:
+          # The privileged flag is necessary for OCP 4.x and other Kubernetes setups that deny host filesystem access to
+          # running containers by default regardless of volume mounts. In those cases, the benchmark process would fail.
+          privileged: true
+        resources:
+          limits:
+            cpu: 500m
+            memory: 256Mi
+          requests:
+            cpu: 250m
+            memory: 128Mi
+        volumeMounts:
+          - mountPath: /host
+            name: root-vol
+            readOnly: true
+          - mountPath: /host/tmp
+            name: tmp-vol
+        env:
+          - name: ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: sysdig-agent
+                key: access-key
+          - name: BACKEND_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: sysdig-benchmark-runner
+                key: collector_endpoint
+          - name: BACKEND_SKIP_TLS
+            valueFrom:
+              configMapKeyRef:
+                name: sysdig-benchmark-runner
+                key: skip_tls
+          - name: KUBERNETES_CLUSTER_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: sysdig-benchmark-runner
+                key: skip_tls
+          - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: DEBUG
+            valueFrom:
+              configMapKeyRef:
+                name: sysdig-image-analyzer
+                key: debug
+                optional: true
+          - name: HTTP_PROXY
+            valueFrom:
+              configMapKeyRef:
+                key: http_proxy
+                name: sysdig-image-analyzer
+                optional: true
+          - name: HTTPS_PROXY
+            valueFrom:
+              configMapKeyRef:
+                key: https_proxy
+                name: sysdig-image-analyzer
+                optional: true
+          - name: NO_PROXY
+            valueFrom:
+              configMapKeyRef:
+                key: no_proxy
+                name: sysdig-image-analyzer
+                optional: true

--- a/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
@@ -41,7 +41,7 @@ spec:
           optional: true
       # Needed to run Benchmarks. This mount is read-only.
       # Benchmarks include numerous checks that run tests against config files in the host filesystem. There are also
-      # checks that test various host configurations such as loaded modules and ebnabled security features.
+      # checks that test various host configurations such as loaded modules and enabled security features.
       - name: root-vol
         hostPath:
           path: /
@@ -54,7 +54,7 @@ spec:
       serviceAccount: sysdig-agent
       terminationGracePeriodSeconds: 5
       # Use the Host Network Namespace.
-      # This is required by the Benchmark container to determine the hostname and host mac
+      # This is required by the Benchmark container to determine the hostname and host mac address
       hostNetwork: true
       # Use the Host PID namespace.
       # This is required for Kubernetes benchmarks, as they contain tests that check Kubernetes processes running on

--- a/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
@@ -45,12 +45,8 @@ spec:
       - name: root-vol
         hostPath:
           path: /
-      # Needed to run Benchmarks. This mount is read-write.
-      # Benchmarks are executed on the host, and to do sothe benchmarking binaries are copied onto the host filesystem
-      # temporarily.
       - name: tmp-vol
-        hostPath:
-          path: /tmp
+        emptyDir: {}
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master

--- a/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
@@ -219,12 +219,13 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: sysdig-benchmark-runner
-                key: skip_tls
+                key: ssl_verify_certificate
           - name: KUBERNETES_CLUSTER_NAME
             valueFrom:
               configMapKeyRef:
                 name: sysdig-benchmark-runner
                 key: kubernetes_cluster_name
+                optional: true
           - name: KUBERNETES_NODE_NAME
             valueFrom:
               fieldRef:


### PR DESCRIPTION
https://sysdig.atlassian.net/browse/SSPROD-6639

This PR adds a new `Node Analyser` daemonset to replace the existing `Node Image Analyzer`. This new daemonset contains the existing NIA container, as well as the new Benchmark Runner container. The sysdigcloud-image-analyzer-configmap is unchanged, and there is also an additional sysdigcloud-benchmark-runner-configmap applied as well. 

The single-line installer changes are in a PR here: https://github.com/draios/agent/pull/2481

Note: we will need to update the onboarding UI and the [documentation here](https://docs.sysdig.com/en/quick-install-sysdig-agent-on-kubernetes.html)

Please see https://sysdigcloud.slack.com/archives/C013QKAEQ2G/p1617211290072100 and https://sysdigcloud.slack.com/archives/C013QKAEQ2G/p1619085395165800 for more context