### PR TITLE
[get_support_bundle.sh] Add safeguard when getting containers name from pod

### DIFF
--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -198,7 +198,7 @@ main() {
         for pod in ${SYSDIGCLOUD_PODS}; do
             echo "Getting support logs for ${pod}"
             mkdir -p ${LOG_DIR}/${pod}
-            containers=$(kubectl ${KUBE_OPTS} get pod ${pod} -o json | jq -r '.spec.containers[].name')
+            containers=$(kubectl ${KUBE_OPTS} get pod ${pod} -o json | jq -r '.spec.containers[].name' || echo "")
             for container in ${containers}; do
                 kubectl ${KUBE_OPTS} logs ${pod} -c ${container} ${SINCE_OPTS} > ${LOG_DIR}/${pod}/${container}-kubectl-logs.txt || true
                 echo "Execing into ${container}"


### PR DESCRIPTION
It can happen that a pod listed in the previous steps is not present anymore when it comes its time during the for loop (CLBOs, eviction, etc.).
This causes the script to crash since it tries to access the non existen pod to retrieve the list of containers.

This commit is adding a safeguard for this kind of situation.
