### PR TITLE
Add leases support on OpenShift clusterrole

### DIFF
--- a/agent_deploy/openshift/sysdig-agent-clusterrole.yaml
+++ b/agent_deploy/openshift/sysdig-agent-clusterrole.yaml
@@ -68,3 +68,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - watch


### PR DESCRIPTION
This PR align OpenShift clusterole with Kubernetes' one. Leases were missing in Openshift