### PR TITLE
Adapt k8s audit scripts and files so it work in k8s versions higher than 1.18

### DIFF
--- a/k8s_audit_config/apiserver-config.patch.sh
+++ b/k8s_audit_config/apiserver-config.patch.sh
@@ -68,10 +68,12 @@ elif [ "${VARIANT}" == "minishift-3.11" ]; then
 elif [[ "${VARIANT}" == minikube* ]]; then
 
 	sudo mkdir -p /var/lib/k8s_audit
+	cp "${SCRIPTDIR}/webhook-config.yaml" /var/lib/k8s_audit/webhook-config.yaml
 	if [[ "${VARIANT}" == *1.12* ]]; then
-		cp "${SCRIPTDIR}/webhook-config.yaml" /var/lib/k8s_audit/webhook-config.yaml
+		cp "${SCRIPTDIR}/audit-policy.yaml" /var/lib/k8s_audit/audit-policy.yaml
+	else
+		cp "${SCRIPTDIR}/audit-policy-v2.yaml" /var/lib/k8s_audit/audit-policy.yaml
 	fi
-	cp "${SCRIPTDIR}/audit-policy.yaml" /var/lib/k8s_audit/audit-policy.yaml
 
 	APISERVER_PREFIX="    -"
 	APISERVER_LINE="- kube-apiserver"
@@ -92,14 +94,8 @@ elif [[ "${VARIANT}" == minikube* ]]; then
 			echo "$APISERVER_PREFIX --audit-policy-file=/var/lib/k8s_audit/audit-policy.yaml" >>"$TMPFILE"
 			echo "$APISERVER_PREFIX --audit-log-maxbackup=1" >>"$TMPFILE"
 			echo "$APISERVER_PREFIX --audit-log-maxsize=10" >>"$TMPFILE"
-			if [[ "${VARIANT}" == *1.13* ]]; then
-				echo "$APISERVER_PREFIX --audit-dynamic-configuration" >> "$TMPFILE"
-				echo "$APISERVER_PREFIX --feature-gates=DynamicAuditing=true" >> "$TMPFILE"
-				echo "$APISERVER_PREFIX --runtime-config=auditregistration.k8s.io/v1alpha1=true" >> "$TMPFILE"
-			else
-				echo "$APISERVER_PREFIX --audit-webhook-config-file=/var/lib/k8s_audit/webhook-config.yaml" >>"$TMPFILE"
-				echo "$APISERVER_PREFIX --audit-webhook-batch-max-wait=5s" >>"$TMPFILE"
-			fi
+			echo "$APISERVER_PREFIX --audit-webhook-config-file=/var/lib/k8s_audit/webhook-config.yaml" >>"$TMPFILE"
+			echo "$APISERVER_PREFIX --audit-webhook-batch-max-wait=5s" >>"$TMPFILE"
 			;;
 		*"volumeMounts:"*)
 			echo "    - mountPath: /var/lib/k8s_audit/" >>"$TMPFILE"
@@ -119,7 +115,7 @@ elif [[ "${VARIANT}" == minikube* ]]; then
 elif [[ "${VARIANT}" == "rke-1.13" ]]; then
 	echo "Copying audit-policy.yaml to /var/lib/k8s_audit/audit-policy.yaml"
 	sudo mkdir -p /var/lib/k8s_audit
-	cp "$SCRIPTDIR"/audit-policy.yaml /var/lib/k8s_audit/audit-policy.yaml
+	cp "$SCRIPTDIR"/audit-policy-v2.yaml /var/lib/k8s_audit/audit-policy.yaml
 	cp "$SCRIPTDIR"/webhook-config.yaml /var/lib/k8s_audit/webhook-config.yaml
 else
 	fatal "Unknown variant $VARIANT"

--- a/k8s_audit_config/audit-policy-v2.yaml
+++ b/k8s_audit_config/audit-policy-v2.yaml
@@ -1,4 +1,4 @@
-apiVersion: audit.k8s.io/v1beta1 # This is required.
+apiVersion: audit.k8s.io/v1 # This is required.
 kind: Policy
 # Don't generate audit events for all requests in RequestReceived stage.
 omitStages:

--- a/k8s_audit_config/audit-policy.yaml
+++ b/k8s_audit_config/audit-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: audit.k8s.io/v1beta1 # This is required.
+apiVersion: audit.k8s.io/v1 # This is required.
 kind: Policy
 # Don't generate audit events for all requests in RequestReceived stage.
 omitStages:

--- a/k8s_audit_config/enable-k8s-audit.sh
+++ b/k8s_audit_config/enable-k8s-audit.sh
@@ -149,7 +149,7 @@ $(cat webhook-config.yaml | sed -e 's/^/          /')
         path: /var/lib/k8s_audit/audit-policy.yaml
         roles: [Master]
         content: |
-$(cat audit-policy.yaml | sed -e 's/^/          /')
+$(cat audit-policy-v2.yaml | sed -e 's/^/          /')
     kubeAPIServer:
         auditLogPath: /var/lib/k8s_audit/audit.log
         auditLogMaxBackups: 1

--- a/k8s_audit_config/enable-k8s-audit.sh
+++ b/k8s_audit_config/enable-k8s-audit.sh
@@ -184,7 +184,7 @@ prepare_audit_sink_config
 echo "***Copying apiserver config patch script/supporting files to apiserver..."
 $SSH_CMD "rm -rf /tmp/enable_k8s_audit && mkdir -p /tmp/enable_k8s_audit"
 
-for f in apiserver-config.patch.sh audit-policy.yaml webhook-config.yaml; do
+for f in apiserver-config.patch.sh audit-policy.yaml audit-policy-v2.yaml webhook-config.yaml; do
     echo "   $f"
     copy_using_cmd "${COPY_CMD}" $f /tmp/enable_k8s_audit/$f
 done
@@ -242,16 +242,6 @@ elif [ "$VARIANT" == "openshift-3.11" ]; then
     echo "**Restarting API Server.."
     $SSH_CMD sudo /usr/local/bin/master-restart api
     $SSH_CMD sudo /usr/local/bin/master-restart controllers
-elif [[ "${VARIANT}" == "minikube-1.13" ]]; then
-    echo "Waiting for api server to restart..."
-    RC=1
-    while [ $RC -ne "0" ]; do
-        sleep 5
-        kubectl get nodes
-        RC=$?
-    done
-    echo "Creating dynamic audit sink..."
-    kubectl apply -f audit-sink.yaml
 elif [[ "${VARIANT}" == "rke-1.13" ]]; then
     echo "Modifying ${RKE_CLUSTER_YAML} to add audit policy/webhook configuration..."
     yq w "${RKE_CLUSTER_YAML}" services.kube-api.extra_args.audit-policy-file /var/lib/k8s_audit/audit-policy.yaml \


### PR DESCRIPTION
Things done here:
* Now minikube-1.13 variant uses webhook too as audit sink has been deprecated and removed
* For k8s versions higher than 1.12 we use a v2 audit_policy file with the proper api version that it's not deprecated, moved from v1beta1 to v1 
* For kops and rke we use v2 version so we don't support anymore k8s 1.11 and 1.12

I need to validate this changes yet in minikube and kops I will update the PR when all the checks has been done