### PR TITLE
[SMAGENT-3336] Expose k8s node name to agent pods using downward API

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -117,9 +117,13 @@ spec:
           exec:
             command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
+        env:
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         # This section is for eBPF support. Please refer to Sysdig Support before
         # uncommenting, as eBPF is recommended for only a few configurations.
-        #env:
         #  - name: SYSDIG_BPF_PROBE
         #    value: ""
         volumeMounts:

--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -105,9 +105,13 @@ spec:
             memory: 384Mi
           limits:
             memory: 512Mi
+        env:
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         # This section is for eBPF support. Please refer to Sysdig Support before
         # uncommenting, as eBPF is recommended for only a few configurations.
-        #env:
         #  - name: SYSDIG_BPF_PROBE
         #    value: ""
         volumeMounts:

--- a/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
@@ -100,9 +100,13 @@ spec:
           limits:
             cpu: 1000m
             memory: 512Mi
+        env:
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         # This section is for eBPF support. Please refer to Sysdig Support before
         # uncommenting, as eBPF is recommended for only a few configurations.
-        #env:
         #  - name: SYSDIG_BPF_PROBE
         #    value: ""
         volumeMounts:

--- a/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
+++ b/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
@@ -86,6 +86,11 @@ spec:
           exec:
             command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
+        env:
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
         - mountPath: /etc/modprobe.d
           name: modprobe-d


### PR DESCRIPTION
This PR exposes the k8s node name to agent pods through an environment variable using [downward API](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/). This avoids the agent to run the node name discovery.