### PR TITLE
Use sh if bash is not available when doing a docker exec

### DIFF
--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -29,7 +29,13 @@ for pod in ${SYSDIGCLOUD_PODS}; do
     containers=$(kubectl ${KUBE_OPTS} get pod ${pod} -o json | jq -r '.spec.containers[].name')
     for container in ${containers}; do
         kubectl ${KUBE_OPTS} logs ${pod} -c ${container} > ${LOG_DIR}/${pod}/${container}-kubectl-logs.txt
-        kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- bash -c "${command}" > ${LOG_DIR}/${pod}/${container}-support-files.tgz || true
+        if kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- bash -c "pwd" > /dev/null 2>&1; then
+            shell="bash"
+        else
+            echo "using sh instead of bash"
+            shell="sh"
+        fi
+        kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- ${shell} -c "${command}" > ${LOG_DIR}/${pod}/${container}-support-files.tgz || true
     done
 done
 


### PR DESCRIPTION
When trying to get some log files from the container if bash doesn't exist in the container the script show an error log  "command terminated with exit code 126" and it doesn't get those files.
With this change we check if bash exists and the script uses bash or sh according to the result of that check so that it can get the log files without error. 