### PR TITLE
[QA-2735] Prevent the script from exiting if configmap "sysdigcloud-config" doesn't exist

### DIFF
--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -41,7 +41,7 @@ for object in svc deployment sts pvc daemonset ingress replicaset; do
     done
 done
 
-kubectl ${KUBE_OPTS} get configmap sysdigcloud-config -o yaml | grep -v password > ${LOG_DIR}/config.yaml
+kubectl ${KUBE_OPTS} get configmap sysdigcloud-config -o yaml | grep -v password > ${LOG_DIR}/config.yaml || true
 
 BUNDLE_NAME=$(date +%s)_sysdig_cloud_support_bundle.tgz
 tar czf ${BUNDLE_NAME} ${LOG_DIR}


### PR DESCRIPTION
When we use the get_support_bundle.sh script with the namespace sysdig-agent, there is no configmap called "sysdigcloud-config" and therefore when the command `kubectl ${KUBE_OPTS} get configmap sysdigcloud-config -o yaml | grep -v password > ${LOG_DIR}/config.yaml` is run the script exists without writing the tgz file

Adding just a || true this doesn't happen and the tgz file can be written