### PR TITLE
Add storageclasse resources in the agent clusterrole

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
@@ -68,3 +68,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/agent_deploy/openshift/sysdig-agent-clusterrole.yaml
+++ b/agent_deploy/openshift/sysdig-agent-clusterrole.yaml
@@ -68,3 +68,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
We are adding the `storageclass` resource in the agent clusterrole, so to agent is able to grap storageclasses' metrics
