### PR TITLE
Add new resources to ClusterRole to support collection of Kubelet metrics

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-clusterrole.yaml
@@ -14,6 +14,8 @@ rules:
   - limitranges
   - namespaces
   - nodes
+  - nodes/metrics
+  - nodes/proxy
   - resourcequotas
   - persistentvolumes
   - persistentvolumeclaims
@@ -86,3 +88,7 @@ rules:
   - get
   - list
   - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get


### PR DESCRIPTION
We need to add permissions to the ClusterRole of the Sysdig Agent to allow for collection of Kubelet metrics, specifically, Persistent Volume Claim metrics