### PR TITLE
SMAGENT-3408 make whitespace consistent for container env 

### DIFF
--- a/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
+++ b/agent_deploy/kubernetes/sysdig-agent-slim-daemonset-v2.yaml
@@ -106,10 +106,10 @@ spec:
           limits:
             memory: 512Mi
         env:
-        - name: K8S_NODE
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
+          - name: K8S_NODE
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         # This section is for eBPF support. Please refer to Sysdig Support before
         # uncommenting, as eBPF is recommended for only a few configurations.
         #  - name: SYSDIG_BPF_PROBE

--- a/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
+++ b/agent_deploy/kubernetes/sysdig-kmod-thin-agent-slim-daemonset.yaml
@@ -101,10 +101,10 @@ spec:
             cpu: 1000m
             memory: 512Mi
         env:
-        - name: K8S_NODE
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
+          - name: K8S_NODE
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         # This section is for eBPF support. Please refer to Sysdig Support before
         # uncommenting, as eBPF is recommended for only a few configurations.
         #  - name: SYSDIG_BPF_PROBE

--- a/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
+++ b/agent_deploy/openshift/sysdig-agent-daemonset-redhat-openshift.yaml
@@ -87,10 +87,10 @@ spec:
             command: [ "test", "-e", "/opt/draios/logs/running" ]
           initialDelaySeconds: 10
         env:
-        - name: K8S_NODE
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
+          - name: K8S_NODE
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         volumeMounts:
         - mountPath: /etc/modprobe.d
           name: modprobe-d


### PR DESCRIPTION
Updates `sysdig-agent-slim-daemonset-v2.yaml`, `sysdig-kmod-thin-agent-slim-daemonset.yaml`, and `sysdig-agent-daemonset-redhat-openshift.yaml`, though I am reasonably certain that last one isn't used by the install script.