### PR TITLE
SMAGENT-3408 make whitespace consistent for container env

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-daemonset-v2.yaml
@@ -78,7 +78,7 @@ spec:
           - fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-            path: name          
+            path: name
       # This section is for eBPF support. Please refer to Sysdig Support before
       # uncommenting, as eBPF is recommended for only a few configurations.
       #- name: sys-tracing
@@ -118,10 +118,10 @@ spec:
             command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
         env:
-        - name: K8S_NODE
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
+          - name: K8S_NODE
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         # This section is for eBPF support. Please refer to Sysdig Support before
         # uncommenting, as eBPF is recommended for only a few configurations.
         #  - name: SYSDIG_BPF_PROBE
@@ -163,7 +163,7 @@ spec:
           name: osrel
           readOnly: true
         - mountPath: /etc/podinfo
-          name: podinfo          
+          name: podinfo
 ### Uncomment these lines if you'd like to map /root/ from the
 #   host into the container. This can be useful to map
 #   /root/.sysdig to pick up custom kernel modules.


### PR DESCRIPTION
Due to how the `install-agent-kubernetes` script uncomments lines, it expects an indented list item for the BPF env. Easiest fix seemed to be to also indent the downward api var to match.