### PR TITLE
[SMAGENT-3049] Add new resources to ClusterRole to support collection of Kubelet metrics

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
@@ -14,6 +14,8 @@ rules:
   - limitranges
   - namespaces
   - nodes
+  - nodes/metrics
+  - nodes/proxy
   - resourcequotas
   - persistentvolumes
   - persistentvolumeclaims
@@ -60,3 +62,17 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
@@ -62,16 +62,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - watch
 - nonResourceURLs:
   - /metrics
   verbs:


### PR DESCRIPTION
We need to add permissions to the ClusterRole of the Sysdig Agent  to allow for collection of Kubelet metrics, specifically, Persistent Volume Claim metrics. 