### PR TITLE
[SMPROD-5326] Daemonset: Add dnsPolicy: ClusterFirstWithHostNet

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v1.yaml
@@ -51,6 +51,7 @@ spec:
         hostPath:
           path: /var/run
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       tolerations:
         - effect: NoSchedule

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v1.yaml
@@ -51,6 +51,7 @@ spec:
         hostPath:
           path: /var/run
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       tolerations:
         - effect: NoSchedule

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -66,6 +66,7 @@ spec:
       #    path: /etc/os-release
       #    type: FileOrCreate
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       tolerations:
         - effect: NoSchedule

--- a/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
@@ -60,6 +60,7 @@ spec:
       #    path: /etc/os-release
       #    type: FileOrCreate
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       tolerations:
         - effect: NoSchedule

--- a/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-node-analyzer-daemonset.yaml
@@ -64,6 +64,7 @@ spec:
       # Use the Host Network Namespace.
       # This is required by the Benchmark container to determine the hostname and host mac address
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       # Use the Host PID namespace.
       # This is required for Kubernetes benchmarks, as they contain tests that check Kubernetes processes running on
       # the host


### PR DESCRIPTION
Thanks to @ctolon22 to let us know that dnsPolicy is missed.

As explained in https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy, when using hostNetwork as we do, it is mandatory using ClusterFirstWithHostNet, while the default value is ClusterFirst. This misconfiguration produces problem when resolving Kubernetes Service Names 

This PR fixes all the daemonset with this issue

Tested (except for V1 daemonset that I don know how to use them) using a fresh k8s created with OSC https://sysdig-jenkins.internal.sysdig.com/view/QA/job/QA-onprem/job/stack-creator/3406/
Details of tests here https://docs.google.com/document/d/156bkBfqAsPyKlQU7jem-gDictbYm-L2GJAmQOWLXYpM/edit
