### PR TITLE
Don't require TLS config in NA Benchmark config 

### DIFF
--- a/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
@@ -324,6 +324,7 @@ spec:
               configMapKeyRef:
                 name: sysdig-benchmark-runner
                 key: ssl_verify_certificate
+                optional: true
           - name: KUBERNETES_NODE_NAME
             valueFrom:
               fieldRef:


### PR DESCRIPTION
Verify_TLS is defaulted in the benchmark image, and does not need to be set in the configmap. Before this PR, not specifying `ssl_verify_certificate` in the benchmark configmap would cause a container config error