### PR TITLE
Add support for openshift on AWS

### DIFF
--- a/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
+++ b/agent_deploy/IBMCloud-Kubernetes-Service/install-agent-k8s.sh
@@ -219,12 +219,8 @@ function install_k8s_agent {
 
     echo "* Retrieving the Cluster ID and Cluster Name"
     IKS_CLUSTER_ID=$(kubectl get cm -n kube-system cluster-info -o yaml | grep ' "cluster_id": ' | cut -d'"' -f4)
-    if [ $OPENSHIFT -eq 0 ]; then
-        CLUSTER_NAME=$(kubectl config current-context)
-        # Parse  out AWS cluster name
-        if [ $AWS -eq 1 ]; then
-            CLUSTER_NAME=$(echo $CLUSTER_NAME | cut -d'/' -f2)
-        fi
+    if [ $AWS -eq 1 ]; then
+	CLUSTER_NAME=$(echo $CLUSTER_NAME | cut -d'/' -f2 | cut -d: -f1)
     else
         # Pull the cluster name using the cluster ID using ibmcloud ks
         # since the current-context is not a user-friendly value


### PR DESCRIPTION
cluster name can be parsed out of current context for aws rosa or aws eks. The format is as follows:

rosa: 
```
[terminal]$ kubectl config current-context
default/api-abc-def-j8jd-di-openshiftapps-com:6443/some.email@site.com
```

eks:
```
[terminal]$ kubectl config current-context
arn:aws:eks:us-east-1:01234567:cluster/cluster-name
```

The PR satisfies both outputs above with:

rosa: `api-abc-def-j8jd-di-openshiftapps-com`
eks: `cluster-name`