### PR TITLE
[TSDEVOPS-51] Add configmap to object list of manifests

### DIFF
--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -254,7 +254,7 @@ main() {
 
     # Get info on deployments, statefulsets, persistentVolumeClaims, daemonsets, and ingresses
     echo "Gathering Manifest Information"
-    for object in svc deployment sts pvc daemonset ingress replicaset networkpolicy
+    for object in svc deployment sts pvc daemonset ingress replicaset networkpolicy configmap
     do
         items=$(kubectl ${KUBE_OPTS} get ${object} -o jsonpath="{.items[*]['metadata.name']}")
         mkdir -p ${LOG_DIR}/${object}


### PR DESCRIPTION
on-premise v6 we have individual configMaps per workload so we need to extract them independently for health checks/configuration validation