### PR TITLE
Add agent configmap mount in benchmark-runner

### DIFF
--- a/agent_deploy/kubernetes/sysdig-benchmark-runner-configmap.yaml
+++ b/agent_deploy/kubernetes/sysdig-benchmark-runner-configmap.yaml
@@ -5,9 +5,6 @@ metadata:
 data:
   debug: "false"
 
-  # Optional:
-  # kubernetes_cluster_name: <Name of your cluster>
-
   # Set and customize the following to enable proxy support
   # http_proxy: "http://proxy_server:8080"
   # https_proxy: "https://proxy_server:8080"

--- a/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
@@ -17,6 +17,10 @@ spec:
         app: sysdig-node-analyzer
     spec:
       volumes:
+      - name: sysdig-agent-config
+        configMap:
+          name: sysdig-agent
+          optional: true
       # Needed for cri-o image inspection.
       # cri-o and especially OCP 4.x by default use containers/storage to handle images, and this makes sure that the
       # analyzer has access to the configuration. This file is mounted read-only.
@@ -195,6 +199,8 @@ spec:
             cpu: 250m
             memory: 128Mi
         volumeMounts:
+          - mountPath: /opt/draios/etc/kubernetes/config
+            name: sysdig-agent-config
           - mountPath: /host
             name: root-vol
             readOnly: true

--- a/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
@@ -222,12 +222,6 @@ spec:
               configMapKeyRef:
                 name: sysdig-benchmark-runner
                 key: ssl_verify_certificate
-          - name: KUBERNETES_CLUSTER_NAME
-            valueFrom:
-              configMapKeyRef:
-                name: sysdig-benchmark-runner
-                key: kubernetes_cluster_name
-                optional: true
           - name: KUBERNETES_NODE_NAME
             valueFrom:
               fieldRef:


### PR DESCRIPTION
In order to support agent tags, we mount the agent configmap in to the benchmark container. The benchmark container (and the NIA container) already relies on the agent secret, so this is not a completely new dependency

We also fetch the k8s cluster name to avoid having to specify it twice, causing confusion and drift.

Benchmarks runner is updated here: https://github.com/draios/secure-backend/pull/3177