### PR TITLE
Add build ID to support bundle

### DIFF
--- a/support_bundle/get_support_bundle.sh
+++ b/support_bundle/get_support_bundle.sh
@@ -19,6 +19,7 @@ API_KEY=""
 SECURE_API_KEY=""
 SKIP_LOGS="false"
 ELASTIC_CURL=""
+declare -r BUILD="20240403"
 
 print_help() {
     printf 'Usage: %s [-a|--api-key <API_KEY>] [c|--context <CONTEXT>] [-d|--debug] [-l|--labels <LABELS>] [-n|--namespace <NAMESPACE>] [-s|--since <TIMEFRAME>] [--skip-logs] [-h|--help]\n' "$0"
@@ -125,6 +126,10 @@ segment_by="${2}"
 main() {
     local error
     local RETVAL
+
+    if [[ ! -z ${BUILD} ]]; then
+        echo ${BUILD} >> ${LOG_DIR}/support_bundle_version.txt
+    fi
 
     if [[ ! -z ${CONTEXT} ]]; then
         CONTEXT_OPTS="--context=${CONTEXT}"


### PR DESCRIPTION
This PR aims to add a simple build number that we can use to identify which version of the support bundle is being used. I'm proposing that we use a build ID that contains the date of the PR in the format of yyyymmdd. We will need to remember to update this when changes are made. If there is a better way to do this, please let me know.