### PR TITLE
in get_support_bundle assign value to error variable also in success path 

### DIFF
--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -139,7 +139,7 @@ main() {
     KUBE_OPTS="--namespace ${NAMESPACE} ${CONTEXT_OPTS}"
 
     #verify that the provided namespace exists
-    KUBE_OUTPUT=$(kubectl ${CONTEXT_OPTS} get namespace ${NAMESPACE} --no-headers >/dev/null 2>&1) && RETVAL=$? || { RETVAL=$? && error=1; }
+    KUBE_OUTPUT=$(kubectl ${CONTEXT_OPTS} get namespace ${NAMESPACE} --no-headers >/dev/null 2>&1) && RETVAL=$? && error=0 || { RETVAL=$? && error=1; }
 
     if [[ ${error} -eq 1 ]]; then
         echo "We could not determine the namespace. Please check the spelling and try again.  Return Code: ${RETVAL}"


### PR DESCRIPTION
The get_support_bundle.sh was failing in the jobs complaining about: `line 144: error: unbound variable` 
More details in this ticket: https://sysdig.atlassian.net/browse/QA-4702
We are just assigning value 0 to variable `error` as it seems that it doesn't have a default value on declaration