### PR TITLE
Adding fix to prevent 'get pods' from failing

### DIFF
--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -231,7 +231,7 @@ main() {
     for pod in ${SYSDIGCLOUD_PODS}; do
         echo "Getting pod description for ${pod}"
         mkdir -p ${LOG_DIR}/${pod}
-        kubectl ${KUBE_OPTS} get pod ${pod} -o json > ${LOG_DIR}/${pod}/kubectl-describe.json
+        kubectl ${KUBE_OPTS} get pod ${pod} -o json > ${LOG_DIR}/${pod}/kubectl-describe.json || true
     done
 
     #Collect Describe Node Output


### PR DESCRIPTION
Adding in an "or true" statement to prevent the 'kubectl get pods' command from causing the script to fail.