### PR TITLE
Node analyzer: use host base provided by daemonset for host analyzer

### DIFF
--- a/agent_deploy/kubernetes/sysdig-host-analyzer-configmap.yaml
+++ b/agent_deploy/kubernetes/sysdig-host-analyzer-configmap.yaml
@@ -21,5 +21,4 @@ data:
   
   # uncomment the following line to use a self-signed cert for backend communication
   # ssl_verify_certificate: "false"
-  host_base: "/host"
   dirs_to_scan: "/etc,/var/lib/dpkg,/usr/local,/usr/lib/sysimage/rpm,/var/lib/rpm,/lib/apk/db"

--- a/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
@@ -239,11 +239,7 @@ spec:
               key: analyze_at_startup
               optional: true
         - name: HOST_BASE
-          valueFrom:
-            configMapKeyRef:
-              name: sysdig-host-analyzer
-              key: host_base
-              optional: true
+          value: /host
         - name: DIRS_TO_SCAN
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Previously we let users configure which host base to use for host scanning. This is a bit confusing as the expected one is actually hard coded in the DS, so the configuration is not actually useable.
This needs to be translated in the Helm chart as well.