### PR TITLE
[SMAGENT-3114] Add /sys/kernel/debug VolumeMount when eBPF is in use

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -69,9 +69,8 @@ spec:
           secretName: sysdig-agent
       # This section is for eBPF support. Please refer to Sysdig Support before
       # uncommenting, as eBPF is recommended for only a few configurations.
-      #- name: bpf-probes
-      #  emptyDir: {}
       #- name: sys-tracing
+      #  hostPath:
       #    path: /sys/kernel/debug
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -149,9 +148,8 @@ spec:
         #  name: host-root-vol
         # This section is for eBPF support. Please refer to Sysdig Support before
         # uncommenting, as eBPF is recommended for only a few configurations.
-        #- mountPath: /root/.sysdig
-        #  name: bpf-probes
         #- mountPath: /sys/kernel/debug
         #  name: sys-tracing
+        #  readOnly: true
 
 

--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -54,12 +54,12 @@ spec:
       - name: varrun-vol
         hostPath:
           path: /var/run
-      # Uncomment these lines if you'd like to map /root/ from the
-      # host into the container. This can be useful to map
-      # /root/.sysdig to pick up custom kernel modules.
-      #- name: host-root-vol
-      #  hostPath:
-      #    path: /root
+### Uncomment these lines if you'd like to map /root/ from the
+#   host into the container. This can be useful to map
+#   /root/.sysdig to pick up custom kernel modules.
+#     - name: host-root-vol
+#       hostPath:
+#         path: /root
       - name: sysdig-agent-config
         configMap:
           name: sysdig-agent
@@ -141,11 +141,11 @@ spec:
         - mountPath: /host/etc/os-release
           name: osrel
           readOnly: true
-        # Uncomment these lines if you'd like to map /root/ from the
-        # host into the container. This can be useful to map
-        # /root/.sysdig to pick up custom kernel modules.
-        #- mountPath: /root
-        #  name: host-root-vol
+### Uncomment these lines if you'd like to map /root/ from the
+#   host into the container. This can be useful to map
+#   /root/.sysdig to pick up custom kernel modules.
+#       - mountPath: /root
+#         name: host-root-vol
         # This section is for eBPF support. Please refer to Sysdig Support before
         # uncommenting, as eBPF is recommended for only a few configurations.
         #- mountPath: /sys/kernel/debug

--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -67,6 +67,12 @@ spec:
       - name: sysdig-agent-secrets
         secret:
           secretName: sysdig-agent
+      # This section is for eBPF support. Please refer to Sysdig Support before
+      # uncommenting, as eBPF is recommended for only a few configurations.
+      #- name: bpf-probes
+      #  emptyDir: {}
+      #- name: sys-tracing
+      #    path: /sys/kernel/debug
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
@@ -141,3 +147,11 @@ spec:
         # /root/.sysdig to pick up custom kernel modules.
         #- mountPath: /root
         #  name: host-root-vol
+        # This section is for eBPF support. Please refer to Sysdig Support before
+        # uncommenting, as eBPF is recommended for only a few configurations.
+        #- mountPath: /root/.sysdig
+        #  name: bpf-probes
+        #- mountPath: /sys/kernel/debug
+        #  name: sys-tracing
+
+

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -65,6 +65,8 @@ spec:
       #  hostPath:
       #    path: /etc/os-release
       #    type: FileOrCreate
+      #- name: sys-tracing
+      #    path: /sys/kernel/debug
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
@@ -115,6 +117,8 @@ spec:
         #- mountPath: /host/etc/os-release
         #  name: osrel
         #  readOnly: true
+        #- mountPath: /sys/kernel/debug
+        #  name: sys-tracing
       containers:
       - name: sysdig-agent
         # WARNING: the agent-slim release is currently dependent on the above
@@ -162,3 +166,5 @@ spec:
         # uncommenting, as eBPF is recommended for only a few configurations.
         #- mountPath: /root/.sysdig
         #  name: bpf-probes
+        #- mountPath: /sys/kernel/debug
+        #  name: sys-tracing

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -66,6 +66,7 @@ spec:
       #    path: /etc/os-release
       #    type: FileOrCreate
       #- name: sys-tracing
+      #  hostPath:
       #    path: /sys/kernel/debug
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -119,6 +120,7 @@ spec:
         #  readOnly: true
         #- mountPath: /sys/kernel/debug
         #  name: sys-tracing
+        #  readOnly: true
       containers:
       - name: sysdig-agent
         # WARNING: the agent-slim release is currently dependent on the above
@@ -168,3 +170,4 @@ spec:
         #  name: bpf-probes
         #- mountPath: /sys/kernel/debug
         #  name: sys-tracing
+        #  readOnly: true

--- a/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
@@ -59,6 +59,8 @@ spec:
       #  hostPath:
       #    path: /etc/os-release
       #    type: FileOrCreate
+      #- name: sys-tracing
+      #    path: /sys/kernel/debug
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
@@ -106,6 +108,8 @@ spec:
         #- mountPath: /host/etc/os-release
         #  name: osrel
         #  readOnly: true
+        #- mountPath: /sys/kernel/debug
+        #  name: sys-tracing
       containers:
       - name: sysdig-agent
         # WARNING: the agent-slim release is currently dependent on the above
@@ -153,3 +157,5 @@ spec:
         # uncommenting, as eBPF is recommended for only a few configurations.
         #- mountPath: /root/.sysdig
         #  name: bpf-probes
+        #- mountPath: /sys/kernel/debug
+        #  name: sys-tracing

--- a/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
@@ -60,6 +60,7 @@ spec:
       #    path: /etc/os-release
       #    type: FileOrCreate
       #- name: sys-tracing
+      #  hostPath:
       #    path: /sys/kernel/debug
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -110,6 +111,7 @@ spec:
         #  readOnly: true
         #- mountPath: /sys/kernel/debug
         #  name: sys-tracing
+        #  readOnly: true
       containers:
       - name: sysdig-agent
         # WARNING: the agent-slim release is currently dependent on the above
@@ -159,3 +161,4 @@ spec:
         #  name: bpf-probes
         #- mountPath: /sys/kernel/debug
         #  name: sys-tracing
+        #  readOnly: true


### PR DESCRIPTION
Agent eBPF code requires access to the /sys/kernel/debug filesystem.
For certain kernel versions, this filesystem is not accessible by default
from within docker containers, so add a VolumeMount in the daemonset.