### PR TITLE
added k8s_coldstart/namespace to IKS config

### DIFF
--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -294,6 +294,10 @@ function install_k8s_agent {
     fi
 
     echo -e "    new_k8s: true" >> $CONFIG_FILE
+
+    echo -e "    k8s_coldstart:" >> $CONFIG_FILE
+    echo -e "        namespace: $NAMESPACE" >> $CONFIG_FILE
+
     kubectl apply -f $CONFIG_FILE --namespace=$NAMESPACE
 
     if [ $INSTALL_IMAGE_ANALYZER -eq 1 ] || [ $INSTALL_NODE_ANALYZER -eq 1 ]; then


### PR DESCRIPTION
I have noticed a problem a few weeks ago, which results in missing Kubernetes context labels in IBM Cloud Sysdig instances.

Here's what I do:
- create an IBM Cloud Monitoring instance
- create an IBM Cloud Kubernetes Service cluster
- install the monitoring agent on the cluster using the official installer URL (`https://ibm.biz/install-sysdig-k8s-agent` which points to `https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh`
- wait for labels + metrics to be picked up

Unfortunately the Kubernetes context labels are not getting picked up for a few days (5-6-7?), but after that those are suddenly populated and everything starts to work fine.

![image](https://user-images.githubusercontent.com/23562566/145841448-7aceb351-d7f9-444d-9a47-3e7f8536c6d5.png)

```
$ for x in `kubectl -n ibm-observe get pods | grep -i agent|awk '{print $1}'`; do echo $x; kubectl -n ibm-observe logs $x|grep -i "delegated node"; done
sysdig-agent-7wcpd
2021-11-17 19:31:38.156, 10234.10234, Information, dragent:configuration:1615: K8S delegated nodes: 2
2021-11-17 19:32:11.225, 10798.10798, Information, dragent:configuration:1615: K8S delegated nodes: 2
2021-11-17 19:33:54.254, 12628.12628, Information, dragent:configuration:1615: K8S delegated nodes: 2
sysdig-agent-xzxtr
(empty output)
```

---

I have opened an IBM Cloud support ticket, and IBM Cloud ACS opened a ticket for Sysdig. The engineering team suggested adding these configuration values to the ConfigMap which seems to do the trick:

```yaml
    k8s_coldstart:
        namespace: ibm-observe
```

(https://docs.sysdig.com/en/docs/installation/sysdig-agent/agent-installation/using-node-leases/)

With these configurations added to the ConfigMap, the agents instantly picks up Kubernetes context labels and reports them.

![image](https://user-images.githubusercontent.com/23562566/145842888-7ab23967-bf3d-4fe0-b857-bf93955bdd23.png)

```
for x in `kubectl -n ibm-observe get pods | grep -i agent|awk '{print $1}'`; do echo $x; kubectl -n ibm-observe logs $x|grep -i "delegated node"; done
sysdig-agent-cjvcw
(empty output)
sysdig-agent-vlqk7
2021-12-13 14:56:37.309, 3756.3756, Information, dragent:configuration:1615: K8S delegated nodes: 2
2021-12-13 14:56:52.416, 4022.4022, Information, dragent:configuration:1615: K8S delegated nodes: 2
2021-12-13 14:56:57.579, 4197.4197, Information, dragent:configuration:1615: K8S delegated nodes: 2
2021-12-13 14:57:05.668, 4197.4197, Information, analyzer:6457: k8s_deleg: delegated node kube-c6rkp6md0alf0fiv7o50-kubealbmoni-default-0000012d
(...)
```

