### PR TITLE
[QA-3764] Add flags to change the registry and image used in the agent

### DIFF
--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -75,6 +75,7 @@ function help {
     echo "                [-cp | --collector_port <value>] [-s | --secure <value>] [-cc | --check_certificate <value>] \ "
     echo "                [-ns | --namespace | --project <value>] [-ac | --additional_conf <value>] [-np | --no-prometheus] \ "
     echo "                [-sn | --sysdig_instance_name <value>] [-op | --openshift] [-af | --agent-full] [-as | --agent-slim] \ "
+    echo "                [-ar | --agent_registry] [-arr | --agent_repository] [-asr | --agent_slim_repository] [-akr | --agent_kmod_repository] \ "
     echo "                [-ae | --api_endpoint <value> ] [-na | --nodeanalyzer ] \ "
     echo "                [-ia | --imageanalyzer ] [-am | --analysismanager <value>] [-ds | --dockersocket <value>] [-cs | --crisocket <value>] [-cv | --customvolume <value>] \ "
     echo "                [-av | --agent-version <value>] [ -r | --remove ] [ -aws | --aws ] [-h | --help]"
@@ -94,6 +95,10 @@ function help {
     echo " -as : if provided, use agent-slim (this is the default agent). Note: this option is not required"
     echo " -af : if provided, use agent-full instead of agent-slim"
     echo " -ac : if provided, the additional configuration will be appended to agent configuration file"
+	echo " -ar : if provided, the registry for the agent images (default: icr.io)"
+	echo " -arr : if provided, the repository for the agent image (default: ext/sysdig/agent)"
+	echo " -asr : if provided, the repository for the agent-slim image (default: ext/sysdig/agent-slim)"
+	echo " -akr : if provided, the repository for the agent-kmodule image (default: ext/sysdig/agent-kmodule)"
     echo " -av : if provided, use the agent-version specified. (default: latest)"
     echo " -r  : if provided, will remove the sysdig agent's daemonset, configmap, clusterrolebinding,"
     echo "       serviceacccount and secret from the specified namespace"
@@ -374,13 +379,9 @@ function install_k8s_agent {
     if [ $AGENT_FULL -eq 1 ]; then
         echo "Full agent selected "
         DAEMONSET_FILE="$WORKDIR/sysdig-agent-daemonset-v2.yaml"
-        AGENT_STRING="agent"
-        AGENT_NAMES="agent"
     else
         echo "Slim agent selected "
         DAEMONSET_FILE="$WORKDIR/sysdig-kmod-thin-agent-slim-daemonset.yaml"
-        AGENT_STRING="agent-slim"
-        AGENT_NAMES="agent-slim agent-kmodule"
     fi
 
     # -i.bak argument used for compatibility between mac (-i '') and linux (simply -i)
@@ -388,10 +389,8 @@ function install_k8s_agent {
 
     # For IBM use IBM Cloud Container Registry
     if [ $AWS -eq 0 ]; then
-        for agent_name in ${AGENT_NAMES}; do
-            # Use IBM Cloud Container Registry instead of docker.io or quay.io
-            sed -i.bak -e "s|\( *image: \).*sysdig/${agent_name}\(.*\)|\1icr.io/ext/sysdig/${agent_name}:${AGENT_VERSION}|g" $DAEMONSET_FILE
-        done
+        sed -i.bak -e "s|\( *image: \).*sysdig/agent-slim\(.*\)|\1${REGISTRY}/${AGENT_SLIM_REPOSITORY}:${AGENT_VERSION}|g" $DAEMONSET_FILE \
+        -e "s|\( *image: \).*sysdig/agent-kmodule\(.*\)|\1${REGISTRY}/${AGENT_KMOD_REPOSITORY}:${AGENT_VERSION}|g" $DAEMONSET_FILE
 
         ICR_SECRET_EXIST=$(kubectl -n default get secret -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -qE "default-icr-io|all-icr-io" || echo 1)
         if [ "$ICR_SECRET_EXIST" = 1 ]; then
@@ -428,10 +427,7 @@ function install_k8s_agent {
             echo "${INDENT}- name: $SECRET_NAME" >> $DAEMONSET_FILE
         done
     else
-        for agent_name in ${AGENT_NAMES}; do
-            # Don't use IBM Cloud Container Registry when not running in IBM. Force quay.io and append the version
-            sed -i.bak -e "s|\( *image: \).*sysdig/${agent_name}\(.*\)|\1quay.io/sysdig/${agent_name}:${AGENT_VERSION}|g" $DAEMONSET_FILE
-        done
+        sed -i.bak -e "s|\( *image: \).*sysdig/agent\(.*\)|\1${REGISTRY}/${AGENT_REPOSITORY}:${AGENT_VERSION}|g" $DAEMONSET_FILE 
     fi
 
     # Add label for Sysdig instance
@@ -577,6 +573,10 @@ ENABLE_PROMETHEUS=1
 OPENSHIFT=0
 INSTALL_IMAGE_ANALYZER=0
 INSTALL_NODE_ANALYZER=0
+REGISTRY="icr.io"
+AGENT_REPOSITORY="ext/sysdig/agent"
+AGENT_SLIM_REPOSITORY="ext/sysdig/agent-slim"
+AGENT_KMOD_REPOSITORY="ext/sysdig/agent-kmodule"
 AGENT_VERSION="latest"
 AWS=0
 AGENT_FULL=0
@@ -668,6 +668,42 @@ case ${key} in
             SYSDIG_INSTANCE_NAME="${2}"
         else
             echo "ERROR: no value provided for sysdig instance name use -h | --help for $(basename ${0}) Usage"
+            exit 1
+        fi
+        shift
+        ;;
+    -ar|--agent_registry)
+        if is_valid_value "${2}"; then
+            REGISTRY="${2}"
+        else
+            echo "ERROR: no value provided for agent registry option, use -h | --help for $(basename ${0}) Usage"
+            exit 1
+        fi
+        shift
+        ;;
+    -arr|--agent_repository)
+        if is_valid_value "${2}"; then
+            AGENT_REPOSITORY="${2}"
+        else
+            echo "ERROR: no value provided for agent repository option, use -h | --help for $(basename ${0}) Usage"
+            exit 1
+        fi
+        shift
+        ;;
+    -asr|--agent_slim_repository)
+        if is_valid_value "${2}"; then
+            AGENT_SLIM_REPOSITORY="${2}"
+        else
+            echo "ERROR: no value provided for agent slim repository option, use -h | --help for $(basename ${0}) Usage"
+            exit 1
+        fi
+        shift
+        ;;
+    -akr|--agent_kmod_repository)
+        if is_valid_value "${2}"; then
+            AGENT_KMOD_REPOSITORY="${2}"
+        else
+            echo "ERROR: no value provided for agent kmodule repository option, use -h | --help for $(basename ${0}) Usage"
             exit 1
         fi
         shift


### PR DESCRIPTION
As with #189 , porting https://github.com/draios/agent/pull/2727 to allow a complete specification of the agent image, allowing
any agent image installation, maintaining the same defaults as before:
-  -ar : if provided, the registry for the agent images (default: icr.io)
- -arr : if provided, the repository for the agent image (default: ext/sysdig/agent)
- -asr : if provided, the repository for the agent-slim image (default: ext/sysdig/agent-slim)
- -akr : if provided, the repository for the agent-kmodule image (default: ext/sysdig/agent-kmodule)