### PR TITLE
update support bundle to include new data gathering

### DIFF
--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -211,7 +211,6 @@ do
 done
 
 echo "Fetching Elasticsearch health info"
-mkdir -p ${LOG_DIR}/elasticsearch
 # CHECK HERE IF THE TLS ENV VARIABLE IS SET IN ELASTICSEARCH, AND BUILD THE CURL COMMAND OUT
 ELASTIC_POD=$(kubectl ${KUBE_OPTS} get po -l role=elasticsearch --no-headers | head -1 | awk '{print $1}')
 ELASTIC_TLS=$(kubectl ${KUBE_OPTS} exec -it ${ELASTIC_POD} -- env | grep -i ELASTICSEARCH_TLS_ENCRYPTION)
@@ -229,7 +228,7 @@ do
     kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/health" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_health.log
 
     printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/elasticsearch_indices.log
-    kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/indices" | tee -a ${LOG_DIR}/elasticsearch//${pod}/elasticsearch_indices.log
+    kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/indices" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_indices.log
 
     printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/elasticsearch_nodes.log
     kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/nodes?v" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_nodes.log

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -91,7 +91,7 @@ segment_by="${2}"
           --header 'X-Sysdig-Product: SDC'
           --header "Authorization: Bearer ${API_KEY}"
           --header 'Content-Type: application/json'
-          --data-raw "{\"requests\":[{\"format\":{\"type\":\"data\"},\"time\":{\"from\":${FROM_EPOCH_TIME}000000,\"to\":${TO_EPOCH_TIME}000000,\"sampling\":600000000},\"metrics\":{\"v0\":\"${metric}\",\"k0\":\"timestamp\",\"k1\":\"${segment_by}\"},\"group\":{\"aggregations\":{\"v0\":\"avg\"},\"groupAggregations\":{\"v0\":\"avg\"},\"by\":[{\"metric\":\"k0\",\"value\":600000000},{\"metric\":\"k1\"}],\"configuration\":{\"groups\":[{\"groupBy\":[]}]}},\"paging\":{\"from\":0,\"to\":9},\"sort\":[{\"v0\":\"desc\"}],\"scope\":null,\"compareTo\":null}]}'"
+          -d "{\"requests\":[{\"format\":{\"type\":\"data\"},\"time\":{\"from\":${FROM_EPOCH_TIME}000000,\"to\":${TO_EPOCH_TIME}000000,\"sampling\":600000000},\"metrics\":{\"v0\":\"${metric}\",\"k0\":\"timestamp\",\"k1\":\"${segment_by}\"},\"group\":{\"aggregations\":{\"v0\":\"avg\"},\"groupAggregations\":{\"v0\":\"avg\"},\"by\":[{\"metric\":\"k0\",\"value\":600000000},{\"metric\":\"k1\"}],\"configuration\":{\"groups\":[{\"groupBy\":[]}]}},\"paging\":{\"from\":0,\"to\":9},\"sort\":[{\"v0\":\"desc\"}],\"scope\":null,\"compareTo\":null}]}'"
         )
         curl "${PARAMS[@]}" >${LOG_DIR}/metrics/${metric}_${segment_by}.json
 }

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
+trap 'catch' ERR
+catch() {
+  echo "An error has occurred. Please check your input and try again. Run this script with the -d flag for debugging"
+}
+
+gnudate() {
+    if hash gdate 2>/dev/null; then
+        gdate "$@"
+    else
+        date "$@"
+    fi
+}
+
 #generate sysdigcloud support bundle on kubernetes
 
 LABELS=""
@@ -8,8 +21,12 @@ CONTEXT=""
 CONTEXT_OPTS=""
 NAMESPACE=""
 LOG_DIR=$(mktemp -d sysdigcloud-support-bundle-XXXX)
+SINCE_OPTS="" 
+SINCE=""
+API_KEY=""
+ELASTIC_CURL=""
 
-while getopts l:n:c:hced flag; do
+while getopts l:n:c:s:a:hced flag; do
     case "${flag}" in
         l) LABELS=${OPTARG:-};;
         n) NAMESPACE=${OPTARG:-};;
@@ -18,22 +35,34 @@ while getopts l:n:c:hced flag; do
             echo "Usage: ./get_support_bundle.sh -n <NAMESPACE> -l <LABELS>"; 
             echo "Example: ./get_support_bundle.sh -n sysdig -l api,collector,worker,cassandra,elasticsearch"; 
             echo "Flags:"; 
+            echo "-a  Provide the Superuser API key for advanced data collection"
+            echo "-c  Specify the kubectl context. If not set, the current context will be used.";
+            echo "-d  Run the script in debug mode (use this if you encounter a problem).";
             echo "-n  Specify the Sysdig namespace. If not specified, "sysdigcloud" is assumed."; 
-            echo "-c  Specify the kubectl context. If not set, the current context will be used."; 
             echo "-l  Specify Sysdig pod role label to collect (e.g. api,collector,worker)";
             echo "-h  Print these instructions";
+            echo "-s  Specify the timeframe of logs to collect (e.g. -s 1h)"
             exit;;
 
         c) CONTEXT=${OPTARG:-};;
+        s) SINCE=${OPTARG:-};;
+        a) API_KEY=${OPTARG:-};;
+        d) set -x;;
+
     esac
 done
 
+# Check for supplied namespace, kube context, and flags
 if [[ -z ${NAMESPACE} ]]; then
     NAMESPACE="sysdig"
 fi
 
 if [[ ! -z ${CONTEXT} ]]; then
     CONTEXT_OPTS="--context=${CONTEXT}"
+fi
+
+if [[ ! -z ${SINCE} ]]; then
+    SINCE_OPTS="--since ${SINCE}"
 fi
 
 # Set options for kubectl commands
