### PR TITLE
Add (commented out) eBPF support for agent-slim and sysdig-kmod-thin-agent-slim-daemonset

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -57,6 +57,10 @@ spec:
       - name: sysdig-agent-secrets
         secret:
           secretName: sysdig-agent
+      # This section is for eBPF support. Please refer to Sysdig Support before
+      # uncommenting, as eBPF is recommended for only a few configurations.
+      #- name: bpf-probes
+      #  emptyDir: {}
       hostNetwork: true
       hostPID: true
       tolerations:
@@ -77,6 +81,11 @@ spec:
             memory: 384Mi
           limits:
             memory: 512Mi
+        # This section is for eBPF support. Please refer to Sysdig Support before
+        # uncommenting, as eBPF is recommended for only a few configurations.
+        #env:
+        #  - name: SYSDIG_BPF_PROBE
+        #    value: ""
         volumeMounts:
         - mountPath: /etc/modprobe.d
           name: modprobe-d
@@ -94,6 +103,10 @@ spec:
         - mountPath: /host/usr
           name: usr-vol
           readOnly: true
+        # This section is for eBPF support. Please refer to Sysdig Support before
+        # uncommenting, as eBPF is recommended for only a few configurations.
+        #- mountPath: /root/.sysdig
+        #  name: bpf-probes
       containers:
       - name: sysdig-agent
         # WARNING: the agent-slim release is currently dependent on the above
@@ -115,6 +128,11 @@ spec:
           exec:
             command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
+        # This section is for eBPF support. Please refer to Sysdig Support before
+        # uncommenting, as eBPF is recommended for only a few configurations.
+        #env:
+        #  - name: SYSDIG_BPF_PROBE
+        #    value: ""
         volumeMounts:
         - mountPath: /host/dev
           name: dev-vol
@@ -132,3 +150,7 @@ spec:
           name: sysdig-agent-config
         - mountPath: /opt/draios/etc/kubernetes/secrets
           name: sysdig-agent-secrets
+        # This section is for eBPF support. Please refer to Sysdig Support before
+        # uncommenting, as eBPF is recommended for only a few configurations.
+        #- mountPath: /root/.sysdig
+        #  name: bpf-probes

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -61,6 +61,10 @@ spec:
       # uncommenting, as eBPF is recommended for only a few configurations.
       #- name: bpf-probes
       #  emptyDir: {}
+      #- name: osrel
+      #  hostPath:
+      #    path: /etc/os-release
+      #    type: FileOrCreate
       hostNetwork: true
       hostPID: true
       tolerations:
@@ -107,6 +111,9 @@ spec:
         # uncommenting, as eBPF is recommended for only a few configurations.
         #- mountPath: /root/.sysdig
         #  name: bpf-probes
+        #- mountPath: /host/etc/os-release
+        #  name: osrel
+        #  readOnly: true
       containers:
       - name: sysdig-agent
         # WARNING: the agent-slim release is currently dependent on the above

--- a/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
@@ -51,6 +51,14 @@ spec:
       - name: sysdig-agent-secrets
         secret:
           secretName: sysdig-agent
+      # This section is for eBPF support. Please refer to Sysdig Support before
+      # uncommenting, as eBPF is recommended for only a few configurations.
+      #- name: bpf-probes
+      #  emptyDir: {}
+      #- name: osrel
+      #  hostPath:
+      #    path: /etc/os-release
+      #    type: FileOrCreate
       hostNetwork: true
       hostPID: true
       tolerations:
@@ -72,6 +80,11 @@ spec:
           limits:
             cpu: 1000m
             memory: 512Mi
+        # This section is for eBPF support. Please refer to Sysdig Support before
+        # uncommenting, as eBPF is recommended for only a few configurations.
+        #env:
+        #  - name: SYSDIG_BPF_PROBE
+        #    value: ""
         volumeMounts:
         - mountPath: /etc/modprobe.d
           name: modprobe-d
@@ -85,6 +98,13 @@ spec:
         - mountPath: /host/usr
           name: usr-vol
           readOnly: true
+        # This section is for eBPF support. Please refer to Sysdig Support before
+        # uncommenting, as eBPF is recommended for only a few configurations.
+        #- mountPath: /root/.sysdig
+        #  name: bpf-probes
+        #- mountPath: /host/etc/os-release
+        #  name: osrel
+        #  readOnly: true
       containers:
       - name: sysdig-agent
         # WARNING: the agent-slim release is currently dependent on the above
@@ -106,6 +126,11 @@ spec:
           exec:
             command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
+        # This section is for eBPF support. Please refer to Sysdig Support before
+        # uncommenting, as eBPF is recommended for only a few configurations.
+        #env:
+        #  - name: SYSDIG_BPF_PROBE
+        #    value: ""
         volumeMounts:
         - mountPath: /host/dev
           name: dev-vol
@@ -123,3 +148,7 @@ spec:
           name: sysdig-agent-config
         - mountPath: /opt/draios/etc/kubernetes/secrets
           name: sysdig-agent-secrets
+        # This section is for eBPF support. Please refer to Sysdig Support before
+        # uncommenting, as eBPF is recommended for only a few configurations.
+        #- mountPath: /root/.sysdig
+        #  name: bpf-probes


### PR DESCRIPTION
This replaces https://github.com/draios/sysdig-cloud-scripts/pull/156 (needed to change branch name)