### PR TITLE
add support elementary os hera install-agent-k8s.sh

### DIFF
--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -687,6 +687,14 @@ if [ -f /etc/debian_version ]; then
             fi
             ;;
 
+        "elementary")
+            if [ $VERSION -ge 5 ]; then
+                install_curl_deb
+            else
+                unsupported
+            fi
+            ;;
+
         "Debian")
             if [ $VERSION -ge 6 ]; then
                 install_curl_deb


### PR DESCRIPTION
i'm add fix for elementaryOS Hera.
previously i got error Unsupported operating system. Try using the manual installation instructions when install at ElementaryOS Hera 5.

Thankyou if you accept my pull request