@@ -47,6 +76,53 @@ if [[ "$(echo "$KUBE_OUTPUT" | grep -o "^sysdig " || true)" != "${NAMESPACE} " ]
     echo "We could not determine the namespace. Please check the spelling and try again";
     echo "kubectl ${KUBE_OPTS} get ns";
     echo "$(kubectl ${KUBE_OPTS} get ns)";
+fi
+
+get_metrics() {
+# function used to get metric JSON data for particular metrics we are interested in from the agent
+# arguments:
+# 1 - metric_name
+# 2 - segment_by
+metric="${1}"
+segment_by="${2}"
+
+        PARAMS=(
+          -sk --location --request POST "${API_URL}/api/data/batch?metricCompatibilityValidation=true&emptyValuesAsNull=true"
+          --header 'X-Sysdig-Product: SDC'
+          --header "Authorization: Bearer ${API_KEY}"
+          --header 'Content-Type: application/json'
+          --data-raw "{\"requests\":[{\"format\":{\"type\":\"data\"},\"time\":{\"from\":${FROM_EPOCH_TIME}000000,\"to\":${TO_EPOCH_TIME}000000,\"sampling\":600000000},\"metrics\":{\"v0\":\"${metric}\",\"k0\":\"timestamp\",\"k1\":\"${segment_by}\"},\"group\":{\"aggregations\":{\"v0\":\"avg\"},\"groupAggregations\":{\"v0\":\"avg\"},\"by\":[{\"metric\":\"k0\",\"value\":600000000},{\"metric\":\"k1\"}],\"configuration\":{\"groups\":[{\"groupBy\":[]}]}},\"paging\":{\"from\":0,\"to\":9},\"sort\":[{\"v0\":\"desc\"}],\"scope\":null,\"compareTo\":null}]}'"
+        )
+        curl "${PARAMS[@]}" >${LOG_DIR}/metrics/${metric}_${segment_by}.json
+}
+
+# If API key is supplied, collect streamSnap, Index settings, and fastPath settings
+if [[ ! -z ${API_KEY} ]]; then
+    API_URL=$(kubectl ${KUBE_OPTS} get cm sysdigcloud-config -o yaml | grep -i api.url: | head -1 | awk '{print$2}')
+    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/streamsnapSettings" >> ${LOG_DIR}/streamSnap_settings.json
+    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/fastPathSettings" >> ${LOG_DIR}/fastPath_settings.json
+    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/indexSettings" >> ${LOG_DIR}/index_settings.json
+    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/planSettings" >> ${LOG_DIR}/plan_settings.json
+    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/dataRetentionSettings" >> ${LOG_DIR}/dataRetention_settings.json
+    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/agents/connected" >> ${LOG_DIR}/agents-connected.json
+
+    TO_EPOCH_TIME=$(gnudate -d "$(gnudate +%H):00:00" +%s)
+    FROM_EPOCH_TIME=$((TO_EPOCH_TIME-86400))
+    METRICS=("syscall.count" "dragent.analyzer.sr" "container.count" "dragent.analyzer.n_drops_buffer" "dragent.analyzer.n_evts")
+    DEFAULT_SEGMENT="host.hostName"
+    SYSCALL_SEGMENTS=("host.hostName" "proc.name")
+
+    mkdir -p ${LOG_DIR}/metrics
+    for metric in ${METRICS[@]}; do
+        if [ "${metric}" == "syscall.count" ]; then
+            for segment in ${SYSCALL_SEGMENTS[@]}; do
+                get_metrics "${metric}" "${segment}"
+            done
+        else
+            get_metrics "${metric}" "${DEFAULT_SEGMENT}"
+        fi
+    done
+
 fi
 
 # Configure kubectl command if labels are set
@@ -69,8 +145,17 @@ do
     containers=$(kubectl ${KUBE_OPTS} get pod ${pod} -o json | jq -r '.spec.containers[].name')
     for container in ${containers}; 
     do
-        kubectl ${KUBE_OPTS} logs ${pod} -c ${container} > ${LOG_DIR}/${pod}/${container}-kubectl-logs.txt
-        kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- bash -c "${command}" > ${LOG_DIR}/${pod}/${container}-support-files.tgz || true
+        kubectl ${KUBE_OPTS} logs ${pod} -c ${container} ${SINCE_OPTS} > ${LOG_DIR}/${pod}/${container}-kubectl-logs.txt
+        echo "Execing into ${container}"
+        kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- bash >/dev/null 2>&1 && RETVAL=$? || RETVAL=$? && true
+        kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- sh >/dev/null 2>&1 && RETVAL1=$? || RETVAL1=$? && true
+        if [ $RETVAL -eq 0 ]; then
+            kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- bash -c "${command}" > ${LOG_DIR}/${pod}/${container}-support-files.tgz || true
+        elif [ $RETVAL1 -eq 0 ]; then
+            kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- sh -c "${command}" > ${LOG_DIR}/${pod}/${container}-support-files.tgz || true
+        else
+            echo "Skipping log gathering for ${pod}"
+        fi
     done
 done
 
@@ -112,36 +197,89 @@ printf "Containers: ${num_total_containers}\n" >> ${LOG_DIR}/container_density.t
 
 # Fetch Cassandra Nodetool output
 echo "Fetching Cassandra statistics";
-mkdir -p ${LOG_DIR}/cassandra
 for pod in $(kubectl ${KUBE_OPTS} get pod -l role=cassandra | grep -v "NAME" | awk '{print $1}')
 do
-    printf "$pod\t" |tee -a ${LOG_DIR}/cassandra/nodetool_info.log
-    kubectl ${KUBE_OPTS} exec -it $pod -c cassandra -- nodetool info >> ${LOG_DIR}/cassandra/nodetool_info.log
-    kubectl ${KUBE_OPTS} exec -it $pod -c cassandra -- nodetool status | tee -a ${LOG_DIR}/cassandra/nodetool_status.log
-    kubectl ${KUBE_OPTS} exec -it $pod -c cassandra -- nodetool getcompactionthroughput | tee -a ${LOG_DIR}/cassandra/nodetool_getcompactionthroughput.log
-    kubectl ${KUBE_OPTS} exec -it $pod -c cassandra -- nodetool cfstats | tee -a ${LOG_DIR}/cassandra/nodetool_cfstats.log
-    kubectl ${KUBE_OPTS} exec -it $pod -c cassandra -- nodetool cfhistograms draios message_data10 | tee -a ${LOG_DIR}/cassandra/nodetool_cfhistograms.log
-    kubectl ${KUBE_OPTS} exec -it $pod -c cassandra -- nodetool proxyhistograms | tee -a ${LOG_DIR}/cassandra/nodetool_proxyhistograms.log
-    kubectl ${KUBE_OPTS} exec -it $pod -c cassandra -- nodetool tpstats | tee -a ${LOG_DIR}/cassandra/nodetool_tpstats.log
-    kubectl ${KUBE_OPTS} exec -it $pod -c cassandra -- nodetool compactionstats | tee -a ${LOG_DIR}/cassandra/nodetool_compactionstats.log
+    mkdir -p ${LOG_DIR}/cassandra/${pod}
+    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool info | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_info.log
+    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool status | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_status.log
+    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool getcompactionthroughput | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_getcompactionthroughput.log
+    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool cfstats | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_cfstats.log
+    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool cfhistograms draios message_data10 | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_cfhistograms.log
+    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool proxyhistograms | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_proxyhistograms.log
+    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool tpstats | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_tpstats.log
+    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool compactionstats | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_compactionstats.log
 done
 
-# Fetch Elasticsearch storage info
+echo "Fetching Elasticsearch health info"
 mkdir -p ${LOG_DIR}/elasticsearch
-printf "Pod#\tFilesystem\tSize\tUsed\tAvail\tUse\tMounted on\n" |tee -a ${LOG_DIR}/elasticsearch/elasticsearch_storage.log
+# CHECK HERE IF THE TLS ENV VARIABLE IS SET IN ELASTICSEARCH, AND BUILD THE CURL COMMAND OUT
+ELASTIC_POD=$(kubectl ${KUBE_OPTS} get po -l role=elasticsearch --no-headers | head -1 | awk '{print $1}')
+ELASTIC_TLS=$(kubectl ${KUBE_OPTS} exec -it ${ELASTIC_POD} -- env | grep -i ELASTICSEARCH_TLS_ENCRYPTION)
+
+if [[ ${ELASTIC_TLS} == *"ELASTICSEARCH_TLS_ENCRYPTION=true"* ]]; then
+    ELASTIC_CURL='curl -s --cacert /usr/share/elasticsearch/config/root-ca.pem https://${ELASTICSEARCH_ADMINUSER}:${ELASTICSEARCH_ADMIN_PASSWORD}'
+else
+    ELASTIC_CURL='curl -s -k http://$(hostname)'
+fi
+
 for pod in $(kubectl ${KUBE_OPTS} get pods -l role=elasticsearch | grep -v "NAME" | awk '{print $1}')
 do
-    printf "$pod\t" |tee -a elasticsearch_storage.log
-    kubectl ${KUBE_OPTS} exec -it $pod  -c elasticsearch -- df -Ph | grep elasticsearch | grep -v "tmpfs" | awk '{printf "%-13s %10s %6s %8s %6s %s\n",$1,$2,$3,$4,$5,$6}' |tee -a ${LOG_DIR}/elasticsearch/elasticsearch_storage.log
+    mkdir -p ${LOG_DIR}/elasticsearch/${pod}
+    printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_health.log
+    kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/health" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_health.log
+
+    printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/elasticsearch_indices.log
+    kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/indices" | tee -a ${LOG_DIR}/elasticsearch//${pod}/elasticsearch_indices.log
+
+    printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/elasticsearch_nodes.log
+    kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/nodes?v" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_nodes.log
+
+    printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/elasticsearch_index_allocation.log
+    kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cluster/allocation/explain?pretty" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_index_allocation.log
+
+    printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
+    mountpath=$(kubectl ${KUBE_OPTS} get sts sysdigcloud-elasticsearch -ojsonpath='{.spec.template.spec.containers[].volumeMounts[?(@.name == "data")].mountPath}')
+    if [ ! -z $mountpath ]; then
+       echo "Please check this value against the Elasticsearch PV size" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
+       kubectl ${KUBE_OPTS} exec -it ${pod} -c elasticsearch -- du -ch ${mountpath} | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
+   else
+      printf "Error getting ElasticSearch ${pod} mount path\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
+   fi
 done
 
 # Fetch Cassandra storage info
-# Executes a df -h in Cassandra pod, gets proxyhistograms, tpstats, and compactionstats
-printf "Pod#\tFilesystem\tSize\tUsed\tAvail\tUse\tMounted on\n" > ${LOG_DIR}/cassandra/cassandra_storage.log
 for pod in $(kubectl ${KUBE_OPTS} get pods -l role=cassandra  | grep -v "NAME" | awk '{print $1}')
 do
-    printf "$pod\t" > ${LOG_DIR}/cassandra/cassandra_storage.log
-    kubectl ${KUBE_OPTS} exec -it $pod -c cassandra -- df -Ph | grep cassandra | grep -v "tmpfs" | awk '{printf "%-13s %10s %6s %8s %6s %s\n",$1,$2,$3,$4,$5,$6}' > ${LOG_DIR}/cassandra/cassandra_storage.log
+    echo "Checking Cassandra Storage - ${pod}"
+    mkdir -p ${LOG_DIR}/cassandra/${pod}
+    printf "${pod}\n" | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log
+    mountpath=$(kubectl ${KUBE_OPTS} get sts sysdigcloud-cassandra -ojsonpath='{.spec.template.spec.containers[].volumeMounts[?(@.name == "data")].mountPath}')
+    if [ ! -z $mountpath ]; then
+        echo "Please check this value against the Cassandra PV size" | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log
+        kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- du -ch ${mountpath} | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log || true
+   else
+      printf "Error getting Cassandra ${pod} mount path\n" | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log
+   fi
+done
+
+# Fetch postgresql storage info
+for pod in $(kubectl ${KUBE_OPTS} get pods -l role=postgresql  | grep -v "NAME" | awk '{print $1}')
+do
+    echo "Checking PostgreSQL Storage - ${pod}"
+    mkdir -p ${LOG_DIR}/postgresql/${pod}
+    printf "${pod}\n" | tee -a ${LOG_DIR}/postgresql/${pod}/postgresql_storage.log
+    echo "Please check this value against the PostgreSQL PV size" | tee -a ${LOG_DIR}/postgresql/${pod}/postgresql_storage.log
+    kubectl ${KUBE_OPTS} exec -it ${pod} -c postgresql -- du -ch /var/lib/postgresql | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/postgresql/${pod}/postgresql_storage.log || true
+done
+
+# Fetch mysql storage info
+for pod in $(kubectl ${KUBE_OPTS} get pods -l role=mysql  | grep -v "NAME" | awk '{print $1}')
+do
+    echo "Checking MySQL Storage - ${pod}"
+    mkdir -p ${LOG_DIR}/mysql/${pod}
+    printf "${pod}\n" | tee -a ${LOG_DIR}/mysql/${pod}/mysql_storage.log
+    echo "Please check this value against the mysql PV size" | tee -a ${LOG_DIR}/mysql/${pod}/mysql_storage.log
+    kubectl ${KUBE_OPTS} exec -it ${pod} -c mysql -- du -ch /var/lib/mysql | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/mysql/${pod}/mysql_storage.log || true
 done
 
 # Collect the sysdigcloud-config configmap, and write to the log directory

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -245,6 +245,7 @@ main() {
     #Collect PV info
     kubectl ${KUBE_OPTS} get pv | grep sysdig | tee -a ${LOG_DIR}/pv_output.log || echo "No permission to get PersistentVolumes"
     kubectl ${KUBE_OPTS} get pvc | grep sysdig | tee -a ${LOG_DIR}/pvc_output.log
+    kubectl ${KUBE_OPTS} get storageclass | tee -a ${LOG_DIR}/sc_output.log || echo "No permission to get StorageClasses"
     
     # Get info on deployments, statefulsets, persistentVolumeClaims, daemonsets, and ingresses
     echo "Gathering Manifest Information"

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -227,13 +227,13 @@ do
     printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_health.log
     kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/health" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_health.log
 
-    printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/elasticsearch_indices.log
+    printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_indices.log
     kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/indices" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_indices.log
 
-    printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/elasticsearch_nodes.log
+    printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_nodes.log
     kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/nodes?v" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_nodes.log
 
-    printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/elasticsearch_index_allocation.log
+    printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_index_allocation.log
     kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cluster/allocation/explain?pretty" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_index_allocation.log
 
     printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -262,10 +262,10 @@ if [ ! -z ${ELASTIC_POD} ]; then
         kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- openssl x509 -in /usr/share/elasticsearch/config/admin.pem -noout -enddate | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_admin_pem_expiration.log
         kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- openssl x509 -in /usr/share/elasticsearch/config/root-ca.pem -noout -enddate | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_root_ca_pem_expiration.log
     
+        echo "Checking Used Elasticsearch Storage - ${pod}"
         printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
         mountpath=$(kubectl ${KUBE_OPTS} get sts sysdigcloud-elasticsearch -ojsonpath='{.spec.template.spec.containers[].volumeMounts[?(@.name == "data")].mountPath}')
         if [ ! -z $mountpath ]; then
-           echo "Please check this value against the Elasticsearch PV size" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
            kubectl ${KUBE_OPTS} exec -it ${pod} -c elasticsearch -- du -ch ${mountpath} | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
        else
           printf "Error getting ElasticSearch ${pod} mount path\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
@@ -280,12 +280,11 @@ fi
 # Fetch Cassandra storage info
 for pod in $(kubectl ${KUBE_OPTS} get pods -l role=cassandra  | grep -v "NAME" | awk '{print $1}')
 do
-    echo "Checking Cassandra Storage - ${pod}"
+    echo "Checking Used Cassandra Storage - ${pod}"
     mkdir -p ${LOG_DIR}/cassandra/${pod}
     printf "${pod}\n" | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log
     mountpath=$(kubectl ${KUBE_OPTS} get sts sysdigcloud-cassandra -ojsonpath='{.spec.template.spec.containers[].volumeMounts[?(@.name == "data")].mountPath}')
     if [ ! -z $mountpath ]; then
-        echo "Please check this value against the Cassandra PV size" | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log
         kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- du -ch ${mountpath} | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log || true
    else
       printf "Error getting Cassandra ${pod} mount path\n" | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log
@@ -295,20 +294,18 @@ done
 # Fetch postgresql storage info
 for pod in $(kubectl ${KUBE_OPTS} get pods -l role=postgresql  | grep -v "NAME" | awk '{print $1}')
 do
-    echo "Checking PostgreSQL Storage - ${pod}"
+    echo "Checking Used PostgreSQL Storage - ${pod}"
     mkdir -p ${LOG_DIR}/postgresql/${pod}
     printf "${pod}\n" | tee -a ${LOG_DIR}/postgresql/${pod}/postgresql_storage.log
-    echo "Please check this value against the PostgreSQL PV size" | tee -a ${LOG_DIR}/postgresql/${pod}/postgresql_storage.log
     kubectl ${KUBE_OPTS} exec -it ${pod} -c postgresql -- du -ch /var/lib/postgresql | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/postgresql/${pod}/postgresql_storage.log || true
 done
 
 # Fetch mysql storage info
 for pod in $(kubectl ${KUBE_OPTS} get pods -l role=mysql  | grep -v "NAME" | awk '{print $1}')
 do
-    echo "Checking MySQL Storage - ${pod}"
+    echo "Checking Used MySQL Storage - ${pod}"
     mkdir -p ${LOG_DIR}/mysql/${pod}
     printf "${pod}\n" | tee -a ${LOG_DIR}/mysql/${pod}/mysql_storage.log
-    echo "Please check this value against the mysql PV size" | tee -a ${LOG_DIR}/mysql/${pod}/mysql_storage.log
     kubectl ${KUBE_OPTS} exec -it ${pod} -c mysql -- du -ch /var/lib/mysql | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/mysql/${pod}/mysql_storage.log || true
 done
 

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -19,13 +19,6 @@ API_KEY=""
 SKIP_LOGS="false"
 ELASTIC_CURL=""
 
-begins_with_short_option() {
-    local first_option all_short_options
-    all_short_options='acdhlns'
-    first_option="${1:0:1}"
-    test "$all_short_options" = "${all_short_options/$first_option/}" && return 1 || return 0
-}
-
 print_help() {
     printf 'Usage: %s [-a|--api-key <API_KEY>] [c|--context <CONTEXT>] [-d|--debug] [-l|--labels <LABELS>] [-n|--namespace <NAMESPACE>] [-s|--since <TIMEFRAME>] [--skip-logs] [-h|--help]\n' "$0"
     printf "\t%s\n" "-a,--api-key: Provide the Superuser API key for advanced data collection"

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -219,7 +219,6 @@ main() {
         do
             echo "Getting support logs for ${pod}"
             mkdir -p ${LOG_DIR}/${pod}
-            kubectl ${KUBE_OPTS} get pod ${pod} -o json > ${LOG_DIR}/${pod}/kubectl-describe.json
             containers=$(kubectl ${KUBE_OPTS} get pod ${pod} -o json | jq -r '.spec.containers[].name')
             for container in ${containers}; 
             do
@@ -237,6 +236,14 @@ main() {
             done
         done
     fi
+
+    echo "Gathering pod descriptions"
+    for pod in ${SYSDIGCLOUD_PODS}; 
+    do
+        echo "Getting pod description for ${pod}"
+        mkdir -p ${LOG_DIR}/${pod}
+        kubectl ${KUBE_OPTS} get pod ${pod} -o json > ${LOG_DIR}/${pod}/kubectl-describe.json
+    done
     
     #Collect Describe Node Output
     echo "Collecting node information"

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -114,6 +114,7 @@ segment_by="${2}"
 if [[ ! -z ${API_KEY} ]]; then
     API_URL=$(kubectl ${KUBE_OPTS} get cm sysdigcloud-config -o yaml | grep -i api.url: | head -1 | awk '{print$2}')
     curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/streamsnapSettings" >> ${LOG_DIR}/streamSnap_settings.json
+    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customers/1/snapshotSettings" >> ${LOG_DIR}/snapshot_settings.json
     curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/fastPathSettings" >> ${LOG_DIR}/fastPath_settings.json
     curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/indexSettings" >> ${LOG_DIR}/index_settings.json
     curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/planSettings" >> ${LOG_DIR}/plan_settings.json

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -113,6 +113,7 @@ segment_by="${2}"
 # If API key is supplied, collect streamSnap, Index settings, and fastPath settings
 if [[ ! -z ${API_KEY} ]]; then
     API_URL=$(kubectl ${KUBE_OPTS} get cm sysdigcloud-config -o yaml | grep -i api.url: | head -1 | awk '{print$2}')
+    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/license" >> ${LOG_DIR}/license.json
     curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/streamsnapSettings" >> ${LOG_DIR}/streamSnap_settings.json
     curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customers/1/snapshotSettings" >> ${LOG_DIR}/snapshot_settings.json
     curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/fastPathSettings" >> ${LOG_DIR}/fastPath_settings.json

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -183,8 +183,8 @@ main() {
         SYSDIGCLOUD_PODS=$(kubectl ${KUBE_OPTS} -l "role in (${LABELS})" get pods | awk '{ print $1 }' | grep -v NAME)
     fi
 
-    echo "Using namespace ${NAMESPACE}";
-    echo "Using context ${CONTEXT}";
+    echo "Using namespace ${NAMESPACE}"
+    echo "Using context ${CONTEXT}"
 
     # Collect container logs for each pod
     if [[ "${SKIP_LOGS}" == "false" ]]; then

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -239,8 +239,17 @@ main() {
     fi
     
     #Collect Describe Node Output
-    echo "Collecting describe node output"
-    kubectl ${KUBE_OPTS} describe nodes | tee -a ${LOG_DIR}/describe_node_output.log || echo "No permission to describe nodes"
+    echo "Collecting node information"
+    kubectl ${KUBE_OPTS} describe nodes | tee -a ${LOG_DIR}/describe_node_output.log || echo "No permission to describe nodes!"
+
+    NODES=$(kubectl ${KUBE_OPTS} get nodes --no-headers | awk '{print $1}') && RETVAL=0 || { RETVAL=$? && echo "No permission to get nodes!"; }
+    if [[ "${RETVAL}" == "0" ]]; then
+        mkdir -p ${LOG_DIR}/nodes
+        for node in ${NODES[@]}; do
+            kubectl ${KUBE_OPTS} get node ${node} -ojson > ${LOG_DIR}/nodes/${node}-kubectl.json
+        done
+        unset RETVAL
+    fi
     
     #Collect PV info
     kubectl ${KUBE_OPTS} get pv | grep sysdig | tee -a ${LOG_DIR}/pv_output.log || echo "No permission to get PersistentVolumes"

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -245,16 +245,12 @@ if [ ! -z ${ELASTIC_POD} ]; then
     for pod in $(kubectl ${KUBE_OPTS} get pods -l role=elasticsearch | grep -v "NAME" | awk '{print $1}')
     do
         mkdir -p ${LOG_DIR}/elasticsearch/${pod}
-        printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_health.log
         kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/health" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_health.log
     
-        printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_indices.log
         kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/indices" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_indices.log
     
-        printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_nodes.log
         kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/nodes?v" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_nodes.log
     
-        printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_index_allocation.log
         kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cluster/allocation/explain?pretty" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_index_allocation.log
 
         echo "Fetching ElasticSearch SSL Certificate Expiration Dates"
@@ -263,7 +259,6 @@ if [ ! -z ${ELASTIC_POD} ]; then
         kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- openssl x509 -in /usr/share/elasticsearch/config/root-ca.pem -noout -enddate | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_root_ca_pem_expiration.log
     
         echo "Checking Used Elasticsearch Storage - ${pod}"
-        printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
         mountpath=$(kubectl ${KUBE_OPTS} get sts sysdigcloud-elasticsearch -ojsonpath='{.spec.template.spec.containers[].volumeMounts[?(@.name == "data")].mountPath}')
         if [ ! -z $mountpath ]; then
            kubectl ${KUBE_OPTS} exec -it ${pod} -c elasticsearch -- du -ch ${mountpath} | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -93,7 +93,7 @@ segment_by="${2}"
           --header 'Content-Type: application/json'
           -d "{\"requests\":[{\"format\":{\"type\":\"data\"},\"time\":{\"from\":${FROM_EPOCH_TIME}000000,\"to\":${TO_EPOCH_TIME}000000,\"sampling\":600000000},\"metrics\":{\"v0\":\"${metric}\",\"k0\":\"timestamp\",\"k1\":\"${segment_by}\"},\"group\":{\"aggregations\":{\"v0\":\"avg\"},\"groupAggregations\":{\"v0\":\"avg\"},\"by\":[{\"metric\":\"k0\",\"value\":600000000},{\"metric\":\"k1\"}],\"configuration\":{\"groups\":[{\"groupBy\":[]}]}},\"paging\":{\"from\":0,\"to\":9},\"sort\":[{\"v0\":\"desc\"}],\"scope\":null,\"compareTo\":null}]}'"
         )
-        curl "${PARAMS[@]}" >${LOG_DIR}/metrics/${metric}_${segment_by}.json
+        curl "${PARAMS[@]}" >${LOG_DIR}/metrics/${metric}_${segment_by}.json || echo "Curl failed collecting ${metric}_${segment_by} data!" && true
 }
 
 # If API key is supplied, collect streamSnap, Index settings, and fastPath settings

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -213,7 +213,7 @@ done
 echo "Fetching Elasticsearch health info"
 # CHECK HERE IF THE TLS ENV VARIABLE IS SET IN ELASTICSEARCH, AND BUILD THE CURL COMMAND OUT
 ELASTIC_POD=$(kubectl ${KUBE_OPTS} get po -l role=elasticsearch --no-headers | head -1 | awk '{print $1}')
-ELASTIC_TLS=$(kubectl ${KUBE_OPTS} exec -it ${ELASTIC_POD} -- env | grep -i ELASTICSEARCH_TLS_ENCRYPTION)
+ELASTIC_TLS=$(kubectl ${KUBE_OPTS} exec -it ${ELASTIC_POD} -c elasticsearch -- env | grep -i ELASTICSEARCH_TLS_ENCRYPTION)
 
 if [[ ${ELASTIC_TLS} == *"ELASTICSEARCH_TLS_ENCRYPTION=true"* ]]; then
     ELASTIC_CURL='curl -s --cacert /usr/share/elasticsearch/config/root-ca.pem https://${ELASTICSEARCH_ADMINUSER}:${ELASTICSEARCH_ADMIN_PASSWORD}'

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -256,6 +256,11 @@ if [ ! -z ${ELASTIC_POD} ]; then
     
         printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_index_allocation.log
         kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cluster/allocation/explain?pretty" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_index_allocation.log
+
+        echo "Fetching ElasticSearch SSL Certificate Expiration Dates"
+        kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- openssl x509 -in /usr/share/elasticsearch/config/node.pem -noout -enddate | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_node_pem_expiration.log
+        kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- openssl x509 -in /usr/share/elasticsearch/config/admin.pem -noout -enddate | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_admin_pem_expiration.log
+        kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- openssl x509 -in /usr/share/elasticsearch/config/root-ca.pem -noout -enddate | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_root_ca_pem_expiration.log
     
         printf "${pod}\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
         mountpath=$(kubectl ${KUBE_OPTS} get sts sysdigcloud-elasticsearch -ojsonpath='{.spec.template.spec.containers[].volumeMounts[?(@.name == "data")].mountPath}')
@@ -269,6 +274,8 @@ if [ ! -z ${ELASTIC_POD} ]; then
 else
     echo "Unable to fetch ElasticSearch pod to gather health info!"
 fi
+
+
 
 # Fetch Cassandra storage info
 for pod in $(kubectl ${KUBE_OPTS} get pods -l role=cassandra  | grep -v "NAME" | awk '{print $1}')

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -6,6 +6,109 @@ catch() {
   echo "An error has occurred. Please check your input and try again. Run this script with the -d flag for debugging"
 }
 
+#generate sysdigcloud support bundle on kubernetes
+
+LABELS=""
+CONTEXT=""
+CONTEXT_OPTS=""
+NAMESPACE="sysdigcloud"
+LOG_DIR=$(mktemp -d sysdigcloud-support-bundle-XXXX)
+SINCE_OPTS="" 
+SINCE=""
+API_KEY=""
+SKIP_LOGS="false"
+ELASTIC_CURL=""
+
+begins_with_short_option() {
+    local first_option all_short_options
+    all_short_options='acdhlns'
+    first_option="${1:0:1}"
+    test "$all_short_options" = "${all_short_options/$first_option/}" && return 1 || return 0
+}
+
+print_help() {
+    printf 'Usage: %s [-a|--api-key <API_KEY>] [c|--context <CONTEXT>] [-d|--debug] [-l|--labels <LABELS>] [-n|--namespace <NAMESPACE>] [-s|--since <TIMEFRAME>] [--skip-logs] [-h|--help]\n' "$0"
+    printf "\t%s\n" "-a,--api-key: Provide the Superuser API key for advanced data collection"
+    printf "\t%s\n" "-c,--context: Specify the kubectl context. If not set, the current context will be used."
+    printf "\t%s\n" "-d,--debug: Enables Debug"
+    printf "\t%s\n" "-l,--labels: Specify Sysdig pod role label to collect (e.g. api,collector,worker)"
+    printf "\t%s\n" "-n,--namespace: Specify the Sysdig namespace. (default: ${NAMESPACE})"
+    printf "\t%s\n" "-s,--since: Specify the timeframe of logs to collect (e.g. -s 1h)"
+    printf "\t%s\n" "--skip-logs: Skip all log collection. (default: ${SKIP_LOGS})"
+    printf "\t%s\n" "-h,--help: Prints help"
+}
+
+parse_commandline() {
+    while test $# -gt 0
+    do
+        _key="$1"
+        case "$_key" in
+            -a|--api-key)
+                test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+                API_KEY="$2"
+                shift
+                ;;
+            --api-key=*)
+                API_KEY="${_key##--api-key=}"
+                ;;
+            -a*)
+                API_KEY="${_key##-a}"
+                ;;
+            -c|--context)
+                test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+                CONTEXT="$2"
+                shift
+                ;;
+            --context=*)
+                CONTEXT="${_key##--context=}"
+                ;;
+            -c*)
+                CONTEXT="${_key##-c}"
+                ;;
+            -d|--debug)
+                set -x
+                ;;
+            -d*)
+                set -x
+                ;;
+            -l|--labels)
+                test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+                LABELS="$2"
+                shift
+                ;;
+            --labels=*)
+                LABELS="${_key##--labels=}"
+                ;;
+            -l*)
+                LABELS="${_key##-l}"
+                ;;
+            -s|--since)
+                test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+                SINCE="$2"
+                shift
+                ;;
+            --since=*)
+                SINCE="${_key##--since=}"
+                ;;
+            -s*)
+                SINCE="${_key##-s}"
+                ;;
+            --skip-logs)
+                SKIP_LOGS="true"
+                ;;
+            -h|--help)
+                print_help
+                exit 0
+                ;;
+            -h*)
+                print_help
+                exit 0
+                ;;
+        esac
+        shift
+    done
+}
+
 gnudate() {
     if hash gdate 2>/dev/null; then
         gdate "$@"
@@ -13,70 +116,6 @@ gnudate() {
         date "$@"
     fi
 }
-
-#generate sysdigcloud support bundle on kubernetes
-
-LABELS=""
-CONTEXT=""
-CONTEXT_OPTS=""
-NAMESPACE=""
-LOG_DIR=$(mktemp -d sysdigcloud-support-bundle-XXXX)
-SINCE_OPTS="" 
-SINCE=""
-API_KEY=""
-ELASTIC_CURL=""
-
-while getopts l:n:c:s:a:hd flag; do
-    case "${flag}" in
-        l) LABELS=${OPTARG:-};;
-        n) NAMESPACE=${OPTARG:-};;
-        h) 
-
-            echo "Usage: ./get_support_bundle.sh -n <NAMESPACE> -l <LABELS>"; 
-            echo "Example: ./get_support_bundle.sh -n sysdig -l api,collector,worker,cassandra,elasticsearch"; 
-            echo "Flags:"; 
-            echo "-a  Provide the Superuser API key for advanced data collection"
-            echo "-c  Specify the kubectl context. If not set, the current context will be used.";
-            echo "-d  Run the script in debug mode (use this if you encounter a problem).";
-            echo "-n  Specify the Sysdig namespace. If not specified, "sysdigcloud" is assumed."; 
-            echo "-l  Specify Sysdig pod role label to collect (e.g. api,collector,worker)";
-            echo "-h  Print these instructions";
-            echo "-s  Specify the timeframe of logs to collect (e.g. -s 1h)"
-            exit;;
-
-        c) CONTEXT=${OPTARG:-};;
-        s) SINCE=${OPTARG:-};;
-        a) API_KEY=${OPTARG:-};;
-        d) set -x;;
-
-    esac
-done
-
-# Check for supplied namespace, kube context, and flags
-if [[ -z ${NAMESPACE} ]]; then
-    NAMESPACE="sysdig"
-fi
-
-if [[ ! -z ${CONTEXT} ]]; then
-    CONTEXT_OPTS="--context=${CONTEXT}"
-fi
-
-if [[ ! -z ${SINCE} ]]; then
-    SINCE_OPTS="--since ${SINCE}"
-fi
-
-# Set options for kubectl commands
-KUBE_OPTS="--namespace ${NAMESPACE} ${CONTEXT_OPTS}"
-
-#verify that the provided namespace exists
-KUBE_OUTPUT=$(kubectl ${KUBE_OPTS} get namespace ${NAMESPACE}) || true
-
-# Check that the supplied namespace exists, and if not, output current namespaces
-if [[ "$(echo "$KUBE_OUTPUT" | grep -o "^sysdig " || true)" != "${NAMESPACE} " ]]; then
-    echo "We could not determine the namespace. Please check the spelling and try again";
-    echo "kubectl ${KUBE_OPTS} get ns";
-    echo "$(kubectl ${KUBE_OPTS} get ns)";
-fi
 
 get_agent_version_metric_limits() {
 # function used to get metric JSON data for Agent versions and metric counts for each agent.
@@ -110,209 +149,248 @@ segment_by="${2}"
         curl "${PARAMS[@]}" >${LOG_DIR}/metrics/${metric}_${segment_by}.json || echo "Curl failed collecting ${metric}_${segment_by} data!" && true
 }
 
