### PR TITLE
Use downwardAPI for propagating pod metadata into containers

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
@@ -50,6 +50,18 @@ spec:
       - name: varrun-vol
         hostPath:
           path: /var/run
+      - name: podinfo
+        downwardAPI:
+          defaultMode: 420
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+            path: name
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
@@ -127,3 +139,5 @@ spec:
           name: varrun-vol
         - mountPath: /dev/shm
           name: dshm
+        - mountPath: /etc/podinfo
+          name: podinfo

--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -67,6 +67,18 @@ spec:
       - name: sysdig-agent-secrets
         secret:
           secretName: sysdig-agent
+      - name: podinfo
+        downwardAPI:
+          defaultMode: 420
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+            path: name          
       # This section is for eBPF support. Please refer to Sysdig Support before
       # uncommenting, as eBPF is recommended for only a few configurations.
       #- name: sys-tracing
@@ -141,6 +153,8 @@ spec:
         - mountPath: /host/etc/os-release
           name: osrel
           readOnly: true
+        - mountPath: /etc/podinfo
+          name: podinfo          
 ### Uncomment these lines if you'd like to map /root/ from the
 #   host into the container. This can be useful to map
 #   /root/.sysdig to pick up custom kernel modules.

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
@@ -50,6 +50,18 @@ spec:
       - name: varrun-vol
         hostPath:
           path: /var/run
+      - name: podinfo
+        downwardAPI:
+          defaultMode: 420
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+            path: name
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
@@ -142,3 +154,5 @@ spec:
           name: varrun-vol
         - mountPath: /dev/shm
           name: dshm
+        - mountPath: /etc/podinfo
+          name: podinfo

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -57,6 +57,18 @@ spec:
       - name: sysdig-agent-secrets
         secret:
           secretName: sysdig-agent
+      - name: podinfo
+        downwardAPI:
+          defaultMode: 420
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+            path: name
       # This section is for eBPF support. Please refer to Sysdig Support before
       # uncommenting, as eBPF is recommended for only a few configurations.
       #- name: bpf-probes
@@ -164,6 +176,8 @@ spec:
           name: sysdig-agent-config
         - mountPath: /opt/draios/etc/kubernetes/secrets
           name: sysdig-agent-secrets
+        - mountPath: /etc/podinfo
+          name: podinfo
         # This section is for eBPF support. Please refer to Sysdig Support before
         # uncommenting, as eBPF is recommended for only a few configurations.
         #- mountPath: /root/.sysdig

--- a/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
+++ b/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
@@ -49,6 +49,18 @@ spec:
       - name: sysdig-agent-secrets
         secret:
           secretName: sysdig-agent
+      - name: podinfo
+        downwardAPI:
+          defaultMode: 420
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+            path: name
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
@@ -101,3 +113,5 @@ spec:
           name: sysdig-agent-config
         - mountPath: /opt/draios/etc/kubernetes/secrets
           name: sysdig-agent-secrets
+        - mountPath: /etc/podinfo
+          name: podinfo


### PR DESCRIPTION
Using the _downwardAPI_, the agent container will find some pod-level metadata, stored in files.
Namely, with this PR we are storing:

**pod namespace** in _/etc/podinfo/metadata/namespace_
**pod name** in _/etc/podinfo/metadata/name_