### PR TITLE
[SMAGENT-3306] Add imagePullSecret commented lines to agent daemonset

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -93,6 +93,10 @@ spec:
       # The following line is necessary for RBAC
       serviceAccount: sysdig-agent
       terminationGracePeriodSeconds: 5
+      ### Uncomment following 2 lines to pull images from a private registry,
+      ### replacing secret-name with your secret name (previously created)
+      #imagePullSecrets:
+      #- name: secret-name
       containers:
       - name: sysdig-agent
         image: quay.io/sysdig/agent

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -89,6 +89,10 @@ spec:
       # The following line is necessary for RBAC
       serviceAccount: sysdig-agent
       terminationGracePeriodSeconds: 5
+      ### Uncomment following 2 lines to pull images from a private registry,
+      ### replacing secret-name with your secret name (previously created)
+      #imagePullSecrets:
+      #- name: secret-name
       initContainers:
       - name: sysdig-agent-kmodule
         image: quay.io/sysdig/agent-kmodule

--- a/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
@@ -71,6 +71,10 @@ spec:
       # The following line is necessary for RBAC
       serviceAccount: sysdig-agent
       terminationGracePeriodSeconds: 5
+      ### Uncomment following 2 lines to pull images from a private registry,
+      ### replacing secret-name with your secret name (previously created)
+      #imagePullSecrets:
+      #- name: secret-name
       initContainers:
       - name: sysdig-agent-kmodule
         image: quay.io/sysdig/agent-kmodule-thin


### PR DESCRIPTION
To be able to use the agent from our artifactory (now it's in docker.io and so no imagePullSecret is needed), the agent daemonset (both regular and slim agent) has to be modified to include an imagePullSecret to enable to access to it.

This first PR is modifying the agent daemonsets, to include these parameter commented.
And a second PR will modify the install_agent_kubernetes, to be able to enable it.