-# If API key is supplied, collect streamSnap, Index settings, and fastPath settings
-if [[ ! -z ${API_KEY} ]]; then
-    API_URL=$(kubectl ${KUBE_OPTS} get cm sysdigcloud-config -o yaml | grep -i api.url: | head -1 | awk '{print$2}')
-    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/license" >> ${LOG_DIR}/license.json
-    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/streamsnapSettings" >> ${LOG_DIR}/streamSnap_settings.json
-    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customers/1/snapshotSettings" >> ${LOG_DIR}/snapshot_settings.json
-    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/fastPathSettings" >> ${LOG_DIR}/fastPath_settings.json
-    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/indexSettings" >> ${LOG_DIR}/index_settings.json
-    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/planSettings" >> ${LOG_DIR}/plan_settings.json
-    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/dataRetentionSettings" >> ${LOG_DIR}/dataRetention_settings.json
-    curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/agents/connected" >> ${LOG_DIR}/agents-connected.json
-
-    TO_EPOCH_TIME=$(gnudate -d "$(gnudate +%H):00:00" +%s)
-    FROM_EPOCH_TIME=$((TO_EPOCH_TIME-86400))
-    METRICS=("syscall.count" "dragent.analyzer.sr" "container.count" "dragent.analyzer.n_drops_buffer" "dragent.analyzer.n_evts")
-    DEFAULT_SEGMENT="host.hostName"
-    SYSCALL_SEGMENTS=("host.hostName" "proc.name")
-
-    mkdir -p ${LOG_DIR}/metrics
-    for metric in ${METRICS[@]}; do
-        if [ "${metric}" == "syscall.count" ]; then
-            for segment in ${SYSCALL_SEGMENTS[@]}; do
-                get_metrics "${metric}" "${segment}"
-            done
-        else
-            get_metrics "${metric}" "${DEFAULT_SEGMENT}"
-        fi
-    done
-
-    get_agent_version_metric_limits
-fi
-
-# Configure kubectl command if labels are set
-if [[ -z ${LABELS} ]]; then
-    SYSDIGCLOUD_PODS=$(kubectl ${KUBE_OPTS} get pods | awk '{ print $1 }' | grep -v NAME)
-else
-    SYSDIGCLOUD_PODS=$(kubectl ${KUBE_OPTS} -l "role in (${LABELS})" get pods | awk '{ print $1 }' | grep -v NAME)
-fi
-
-echo "Using namespace ${NAMESPACE}";
-echo "Using context ${CONTEXT}";
-
-# Collect container logs for each pod
-command='tar czf - /logs/ /opt/draios/ /var/log/sysdigcloud/ /var/log/cassandra/ /tmp/redis.log /var/log/redis-server/redis.log /var/log/mysql/error.log /opt/prod.conf 2>/dev/null || true'
-for pod in ${SYSDIGCLOUD_PODS}; 
-do
-    echo "Getting support logs for ${pod}"
-    mkdir -p ${LOG_DIR}/${pod}
-    kubectl ${KUBE_OPTS} get pod ${pod} -o json > ${LOG_DIR}/${pod}/kubectl-describe.json
-    containers=$(kubectl ${KUBE_OPTS} get pod ${pod} -o json | jq -r '.spec.containers[].name')
-    for container in ${containers}; 
-    do
-        kubectl ${KUBE_OPTS} logs ${pod} -c ${container} ${SINCE_OPTS} > ${LOG_DIR}/${pod}/${container}-kubectl-logs.txt
-        echo "Execing into ${container}"
-        kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- bash >/dev/null 2>&1 && RETVAL=$? || RETVAL=$? && true
-        kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- sh >/dev/null 2>&1 && RETVAL1=$? || RETVAL1=$? && true
-        if [ $RETVAL -eq 0 ]; then
-            kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- bash -c "${command}" > ${LOG_DIR}/${pod}/${container}-support-files.tgz || true
-        elif [ $RETVAL1 -eq 0 ]; then
-            kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- sh -c "${command}" > ${LOG_DIR}/${pod}/${container}-support-files.tgz || true
-        else
-            echo "Skipping log gathering for ${pod}"
-        fi
-    done
-done
-
-#Collect PV info
-kubectl ${KUBE_OPTS} get pv | grep sysdig | tee -a ${LOG_DIR}/pv_output.log
-kubectl ${KUBE_OPTS} get pvc | grep sysdig | tee -a ${LOG_DIR}/pvc_output.log
-
-# Get info on deployments, statefulsets, persistentVolumeClaims, daemonsets, and ingresses
-for object in svc deployment sts pvc daemonset ingress replicaset
-do
-    items=$(kubectl ${KUBE_OPTS} get ${object} -o jsonpath="{.items[*]['metadata.name']}")
-    mkdir -p ${LOG_DIR}/${object}
-    for item in ${items}; do 
-        kubectl ${KUBE_OPTS} get ${object} ${item} -o json > ${LOG_DIR}/${object}/${item}-kubectl.json
-    done
-done
-
-# Fetch container density information
-num_nodes=0
-num_pods=0
-num_running_containers=0
-num_total_containers=0
-
-printf "%-30s %-10s %-10s %-10s %-10s\n" "Node" "Pods" "Running Containers" "Total Containers" >> ${LOG_DIR}/container_density.txt
-for node in $(kubectl ${KUBE_OPTS} get nodes --no-headers -o custom-columns=node:.metadata.name);
-do
-    total_pods=$(kubectl ${KUBE_OPTS} get pods -A --no-headers -o wide | grep ${node} |wc -l |xargs)
-    running_containers=$( kubectl ${KUBE_OPTS} get pods -A --no-headers -o wide |grep ${node} |awk '{print $3}' |cut -f 1 -d/ | awk '{ SUM += $1} END { print SUM }' |xargs)
-    total_containers=$( kubectl get ${KUBE_OPTS} pods -A --no-headers -o wide |grep ${node} |awk '{print $3}' |cut -f 2 -d/ | awk '{ SUM += $1} END { print SUM }' |xargs)
-    printf "%-30s %-15s %-20s %-10s\n" "${node}" "${total_pods}" "${running_containers}" "${total_containers}" >> ${LOG_DIR}/container_density.txt
-    num_nodes=$((num_nodes+1))
-    num_pods=$((num_pods+${total_pods}))
-    num_running_containers=$((num_running_containers+${running_containers}))
-    num_total_containers=$((num_total_containers+${total_containers}))
-done
-  
-printf "\nTotals\n-----\n" >> ${LOG_DIR}/container_density.txt
-printf "Nodes: ${num_nodes}\n" >> ${LOG_DIR}/container_density.txt
-printf "Pods: ${num_pods}\n" >> ${LOG_DIR}/container_density.txt
-printf "Running Containers: ${num_running_containers}\n" >> ${LOG_DIR}/container_density.txt
-printf "Containers: ${num_total_containers}\n" >> ${LOG_DIR}/container_density.txt
-
-# Fetch Cassandra Nodetool output
-echo "Fetching Cassandra statistics";
-for pod in $(kubectl ${KUBE_OPTS} get pod -l role=cassandra | grep -v "NAME" | awk '{print $1}')
-do
-    mkdir -p ${LOG_DIR}/cassandra/${pod}
-    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool info | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_info.log
-    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool status | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_status.log
-    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool getcompactionthroughput | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_getcompactionthroughput.log
-    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool cfstats | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_cfstats.log
-    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool cfhistograms draios message_data10 | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_cfhistograms.log
-    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool proxyhistograms | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_proxyhistograms.log
-    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool tpstats | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_tpstats.log
-    kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool compactionstats | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_compactionstats.log
-done
-
-echo "Fetching Elasticsearch health info"
-# CHECK HERE IF THE TLS ENV VARIABLE IS SET IN ELASTICSEARCH, AND BUILD THE CURL COMMAND OUT
-ELASTIC_POD=$(kubectl ${KUBE_OPTS} get pods -l role=elasticsearch --no-headers | head -1 | awk '{print $1}') || true
-
-if [ ! -z ${ELASTIC_POD} ]; then
-    ELASTIC_TLS=$(kubectl ${KUBE_OPTS} exec -it ${ELASTIC_POD} -c elasticsearch -- env | grep -i ELASTICSEARCH_TLS_ENCRYPTION) || true
-    
-    if [[ ${ELASTIC_TLS} == *"ELASTICSEARCH_TLS_ENCRYPTION=true"* ]]; then
-        ELASTIC_CURL='curl -s --cacert /usr/share/elasticsearch/config/root-ca.pem https://${ELASTICSEARCH_ADMINUSER}:${ELASTICSEARCH_ADMIN_PASSWORD}'
-    else
-        ELASTIC_CURL='curl -s -k http://$(hostname)'
+main() {
+    # Check for supplied namespace, kube context, and flags
+    if [[ -z ${NAMESPACE} ]]; then
+        NAMESPACE="sysdig"
     fi
     
-    for pod in $(kubectl ${KUBE_OPTS} get pods -l role=elasticsearch | grep -v "NAME" | awk '{print $1}')
+    if [[ ! -z ${CONTEXT} ]]; then
+        CONTEXT_OPTS="--context=${CONTEXT}"
+    fi
+    
+    if [[ ! -z ${SINCE} ]]; then
+        SINCE_OPTS="--since ${SINCE}"
+    fi
+    
+    # Set options for kubectl commands
+    KUBE_OPTS="--namespace ${NAMESPACE} ${CONTEXT_OPTS}"
+    
+    #verify that the provided namespace exists
+    KUBE_OUTPUT=$(kubectl ${KUBE_OPTS} get namespace ${NAMESPACE}) || true
+    
+    # Check that the supplied namespace exists, and if not, output current namespaces
+    if [[ "$(echo "$KUBE_OUTPUT" | grep -o "^sysdig " || true)" != "${NAMESPACE} " ]]; then
+        echo "We could not determine the namespace. Please check the spelling and try again";
+        echo "kubectl ${KUBE_OPTS} get ns";
+        echo "$(kubectl ${KUBE_OPTS} get ns)";
+    fi
+    
+    # If API key is supplied, collect streamSnap, Index settings, and fastPath settings
+    if [[ ! -z ${API_KEY} ]]; then
+        API_URL=$(kubectl ${KUBE_OPTS} get cm sysdigcloud-config -o yaml | grep -i api.url: | head -1 | awk '{print$2}')
+        curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/license" >> ${LOG_DIR}/license.json
+        curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/streamsnapSettings" >> ${LOG_DIR}/streamSnap_settings.json
+        curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customers/1/snapshotSettings" >> ${LOG_DIR}/snapshot_settings.json
+        curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/fastPathSettings" >> ${LOG_DIR}/fastPath_settings.json
+        curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/indexSettings" >> ${LOG_DIR}/index_settings.json
+        curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/planSettings" >> ${LOG_DIR}/plan_settings.json
+        curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/admin/customer/1/dataRetentionSettings" >> ${LOG_DIR}/dataRetention_settings.json
+        curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/agents/connected" >> ${LOG_DIR}/agents-connected.json
+    
+        TO_EPOCH_TIME=$(gnudate -d "$(gnudate +%H):00:00" +%s)
+        FROM_EPOCH_TIME=$((TO_EPOCH_TIME-86400))
+        METRICS=("syscall.count" "dragent.analyzer.sr" "container.count" "dragent.analyzer.n_drops_buffer" "dragent.analyzer.n_evts")
+        DEFAULT_SEGMENT="host.hostName"
+        SYSCALL_SEGMENTS=("host.hostName" "proc.name")
+    
+        mkdir -p ${LOG_DIR}/metrics
+        for metric in ${METRICS[@]}; do
+            if [ "${metric}" == "syscall.count" ]; then
+                for segment in ${SYSCALL_SEGMENTS[@]}; do
+                    get_metrics "${metric}" "${segment}"
+                done
+            else
+                get_metrics "${metric}" "${DEFAULT_SEGMENT}"
+            fi
+        done
+    
+        get_agent_version_metric_limits
+    fi
+    
+    # Configure kubectl command if labels are set
+    if [[ -z ${LABELS} ]]; then
+        SYSDIGCLOUD_PODS=$(kubectl ${KUBE_OPTS} get pods | awk '{ print $1 }' | grep -v NAME)
+    else
+        SYSDIGCLOUD_PODS=$(kubectl ${KUBE_OPTS} -l "role in (${LABELS})" get pods | awk '{ print $1 }' | grep -v NAME)
+    fi
+    
+    echo "Using namespace ${NAMESPACE}";
+    echo "Using context ${CONTEXT}";
+    
+    # Collect container logs for each pod
+    if [[ "${SKIP_LOGS}" == "false" ]]; then
+        echo "Gathering Logs from ${NAMESPACE} pods"
+        command='tar czf - /logs/ /opt/draios/ /var/log/sysdigcloud/ /var/log/cassandra/ /tmp/redis.log /var/log/redis-server/redis.log /var/log/mysql/error.log /opt/prod.conf 2>/dev/null || true'
+        for pod in ${SYSDIGCLOUD_PODS}; 
+        do
+            echo "Getting support logs for ${pod}"
+            mkdir -p ${LOG_DIR}/${pod}
+            kubectl ${KUBE_OPTS} get pod ${pod} -o json > ${LOG_DIR}/${pod}/kubectl-describe.json
+            containers=$(kubectl ${KUBE_OPTS} get pod ${pod} -o json | jq -r '.spec.containers[].name')
+            for container in ${containers}; 
+            do
+                kubectl ${KUBE_OPTS} logs ${pod} -c ${container} ${SINCE_OPTS} > ${LOG_DIR}/${pod}/${container}-kubectl-logs.txt
+                echo "Execing into ${container}"
+                kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- bash >/dev/null 2>&1 && RETVAL=$? || RETVAL=$? && true
+                kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- sh >/dev/null 2>&1 && RETVAL1=$? || RETVAL1=$? && true
+                if [ $RETVAL -eq 0 ]; then
+                    kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- bash -c "${command}" > ${LOG_DIR}/${pod}/${container}-support-files.tgz || true
+                elif [ $RETVAL1 -eq 0 ]; then
+                    kubectl ${KUBE_OPTS} exec ${pod} -c ${container} -- sh -c "${command}" > ${LOG_DIR}/${pod}/${container}-support-files.tgz || true
+                else
+                    echo "Skipping log gathering for ${pod}"
+                fi
+            done
+        done
+    fi
+    
+    #Collect Describe Node Output
+    echo "Collecting describe node output"
+    kubectl ${KUBE_OPTS} describe nodes | tee -a ${LOG_DIR}/describe_node_output.log || echo "No permission to describe nodes"
+    
+    #Collect PV info
+    kubectl ${KUBE_OPTS} get pv | grep sysdig | tee -a ${LOG_DIR}/pv_output.log || echo "No permission to get PersistentVolumes"
+    kubectl ${KUBE_OPTS} get pvc | grep sysdig | tee -a ${LOG_DIR}/pvc_output.log
+    
+    # Get info on deployments, statefulsets, persistentVolumeClaims, daemonsets, and ingresses
+    echo "Gathering Manifest Information"
+    for object in svc deployment sts pvc daemonset ingress replicaset
     do
-        mkdir -p ${LOG_DIR}/elasticsearch/${pod}
-        kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/health" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_health.log
+        items=$(kubectl ${KUBE_OPTS} get ${object} -o jsonpath="{.items[*]['metadata.name']}")
+        mkdir -p ${LOG_DIR}/${object}
+        for item in ${items}; do 
+            kubectl ${KUBE_OPTS} get ${object} ${item} -o json > ${LOG_DIR}/${object}/${item}-kubectl.json
+        done
+    done
     
-        kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/indices" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_indices.log
+    # Fetch container density information
+    num_nodes=0
+    num_pods=0
+    num_running_containers=0
+    num_total_containers=0
     
-        kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/nodes?v" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_nodes.log
+    printf "%-30s %-10s %-10s %-10s %-10s\n" "Node" "Pods" "Running Containers" "Total Containers" >> ${LOG_DIR}/container_density.txt
+    for node in $(kubectl ${KUBE_OPTS} get nodes --no-headers -o custom-columns=node:.metadata.name);
+    do
+        total_pods=$(kubectl ${KUBE_OPTS} get pods -A --no-headers -o wide | grep ${node} |wc -l |xargs)
+        running_containers=$( kubectl ${KUBE_OPTS} get pods -A --no-headers -o wide |grep ${node} |awk '{print $3}' |cut -f 1 -d/ | awk '{ SUM += $1} END { print SUM }' |xargs)
+        total_containers=$( kubectl get ${KUBE_OPTS} pods -A --no-headers -o wide |grep ${node} |awk '{print $3}' |cut -f 2 -d/ | awk '{ SUM += $1} END { print SUM }' |xargs)
+        printf "%-30s %-15s %-20s %-10s\n" "${node}" "${total_pods}" "${running_containers}" "${total_containers}" >> ${LOG_DIR}/container_density.txt
+        num_nodes=$((num_nodes+1))
+        num_pods=$((num_pods+${total_pods}))
+        num_running_containers=$((num_running_containers+${running_containers}))
+        num_total_containers=$((num_total_containers+${total_containers}))
+    done
+      
+    printf "\nTotals\n-----\n" >> ${LOG_DIR}/container_density.txt
+    printf "Nodes: ${num_nodes}\n" >> ${LOG_DIR}/container_density.txt
+    printf "Pods: ${num_pods}\n" >> ${LOG_DIR}/container_density.txt
+    printf "Running Containers: ${num_running_containers}\n" >> ${LOG_DIR}/container_density.txt
+    printf "Containers: ${num_total_containers}\n" >> ${LOG_DIR}/container_density.txt
     
-        kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cluster/allocation/explain?pretty" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_index_allocation.log
-
-        echo "Fetching ElasticSearch SSL Certificate Expiration Dates"
-        kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- openssl x509 -in /usr/share/elasticsearch/config/node.pem -noout -enddate | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_node_pem_expiration.log
-        kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- openssl x509 -in /usr/share/elasticsearch/config/admin.pem -noout -enddate | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_admin_pem_expiration.log
-        kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- openssl x509 -in /usr/share/elasticsearch/config/root-ca.pem -noout -enddate | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_root_ca_pem_expiration.log
+    # Fetch Cassandra Nodetool output
+    echo "Fetching Cassandra statistics";
+    for pod in $(kubectl ${KUBE_OPTS} get pod -l role=cassandra | grep -v "NAME" | awk '{print $1}')
+    do
+        mkdir -p ${LOG_DIR}/cassandra/${pod}
+        kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool info | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_info.log
+        kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool status | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_status.log
+        kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool getcompactionthroughput | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_getcompactionthroughput.log
+        kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool cfstats | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_cfstats.log
+        kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool cfhistograms draios message_data10 | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_cfhistograms.log
+        kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool proxyhistograms | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_proxyhistograms.log
+        kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool tpstats | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_tpstats.log
+        kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- nodetool compactionstats | tee -a ${LOG_DIR}/cassandra/${pod}/nodetool_compactionstats.log
+    done
     
-        echo "Checking Used Elasticsearch Storage - ${pod}"
-        mountpath=$(kubectl ${KUBE_OPTS} get sts sysdigcloud-elasticsearch -ojsonpath='{.spec.template.spec.containers[].volumeMounts[?(@.name == "data")].mountPath}')
+    echo "Fetching Elasticsearch health info"
+    # CHECK HERE IF THE TLS ENV VARIABLE IS SET IN ELASTICSEARCH, AND BUILD THE CURL COMMAND OUT
+    ELASTIC_POD=$(kubectl ${KUBE_OPTS} get pods -l role=elasticsearch --no-headers | head -1 | awk '{print $1}') || true
+    
+    if [ ! -z ${ELASTIC_POD} ]; then
+        ELASTIC_TLS=$(kubectl ${KUBE_OPTS} exec -it ${ELASTIC_POD} -c elasticsearch -- env | grep -i ELASTICSEARCH_TLS_ENCRYPTION) || true
+        
+        if [[ ${ELASTIC_TLS} == *"ELASTICSEARCH_TLS_ENCRYPTION=true"* ]]; then
+            ELASTIC_CURL='curl -s --cacert /usr/share/elasticsearch/config/root-ca.pem https://${ELASTICSEARCH_ADMINUSER}:${ELASTICSEARCH_ADMIN_PASSWORD}'
+        else
+            ELASTIC_CURL='curl -s -k http://$(hostname)'
+        fi
+        
+        for pod in $(kubectl ${KUBE_OPTS} get pods -l role=elasticsearch | grep -v "NAME" | awk '{print $1}')
+        do
+            mkdir -p ${LOG_DIR}/elasticsearch/${pod}
+            kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/health" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_health.log
+        
+            kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/indices" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_indices.log
+        
+            kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cat/nodes?v" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_nodes.log
+        
+            kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- /bin/bash -c "${ELASTIC_CURL}@sysdigcloud-elasticsearch:9200/_cluster/allocation/explain?pretty" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_index_allocation.log
+    
+            echo "Fetching ElasticSearch SSL Certificate Expiration Dates"
+            kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- openssl x509 -in /usr/share/elasticsearch/config/node.pem -noout -enddate | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_node_pem_expiration.log
+            kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- openssl x509 -in /usr/share/elasticsearch/config/admin.pem -noout -enddate | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_admin_pem_expiration.log
+            kubectl ${KUBE_OPTS} exec -it ${pod}  -c elasticsearch -- openssl x509 -in /usr/share/elasticsearch/config/root-ca.pem -noout -enddate | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_root_ca_pem_expiration.log
+        
+            echo "Checking Used Elasticsearch Storage - ${pod}"
+            mountpath=$(kubectl ${KUBE_OPTS} get sts sysdigcloud-elasticsearch -ojsonpath='{.spec.template.spec.containers[].volumeMounts[?(@.name == "data")].mountPath}')
+            if [ ! -z $mountpath ]; then
+               kubectl ${KUBE_OPTS} exec -it ${pod} -c elasticsearch -- du -ch ${mountpath} | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
+           else
+              printf "Error getting ElasticSearch ${pod} mount path\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
+           fi
+        done
+    else
+        echo "Unable to fetch ElasticSearch pod to gather health info!"
+    fi
+    
+    
+    
+    # Fetch Cassandra storage info
+    for pod in $(kubectl ${KUBE_OPTS} get pods -l role=cassandra  | grep -v "NAME" | awk '{print $1}')
+    do
+        echo "Checking Used Cassandra Storage - ${pod}"
+        mkdir -p ${LOG_DIR}/cassandra/${pod}
+        printf "${pod}\n" | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log
+        mountpath=$(kubectl ${KUBE_OPTS} get sts sysdigcloud-cassandra -ojsonpath='{.spec.template.spec.containers[].volumeMounts[?(@.name == "data")].mountPath}')
         if [ ! -z $mountpath ]; then
-           kubectl ${KUBE_OPTS} exec -it ${pod} -c elasticsearch -- du -ch ${mountpath} | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
+            kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- du -ch ${mountpath} | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log || true
        else
-          printf "Error getting ElasticSearch ${pod} mount path\n" | tee -a ${LOG_DIR}/elasticsearch/${pod}/elasticsearch_storage.log
+          printf "Error getting Cassandra ${pod} mount path\n" | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log
        fi
     done
-else
-    echo "Unable to fetch ElasticSearch pod to gather health info!"
-fi
+    
+    # Fetch postgresql storage info
+    for pod in $(kubectl ${KUBE_OPTS} get pods -l role=postgresql  | grep -v "NAME" | awk '{print $1}')
+    do
+        echo "Checking Used PostgreSQL Storage - ${pod}"
+        mkdir -p ${LOG_DIR}/postgresql/${pod}
+        printf "${pod}\n" | tee -a ${LOG_DIR}/postgresql/${pod}/postgresql_storage.log
+        kubectl ${KUBE_OPTS} exec -it ${pod} -c postgresql -- du -ch /var/lib/postgresql | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/postgresql/${pod}/postgresql_storage.log || true
+    done
+    
+    # Fetch mysql storage info
+    for pod in $(kubectl ${KUBE_OPTS} get pods -l role=mysql  | grep -v "NAME" | awk '{print $1}')
+    do
+        echo "Checking Used MySQL Storage - ${pod}"
+        mkdir -p ${LOG_DIR}/mysql/${pod}
+        printf "${pod}\n" | tee -a ${LOG_DIR}/mysql/${pod}/mysql_storage.log
+        kubectl ${KUBE_OPTS} exec -it ${pod} -c mysql -- du -ch /var/lib/mysql | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/mysql/${pod}/mysql_storage.log || true
+    done
+    
+    # Collect the sysdigcloud-config configmap, and write to the log directory
+    echo "Fetching the sysdigcloud-config ConfigMap"
+    kubectl ${KUBE_OPTS} get configmap sysdigcloud-config -o yaml | grep -v password | grep -v apiVersion > ${LOG_DIR}/config.yaml || true
+    
+    # Generate the bundle name, create a tarball, and remove the temp log directory
+    BUNDLE_NAME=$(date +%s)_sysdig_cloud_support_bundle.tgz
+    echo "Creating the ${BUNDLE_NAME} archive now"
+    tar czf ${BUNDLE_NAME} ${LOG_DIR}
+    rm -rf ${LOG_DIR}
+    
+    echo "Support bundle generated:" ${BUNDLE_NAME}
+}
 
