### PR TITLE
[get_support_bundle.sh] Detect OS to get EPOCH time

### DIFF
--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -161,7 +161,11 @@ main() {
         curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/v2/users/light" >> ${LOG_DIR}/users.json
         curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/v2/teams/light" >> ${LOG_DIR}/teams.json
 
-        TO_EPOCH_TIME=$(gnudate -d "$(gnudate +%H):00:00" +%s)
+        if [[ $OSTYPE == 'darwin'* ]]; then
+            TO_EPOCH_TIME=$(date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s")
+        else
+            TO_EPOCH_TIME=$(gnudate -d "$(gnudate +%H):00:00" +%s)
+        fi
         FROM_EPOCH_TIME=$((TO_EPOCH_TIME-86400))
         METRICS=("syscall.count" "dragent.analyzer.sr" "container.count" "dragent.analyzer.n_drops_buffer" "dragent.analyzer.n_evts")
         DEFAULT_SEGMENT="host.hostName"

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -162,7 +162,7 @@ main() {
         curl -ks -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" "${API_URL}/api/v2/teams/light" >> ${LOG_DIR}/teams.json
 
         if [[ $OSTYPE == 'darwin'* ]]; then
-            TO_EPOCH_TIME=$(date -j -f "%a %b %d %T %Z %Y" "`date`" "+%s")
+            TO_EPOCH_TIME=$(date -jf "%H:%M:%S" $(date +%H):00:00 +%s)
         else
             TO_EPOCH_TIME=$(gnudate -d "$(gnudate +%H):00:00" +%s)
         fi

--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -83,14 +83,6 @@ parse_commandline() {
     done
 }
 
-gnudate() {
-    if hash gdate 2>/dev/null; then
-        gdate "$@"
-    else
-        date "$@"
-    fi
-}
-
 get_agent_version_metric_limits() {
 # function used to get metric JSON data for Agent versions and metric counts for each agent.
 # This is taken from the Sysdig Agent and Health Status Dashboard
@@ -164,7 +156,7 @@ main() {
         if [[ $OSTYPE == 'darwin'* ]]; then
             TO_EPOCH_TIME=$(date -jf "%H:%M:%S" $(date +%H):00:00 +%s)
         else
-            TO_EPOCH_TIME=$(gnudate -d "$(gnudate +%H):00:00" +%s)
+            TO_EPOCH_TIME=$(date -d "$(date +%H):00:00" +%s)
         fi
         FROM_EPOCH_TIME=$((TO_EPOCH_TIME-86400))
         METRICS=("syscall.count" "dragent.analyzer.sr" "container.count" "dragent.analyzer.n_drops_buffer" "dragent.analyzer.n_evts")


### PR DESCRIPTION
When users ran this script on macOS, they received an error: 'illegal option -- d' 
Added ability to detect the OS and use the correct way to get EPOCH time for that OS. Tested on MacOS.