-
-
-# Fetch Cassandra storage info
-for pod in $(kubectl ${KUBE_OPTS} get pods -l role=cassandra  | grep -v "NAME" | awk '{print $1}')
-do
-    echo "Checking Used Cassandra Storage - ${pod}"
-    mkdir -p ${LOG_DIR}/cassandra/${pod}
-    printf "${pod}\n" | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log
-    mountpath=$(kubectl ${KUBE_OPTS} get sts sysdigcloud-cassandra -ojsonpath='{.spec.template.spec.containers[].volumeMounts[?(@.name == "data")].mountPath}')
-    if [ ! -z $mountpath ]; then
-        kubectl ${KUBE_OPTS} exec -it ${pod} -c cassandra -- du -ch ${mountpath} | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log || true
-   else
-      printf "Error getting Cassandra ${pod} mount path\n" | tee -a ${LOG_DIR}/cassandra/${pod}/cassandra_storage.log
-   fi
-done
-
-# Fetch postgresql storage info
-for pod in $(kubectl ${KUBE_OPTS} get pods -l role=postgresql  | grep -v "NAME" | awk '{print $1}')
-do
-    echo "Checking Used PostgreSQL Storage - ${pod}"
-    mkdir -p ${LOG_DIR}/postgresql/${pod}
-    printf "${pod}\n" | tee -a ${LOG_DIR}/postgresql/${pod}/postgresql_storage.log
-    kubectl ${KUBE_OPTS} exec -it ${pod} -c postgresql -- du -ch /var/lib/postgresql | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/postgresql/${pod}/postgresql_storage.log || true
-done
-
-# Fetch mysql storage info
-for pod in $(kubectl ${KUBE_OPTS} get pods -l role=mysql  | grep -v "NAME" | awk '{print $1}')
-do
-    echo "Checking Used MySQL Storage - ${pod}"
-    mkdir -p ${LOG_DIR}/mysql/${pod}
-    printf "${pod}\n" | tee -a ${LOG_DIR}/mysql/${pod}/mysql_storage.log
-    kubectl ${KUBE_OPTS} exec -it ${pod} -c mysql -- du -ch /var/lib/mysql | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' | tee -a ${LOG_DIR}/mysql/${pod}/mysql_storage.log || true
-done
-
-# Collect the sysdigcloud-config configmap, and write to the log directory
-echo "Fetching the sysdigcloud-config ConfigMap"
-kubectl ${KUBE_OPTS} get configmap sysdigcloud-config -o yaml | grep -v password | grep -v apiVersion > ${LOG_DIR}/config.yaml || true
-
-# Generate the bundle name, create a tarball, and remove the temp log directory
-BUNDLE_NAME=$(date +%s)_sysdig_cloud_support_bundle.tgz
-echo "Creating the ${BUNDLE_NAME} archive now"
-tar czf ${BUNDLE_NAME} ${LOG_DIR}
-rm -rf ${LOG_DIR}
-
-echo "Support bundle generated:" ${BUNDLE_NAME}
+parse_commandline "$@"
+main

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -41,22 +41,10 @@ parse_commandline() {
                 API_KEY="$2"
                 shift
                 ;;
-            --api-key=*)
-                API_KEY="${_key##--api-key=}"
-                ;;
-            -a*)
-                API_KEY="${_key##-a}"
-                ;;
             -c|--context)
                 test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
                 CONTEXT="$2"
                 shift
-                ;;
-            --context=*)
-                CONTEXT="${_key##--context=}"
-                ;;
-            -c*)
-                CONTEXT="${_key##-c}"
                 ;;
             -d|--debug)
                 set -x
@@ -69,22 +57,10 @@ parse_commandline() {
                 LABELS="$2"
                 shift
                 ;;
-            --labels=*)
-                LABELS="${_key##--labels=}"
-                ;;
-            -l*)
-                LABELS="${_key##-l}"
-                ;;
             -s|--since)
                 test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
                 SINCE="$2"
                 shift
-                ;;
-            --since=*)
-                SINCE="${_key##--since=}"
-                ;;
-            -s*)
-                SINCE="${_key##-s}"
                 ;;
             --skip-logs)
                 SKIP_LOGS="true"


### PR DESCRIPTION
- /api/admin/customer/1/dataRetentionSettings
- metrics (syscall.count, dragent.analyzer.sr, container.count, dragent.analyzer.n_drops_buffer, dragent.analyzer.n_evts)
-  Get Agent Versions and Metric Limits data from the API to see how many metrics agents are indeed sending.
- cleaned up some variables to standardize on formatting (eg; $pod -> ${pod})
- Added mysql storage info (if it exists)
- Added ability to determine if container has **sh** or **bash** installed when we try collect logs using **tar** inside the container.
- Standardize on storage location for checks we are doing against the statefulsets.
- Add snapshotSettings API Call
- Add ElasticSearch SSL Certificate End Date Data Collection
- Add api/license Call if customer passes in API_KEY
- Refactor argument parsing 
- Add --skip-logs optional arg so we don't collect any logs from kubectl or the pods/containers
- Add "get storageclass" kubectl command
- Add "get nodes" JSON via kubectl 