### PR TITLE
CSI-1006: Add sysdig-log-collector tool

### DIFF
--- a/sysdig-log-collector/README.md
+++ b/sysdig-log-collector/README.md
@@ -1,0 +1,211 @@
+# Sysdig Log Collector (SLC)
+
+A single Bash script that collects a **Sysdig support bundle** from a Kubernetes
+cluster and (optionally) uploads it to Sysdig Support. It works for **Agent /
+Shield** on any cluster (SaaS or on-prem) and for the **on-prem Platform**
+backend.
+
+It is **read-only** on the cluster — it never creates, modifies, or deletes
+cluster resources. It only writes a local archive, and logs everything it does
+to the bundle's `activity.log`.
+
+## Requirements
+
+- `bash` 3.2+ (works with the default macOS bash and any Linux bash)
+- `kubectl` (or `oc` for OpenShift) on your `PATH`, configured to reach the cluster
+- Read access to the target namespace(s)
+
+## Download & install
+
+Download the script and install it onto your `PATH`:
+
+```bash
+# 1. Download the script
+curl -fsSL "<download-url>" -o sysdig-log-collector
+
+# 2. Install onto your PATH
+sudo install -m 0555 sysdig-log-collector /usr/local/bin/sysdig-log-collector
+
+# 3. Run it
+sysdig-log-collector --help
+```
+
+Prefer not to install system-wide? Run it straight from the download directory,
+or install without `sudo` to a `PATH` directory you own:
+
+```bash
+# Run in place from the download directory
+chmod +x sysdig-log-collector
+./sysdig-log-collector --help
+
+# Or install to a user PATH directory (no sudo)
+install -m 0555 sysdig-log-collector ~/.local/bin/
+```
+
+**Notes**
+- The filename/extension doesn't matter to Bash; the script has no extension by
+  design.
+- **Windows users:** save with **Unix (LF) line endings**. CRLF line endings will
+  break the script. (Most users collecting Kubernetes bundles run on Linux/macOS.)
+- The examples below use placeholders like `<sysdig-agent>` and `<sysdigcloud>` —
+  replace them with your actual namespace names.
+
+## Upgrading
+
+To upgrade, re-download the latest script and re-run the install — it overwrites
+the existing copy:
+
+```bash
+curl -fsSL "<download-url>" -o sysdig-log-collector
+sudo install -m 0555 sysdig-log-collector /usr/local/bin/sysdig-log-collector
+```
+
+## Quick start
+
+```bash
+# Agent bundle — every Sysdig pod in the namespace (most common)
+sysdig-log-collector collect agent -n <sysdig-agent>
+
+# On-prem Platform bundle — everything in the platform namespace
+sysdig-log-collector collect platform -n <sysdigcloud>
+
+# Interactive, menu-driven (prompts for everything)
+sysdig-log-collector -i
+```
+
+The archive is written to the current directory unless you pass `-o <dir>`.
+
+**Tip:** enable shell tab-completion (bash/zsh auto-detected) for command, flag,
+and live-namespace completion, then restart your shell:
+
+```bash
+sysdig-log-collector autocomplete enable
+```
+
+Disable anytime with `sysdig-log-collector autocomplete disable`.
+
+## Choosing what to collect (scope)
+
+Pick **one** scope per run; the default is "everything in the namespace".
+
+| You want… | Use |
+|---|---|
+| All Sysdig pods in a namespace | *(default)* `-n <ns>` |
+| Only certain component types | `--components <list>` |
+| Only specific pods | `--pods <list>` |
+| Several namespaces at once (agent only) | `--namespaces <entries>` |
+
+Component names depend on which chart is installed: the **Shield** chart exposes
+`shield` and `cluster-shield`; the **sysdig-deploy** chart exposes `agent`,
+`node-analyzer`, `kspm-collector`, and more; the standalone **agent** sub-chart
+exposes `agent`. Discover the exact names with `list` (below).
+
+```bash
+# Shield chart
+sysdig-log-collector collect agent -n <sysdig-agent> --components=cluster-shield
+
+# sysdig-deploy chart
+sysdig-log-collector collect agent -n <sysdig-agent> --components=node-analyzer,kspm-collector
+
+# agent sub-chart — specific pods
+sysdig-log-collector collect agent -n <sysdig-agent> --pods=sysdig-agent-abcde,sysdig-agent-fghij
+```
+
+For long lists, put one name per line in a file (no blank lines) and use
+`--from-file` with `--pods` or `--components`:
+
+```bash
+sysdig-log-collector collect agent -n <sysdig-agent> --pods --from-file=pods.txt
+```
+
+## Discover names first: `list`
+
+```bash
+sysdig-log-collector list agent components -n <sysdig-agent>
+sysdig-log-collector list agent pods -n <sysdig-agent>
+sysdig-log-collector list platform components -n <sysdigcloud>
+```
+
+## Uploading to Sysdig Support
+
+Sysdig Support provides a **presigned S3 URL**. Always wrap it in **single quotes**
+(it contains `&` and `=`).
+
+```bash
+# Collect and upload in one step
+sysdig-log-collector collect agent -n <sysdig-agent> --url='https://...amazonaws.com/...x-id=PutObject'
+
+# Upload an archive you already have
+sysdig-log-collector upload -f bundle.tgz --url='https://...x-id=PutObject'
+
+# Verify a URL without uploading (presigned URLs expire)
+sysdig-log-collector upload -f bundle.tgz --url='https://...PutObject' --dry-run
+```
+
+Add `--no-save` to delete the local copy after a successful upload.
+
+## Common options
+
+| Flag | Meaning |
+|---|---|
+| `-n, --namespace <ns>` | Target namespace |
+| `-c, --context <name>` | kubectl context (defaults to current-context) |
+| `-o, --output-dir <path>` | Where to write the archive (default: current dir) |
+| `-j, --max-jobs <N>` | Parallel collector workers, 1–16 (default 4) |
+| `-u, --url <url>` | Presigned S3 PUT URL to upload to |
+
+Platform-only: `--healthcheck` (skip per-container logs), `--since=<dur>` (log
+window), `--api-key` / `--secure-api-key` (optional API data), `--local-api`
+(reach the API via port-forward).
+
+Run `sysdig-log-collector <command> --help` for the full flag list.
+
+## Version
+
+Print the Sysdig Log Collector version (useful when reporting an issue to Sysdig Support):
+
+```bash
+sysdig-log-collector version
+# Sysdig Log Collector version 1.0.1
+```
+
+The same version is shown under the banner in interactive mode (`-i`) and
+recorded in every bundle's `activity.log` header.
+
+## What gets collected (review before sharing)
+
+A bundle contains operational data from your cluster — pod **logs**, `describe`
+output, Sysdig **manifests/configmaps**, node info, and (for platform) datastore
+telemetry and optional API data. It does **not** include your API keys (entered
+hidden, validated, and wiped after the run). Everything the tool did is recorded
+in the bundle's `activity.log`. Review the archive if you have data-handling
+requirements before sending it to Support.
+
+## Safety
+
+- No Kubernetes resources are created, modified, or deleted.
+- `kubectl`/`oc` access is read-only — `get`, `describe`, `logs`, `cp`, `exec` —
+  with one exception, inside the agent pods: during **agent log collection**,
+  `exec` runs `tar` to create a temporary archive of `/opt/draios/logs`
+  (written to `/tmp/draios-logs.tgz`, or `/opt/draios/draios-logs.tgz` as a
+  fallback — the agent's own writable volume), copies it out, then removes it
+  with `rm -f`. This touches only an ephemeral file inside the pod, never a
+  Kubernetes resource.
+- Sysdig API calls are GET-only against the platform's own endpoints.
+- Before archiving the bundle, all sensitive data (access keys, datastore
+  passwords, bearer tokens, and embedded credentials in connection URLs) are
+  masked in place as `<redacted>`. This is a best-effort safeguard, not a
+  guarantee; kindly review the archive before sharing externally.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `no Sysdig components found in namespace` | Wrong namespace — confirm with `list agent components -n <ns>`. |
+| `unknown component '<x>'` | Not a valid bucket; the error prints the accepted list. |
+| `invalid --url` | URL must start with `https://`, contain `.amazonaws.com`, include `X-Amz-Signature=`, end with `x-id=PutObject` — and be single-quoted. |
+| `presigned URL expired` | Request a fresh URL from Sysdig Support. |
+| Collection is slow / heavy | Lower `-j` (e.g. `-j 2`); for platform add `--healthcheck` and/or `--since=1h`. |
+| `<pod>: file-based logs unavailable (…), fell back to kubectl logs — stdout logs only for this pod` | The in-pod `tar` step (Tier 0) couldn't run — the exec was refused — so only container stdout was collected instead of the full on-disk `draios.log`. The Sysdig image ships `tar`, so the cause is one of:<br>• **Missing RBAC** — grant `create` on `pods/exec` in the Role/ClusterRole bound to the collector's identity (a namespace Role suffices), or run from a context that already has exec.<br>• **Admission controller** (Kyverno / OPA-Gatekeeper) blocking exec — add an exec exception for the namespace.<br>The `Tier 0: cannot exec …` line in `activity.log` has the raw error, which tells you which. |
+| `Error: no logs collected for <pod> (all 3 tiers failed — …)` | The stdout fallback (Tier 3) also produced nothing. The `Reason:` in `activity.log` says which:<br>• The pod **isn't running** — confirm with `kubectl get pod <pod> -n <ns>`.<br>• Missing **`get` on `pods`/`pods/log`** — grant it on the Role/ClusterRole bound to the collector's identity.<br>• The pod has written nothing to stdout. |
+| `bad interpreter` / `\r: command not found` | The file has Windows (CRLF) line endings — re-save as LF, or run `sed -i 's/\r$//' sysdig-log-collector`. |

--- a/sysdig-log-collector/sysdig-log-collector
+++ b/sysdig-log-collector/sysdig-log-collector
@@ -1,0 +1,8241 @@
+#!/bin/bash
+
+# ─────────────────────────────────────────────
+#  Version (single source of truth)
+# ─────────────────────────────────────────────
+# SemVer. Bump on release; the git tag (vX.Y.Z) mirrors this value. Surfaced
+# by the `version` command and printed under the interactive banner.
+SLC_VERSION="1.0.1"
+
+function display_banner() {
+  local term_width
+  term_width=$(tput cols 2>/dev/null || echo 80)
+
+  local title="Sysdig Log Collector"
+  local title_len=${#title}
+  local title_pad=$(( (term_width - title_len) / 2 ))
+  [[ $title_pad -lt 0 ]] && title_pad=0
+  printf "\n%${title_pad}s\033[1;36m%s\033[0m\n" "" "$title"
+
+  local label="Secure Every Second!"
+  local label_len=${#label}
+  local label_pad=$(( (term_width - label_len) / 2 ))
+  [[ $label_pad -lt 0 ]] && label_pad=0
+  printf "%${label_pad}s\033[1;37m%s\033[0m\n" "" "$label"
+
+  # Version badge under the logo, dim so it reads as metadata without competing
+  # with the title. Centered like the lines above; SLC_VERSION is the single
+  # source of truth (\033[2m = dim, matching the interactive _C_DIM palette).
+  local ver="v${SLC_VERSION}"
+  local ver_len=${#ver}
+  local ver_pad=$(( (term_width - ver_len) / 2 ))
+  [[ $ver_pad -lt 0 ]] && ver_pad=0
+  printf "%${ver_pad}s\033[2m%s\033[0m\n\n" "" "$ver"
+}
+
+# ─────────────────────────────────────────────
+#  Colors
+# ─────────────────────────────────────────────
+
+# ANSI color codes for stdout messages. Disabled automatically when stdout
+# isn't a TTY (piped to a file, CI, redirected) so we don't pollute non-
+# interactive output with escape sequences. Use $'...' so the variables
+# carry the actual ESC byte; concatenating "${VAR}TEXT${RESET}" inside a
+# printf format string then yields proper color sequences.
+if [[ -t 1 ]]; then
+  _C_OK=$'\033[0;32m'     # green
+  _C_WARN=$'\033[0;33m'   # yellow
+  _C_ERR=$'\033[0;31m'    # red
+  _C_KEY=$'\033[1;36m'    # bold cyan — highlights interactive shortcut keys
+  _C_DIM=$'\033[2m'       # dim — de-emphasizes status-line labels
+  _C_BOLD=$'\033[1m'      # bold (no color) — section/question headers
+  _C_RESET=$'\033[0m'
+else
+  _C_OK=''
+  _C_WARN=''
+  _C_ERR=''
+  _C_KEY=''
+  _C_DIM=''
+  _C_BOLD=''
+  _C_RESET=''
+fi
+
+# ─────────────────────────────────────────────
+#  Variables & Logging
+# ─────────────────────────────────────────────
+
+namespace=""
+podName=""
+k8sCmd=""
+DEPLOYMENT_TYPE=""
+SYSDIG_PRODUCT=""
+K8S_CONTEXT=""
+BASE_K8S_CMD=""
+UPLOAD_TO_S3=false
+KEEP_LOCAL=false
+SYSDIG_UPLOAD_URL=""
+DEST_DIR=""
+SYSDIG_SUPPORT_DIR="sysdig-support"
+ACTIVITY_LOG=""
+LOG_PHASE="bootstrap"          # bootstrap | run-prep | run-active
+SESSION_BOOTSTRAP_LINES=()     # events buffered during initVar + pre-menu setup + change-settings actions; replayed into every run's log
+RUN_BUFFER_LINES=()            # events buffered between collection-option menu choice and prompt_output_path; replayed into the new run's log
+ARCHIVE_NAME=""
+FAILED_PODS=()
+podNames=()
+PLATFORM_LOG_DIR=""
+PLATFORM_FAIL_DIR=""           # Phase 2: dir under PLATFORM_LOG_DIR where _collect_container_logs touches marker files for containers whose support-files.tgz failed after PLATFORM_TAR_RETRY attempts; replayed into a yellow summary at end of run, then removed before createPlatformArchive.
+BACKEND_VERSION=""
+BACKEND_VERSION_TAG=""
+SYSDIGCLOUD_PODS=()
+MONITOR_API_KEY=""
+SECURE_API_KEY=""
+API_URL=""
+API_PORTFORWARD_PID=""
+REQUESTING_TEAM=""
+
+# Parallel execution config (matches legacy v2 defaults; cap 16 protects the
+# kube-apiserver from concurrent-request floods).
+MAX_JOBS_MIN=1
+MAX_JOBS_MAX=16
+MAX_JOBS_DEFAULT=4
+MAX_JOBS="${MAX_JOBS:-$MAX_JOBS_DEFAULT}"
+BACKGROUND_PIDS=()
+BACKGROUND_FAIL=0
+
+# Manual platform-collection knobs (option 5). Empty/false defaults =
+# behave identically to option 4 (automated).
+MANUAL_COMPONENTS=""    # comma-joined component names picked by the user (display + log)
+MANUAL_SCOPE_MODE=""    # "all" | "components" | "pods" | "health" — set by select_platform_components
+MANUAL_PODS_FILTER=()   # if non-empty, restricts SYSDIGCLOUD_PODS to these names
+MANUAL_SINCE=""         # raw user value, e.g. "1h"; empty = full logs
+MANUAL_SINCE_OPTS=""    # derived: "--since=1h" or empty
+MANUAL_SKIP_LOGS=false
+MANUAL_DEBUG=false
+
+SYSDIG_KSPM_IMAGE_NAME="kspm-analyzer"
+SYSDIG_HS_IMAGE_NAME="host-scanner"
+SYSDIG_RS_IMAGE_NAME="runtime-scanner"
+SYSDIG_HA_IMAGE_NAME="host-analyzer"
+SYSDIG_IA_IMAGE_NAME="node-image-analyzer"
+SYSDIG_BR_IMAGE_NAME="compliance-benchmark-runner"
+SYSDIG_EC_IMAGE_NAME="eveclient-api"
+SYSDIG_KSPMA_CONTAINER_NAME="sysdig-kspm-analyzer"
+SYSDIG_HS_CONTAINER_NAME="sysdig-host-scanner"
+SYSDIG_RS_CONTAINER_NAME="sysdig-runtime-scanner"
+SYSDIG_HA_CONTAINER_NAME="sysdig-host-analyzer"
+SYSDIG_IA_CONTAINER_NAME="sysdig-image-analyzer"
+SYSDIG_BR_CONTAINER_NAME="sysdig-benchmark-runner"
+SYSDIG_EC_CONTAINER_NAME="sysdig-eve-connector"
+SYSDIG_AGENT_CONTAINER_NAME="sysdig"
+SYSDIG_NA_IMAGE_NAME="${SYSDIG_KSPM_IMAGE_NAME}|${SYSDIG_HS_IMAGE_NAME}|${SYSDIG_RS_IMAGE_NAME}|${SYSDIG_HA_IMAGE_NAME}|${SYSDIG_IA_IMAGE_NAME}|${SYSDIG_BR_IMAGE_NAME}|${SYSDIG_EC_IMAGE_NAME}"
+SYSDIG_AGENT_IMAGE_NAME="agent-slim|agent"
+SYSDIG_CS_IMAGE_NAME="cluster-shield"
+SYSDIG_KSPM_COLLECTOR_IMAGE_NAME="kspm-collector"
+SYSDIG_AC_IMAGE_NAME="admission-controller|secure-admission-controller|inline-scan-service"
+SYSDIG_CSCAN_IMAGE_NAME="runtime-status-integrator|image-sbom-extractor"
+SYSDIG_RR_IMAGE_NAME="rapid-response-host-component"
+SYSDIG_AC_CONTAINER_NAMES=("admission-controller" "kspm-admission-controller" "inline-scanner")
+SYSDIG_CSCAN_CONTAINER_NAMES=("rsi" "ise")
+SYSDIG_RR_CONTAINER_NAME="rapid-response"
+SYSDIG_CS_DIR="cluster-shield"
+AGENT_LOG_DIR="opt/draios/logs/"
+AGENT_DRAGENT_DIR="opt/draios/etc/kubernetes/config/..data"
+IS_AIRGAPPED=false
+SYSDIG_CS_ENDPOINT="healthz"
+SYSDIG_CS_MONITORING_PORT=8080
+SYSDIG_AGENT_IMMUTABLE_LABEL="app.kubernetes.io/name"
+SYSDIG_KSPM_COLLECTOR_IMMUTABLE_LABEL="app.kubernetes.io/instance"
+SYSDIG_NA_IMMUTABLE_LABEL="app.kubernetes.io/instance"
+SYSDIG_SHIELD_IMMUTABLE_LABEL="sysdig/component"
+# Known agent-side component buckets, used to validate `collect agent --components`
+# (single- and multi-namespace). Single source of truth for the accepted names.
+AGENT_COMPONENT_BUCKETS="agent shield cluster-shield node-analyzer kspm-collector admission-controller cluster-scanner rapid-response"
+SYSDIG_DS_NAME=""
+SYSDIG_DEPLOY_NAME=""
+JSONPATH_SEARCH="{range .items[*]}{.metadata.name}{'\t'}{.spec.template.spec.containers[0].image}{'\t'}{.metadata.labels.app\.kubernetes\.io/instance}{'\t'}{.metadata.labels.sysdig/component}{'\n'}{end}"
+AGENT_CP_RETRY=5
+PLATFORM_TAR_RETRY=5
+DS_FIND_ATTEMPT_RETRY=1
+DP_FIND_ATTEMPT_RETRY=1
+DS_COUNTER_RETRY=0
+DP_COUNTER_RETRY=0
+ERR_RC_TAR=8
+ERR_RC_CURL=9
+SYSDIG_AGENT_APP_NAME=""
+SYSDIG_NA_APP_NAME=""
+SYSDIG_CS_APP_NAME=""
+SYSDIG_KSPM_COLLECTOR_APP_NAME=""
+SYSDIG_AC_APP_NAME=""
+SYSDIG_CSCAN_APP_NAME=""
+SYSDIG_RR_APP_NAME=""
+SYSDIG_AGENT_PREFIX=""
+SYSDIG_NA_PREFIX=""
+SYSDIG_CS_PREFIX=""
+SYSDIG_KSPMC_PREFIX=""
+SYSDIG_AC_PREFIX=""
+SYSDIG_CSCAN_PREFIX=""
+SYSDIG_RR_PREFIX=""
+SYSDIG_INSTANCE_LABELS=""    # comma-joined distinct app.kubernetes.io/instance values discovered in the current namespace; consumed by _kubectl_get_sysdig_filtered to scope cm/ds/deploy collection
+SYSDIG_AGENT_IS_SHIELD_HOST=0    # 1 when the discovered "agent" workload is actually the new cluster-shield host DaemonSet (image agent-slim + label sysdig/component=host). Causes the agent bucket to be reported as "shield" and its logs to land under logs/shield/ instead of logs/agent/.
+CS_POD_IP=""
+
+function log_activity() {
+  local LINE
+  LINE="$(date '+%Y-%m-%d %H:%M:%S') | $1"
+  case "$LOG_PHASE" in
+    bootstrap)  SESSION_BOOTSTRAP_LINES+=("$LINE") ;;
+    run-prep)   RUN_BUFFER_LINES+=("$LINE") ;;
+    run-active) [[ -n "$ACTIVITY_LOG" ]] && echo "$LINE" >> "$ACTIVITY_LOG" ;;
+  esac
+}
+
+# Validate MAX_JOBS at startup (rejects non-integers and out-of-range values).
+function _validate_max_jobs() {
+  if ! [[ "$MAX_JOBS" =~ ^[0-9]+$ ]]; then
+    printf "${_C_ERR}Error: MAX_JOBS must be a positive integer (got: '%s'). Using default of %d.${_C_RESET}\n" "$MAX_JOBS" "$MAX_JOBS_DEFAULT" >&2
+    MAX_JOBS=$MAX_JOBS_DEFAULT
+    return
+  fi
+  if (( MAX_JOBS < MAX_JOBS_MIN || MAX_JOBS > MAX_JOBS_MAX )); then
+    printf "${_C_ERR}Error: MAX_JOBS must be between %d and %d (got: %s). Using default of %d.${_C_RESET}\n" "$MAX_JOBS_MIN" "$MAX_JOBS_MAX" "$MAX_JOBS" "$MAX_JOBS_DEFAULT" >&2
+    MAX_JOBS=$MAX_JOBS_DEFAULT
+  fi
+}
+_validate_max_jobs
+
+# Run a function as a background job. stdout/stderr are captured to per-job
+# files so parallel workers don't interleave on the terminal. Args after the
+# jobname are the command + its args (no eval).
+#
+# Path policy depends on phase (detected by whether PLATFORM_LOG_DIR is set):
+#   Phase 2 (PLATFORM_LOG_DIR set): $PLATFORM_LOG_DIR/_background_jobs/
+#     The .out files there carry real artifacts (cassandra-stats, postgres
+#     dumps, neo4j queries, ...) and ship in the final bundle.
+#   Phase 1 (PLATFORM_LOG_DIR empty): $DEST_DIR/$SYSDIG_SUPPORT_DIR/.bg/
+#     The .out files are streaming chatter that's replayed to the user and
+#     already mirrored in activity.log; the dir is transient and removed
+#     after the streaming helper finishes. Hidden-dotted so it doesn't
+#     clutter the user's output folder during a run.
+function run_bg() {
+  local jobname="$1"
+  shift
+  local bg_log_dir
+  if [[ -n "$PLATFORM_LOG_DIR" ]]; then
+    bg_log_dir="$PLATFORM_LOG_DIR/_background_jobs"
+  else
+    bg_log_dir="$DEST_DIR/$SYSDIG_SUPPORT_DIR/.bg"
+  fi
+  mkdir -p "$bg_log_dir"
+  # stdout -> .out and stderr -> .err so Phase 2's per-job artifacts are
+  # preserved and ship in the bundle. wait_all reaps PIDs and surfaces non-zero
+  # exit codes via BACKGROUND_FAIL.
+  ( "$@" > "$bg_log_dir/${jobname}.out" 2> "$bg_log_dir/${jobname}.err" ) &
+  BACKGROUND_PIDS+=($!)
+}
+
+# Phase 1 variant of run_bg: the worker's stdout passes through to the parent
+# terminal in real time instead of being buffered to .out. Each printf in the
+# worker shows up the instant it happens, the same way activity.log fills in
+# real time. Stderr is still captured to .err so kubectl/tar's benign warnings
+# stay off the terminal. Phase 1 only — Phase 2 keeps run_bg because its .out
+# files are real artifacts that ship in the bundle.
+function run_bg_inline() {
+  local jobname="$1"
+  shift
+  local bg_log_dir="$DEST_DIR/$SYSDIG_SUPPORT_DIR/.bg"
+  mkdir -p "$bg_log_dir"
+  ( "$@" 2> "$bg_log_dir/${jobname}.err" ) &
+  BACKGROUND_PIDS+=($!)
+}
+
+# Block until concurrent job count drops below MAX_JOBS. Polling only — do not
+# wait -n here, which can confuse PID lifecycle tracking in wait_all.
+function throttle() {
+  while [[ $(jobs -pr | wc -l) -ge $MAX_JOBS ]]; do
+    sleep 0.1
+  done
+}
+
+# Wait for all tracked background jobs. Sets BACKGROUND_FAIL=1 if any job
+# returned non-zero. Clears BACKGROUND_PIDS for the next phase. Per-job
+# .out/.err files are intentionally retained for the tarball.
+function wait_all() {
+  local pid rc
+  for pid in "${BACKGROUND_PIDS[@]}"; do
+    if wait "$pid"; then
+      :
+    else
+      rc=$?
+      BACKGROUND_FAIL=1
+      log_activity "Background job (PID $pid) failed with exit code $rc."
+    fi
+  done
+  BACKGROUND_PIDS=()
+}
+
+# Strict y/n prompt. Repeats until the user enters y, Y, n, or N.
+# Empty input is rejected (no implicit default).
+# Args: prompt text (will have " [y/n]: " appended).
+# Returns 0 on yes, 1 on no.
+function prompt_yn() {
+  local _prompt="$1"
+  local _ans=""
+  while [[ ! "$_ans" =~ ^[YyNn]$ ]]; do
+    printf "%s [y/n]: " "$_prompt"
+    read -r _ans
+    [[ ! "$_ans" =~ ^[YyNn]$ ]] && printf "  Please enter y or n.\n"
+  done
+  [[ "$_ans" =~ ^[Yy]$ ]]
+}
+
+# ─────────────────────────────────────────────
+#  Disclaimer
+# ─────────────────────────────────────────────
+
+function disclaimer() {
+  log_activity "Displayed disclaimer to user."
+  printf "\n  ── ${_C_KEY}Purpose${_C_RESET} ──\n"
+  printf "  Sysdig Log Collector collects diagnostics data for:\n"
+  printf "    • Sysdig agent side (agent, cluster-shield, node-analyzer,\n"
+  printf "      kspm-collector, admission-controller, cluster-scanner,\n"
+  printf "      rapid-response, host-shield) deployed via Helm charts.\n"
+  printf "    • Sysdig on-prem Platform (sysdigcloud-api, Cassandra,\n"
+  printf "      Elasticsearch, Postgres, Kafka, Zookeeper, Neo4j) plus\n"
+  printf "      optional API-backed data (license, settings, users /\n"
+  printf "      teams / SSO, alerts, metrics, scanning results).\n"
+  printf "\n  ── ${_C_KEY}Safety${_C_RESET} ──\n"
+  printf "    • No Kubernetes resources are created, modified, or deleted.\n"
+  printf "    • kubectl/oc access is read-only: get, describe, logs, cp,\n"
+  printf "      exec. One exception, inside the agent pods: agent log\n"
+  printf "      collection uses exec + tar to write a temporary archive\n"
+  printf "      (/tmp/draios-logs.tgz, or /opt/draios/draios-logs.tgz as\n"
+  printf "      a fallback — the agent's own writable volume), copies it\n"
+  printf "      out, then removes it with rm -f. This touches only an\n"
+  printf "      ephemeral file inside the pod, never a Kubernetes resource.\n"
+  printf "    • Sysdig API calls are GET-only against the platform's\n"
+  printf "      own endpoints.\n"
+  printf "    • Activity is logged to activity.log for transparency.\n"
+  printf "\n  ── ${_C_KEY}Privacy${_C_RESET} ──\n"
+  printf "  Collected data may contain hostnames, IPs, container images,\n"
+  printf "  application output, customer settings, users / teams, SSO\n"
+  printf "  configuration, license data, and metric series.\n"
+  printf "    • API keys use hidden input, are validated up-front, and\n"
+  printf "      wiped from memory after the run — never written to the\n"
+  printf "      archive.\n"
+  printf "    • Before archiving the bundle, all sensitive data (access\n"
+  printf "      keys, datastore passwords, bearer tokens, and embedded\n"
+  printf "      credentials in connection URLs) are masked in place as\n"
+  printf "      <redacted>. This is a best-effort safeguard, not a\n"
+  printf "      guarantee.\n"
+  printf "    • Review the archive before sharing externally and apply\n"
+  printf "      your organization's data-handling policies.\n"
+  printf "\n  ── ${_C_KEY}Requirements${_C_RESET} ──\n"
+  printf "    • kubectl or oc available in PATH.\n"
+  printf "    • Read access to the target namespace(s).\n"
+  printf "    • For on-prem platform collection: kubectl exec on platform\n"
+  printf "      pods (Cassandra, Elasticsearch, etc.) and either direct\n"
+  printf "      network reachability to the Sysdig API URL, or permission\n"
+  printf "      to kubectl port-forward sysdigcloud-api.\n"
+  printf "    • For Professional Services collection: a Monitor and/or\n"
+  printf "      Secure SuperUser API key (depending on product mode).\n"
+  printf "    • Disk space proportional to the number of Sysdig pods.\n"
+  printf "    • For the upload option, the file must be an archive\n"
+  printf "      (.tar.gz, .tgz, .tar.bz2, .tbz, .tbz2, .tar.xz, .txz,\n"
+  printf "      .tar, .zip, .7z).\n"
+  printf "\n  ── ${_C_KEY}Navigation${_C_RESET} ──\n"
+  printf "    • Number keys select options; multi-select uses spaces\n"
+  printf "      (e.g. 1 3 5).\n"
+  printf "    • Each menu prints its own commands; y/n prompts need an\n"
+  printf "      explicit answer (no implicit defaults).\n"
+  printf "\n  Press Enter to continue.\n"
+  read -r go
+  log_activity "User confirmed disclaimer and continued."
+  clear
+  display_banner
+}
+
+# Ask how the customer consumes Sysdig. The on-prem path enables two extra
+# main-menu options that target the Sysdig platform components themselves.
+function select_deployment_type() {
+  printf "\n  ${_C_BOLD}How do you use the Sysdig platform?${_C_RESET}\n"
+  printf "    ${_C_KEY}[1]${_C_RESET} SaaS\n"
+  printf "    ${_C_KEY}[2]${_C_RESET} On-premises\n"
+  while true; do
+    printf "\n  >> Select [1-2]: "
+    read -r dt_choice
+    case "$dt_choice" in
+      1) DEPLOYMENT_TYPE="saas"; break ;;
+      2) DEPLOYMENT_TYPE="onprem"; break ;;
+      *) printf "  ${_C_WARN}Please select 1 or 2.${_C_RESET}\n" ;;
+    esac
+  done
+  log_activity "Deployment type selected: $DEPLOYMENT_TYPE"
+}
+
+# Ask which Sysdig product the customer uses. Only invoked when on-prem mode
+# is selected. Determines which API endpoints option 4/5 will hit and which
+# API keys the user will be prompted for.
+function select_sysdig_product() {
+  printf "\n  ${_C_BOLD}Which Sysdig product are you using?${_C_RESET}\n"
+  printf "    ${_C_KEY}[1]${_C_RESET} Monitor\n"
+  printf "    ${_C_KEY}[2]${_C_RESET} Secure\n"
+  printf "    ${_C_KEY}[3]${_C_RESET} Platform   ${_C_DIM}(Monitor + Secure)${_C_RESET}\n"
+  while true; do
+    printf "\n  >> Select [1-3]: "
+    read -r prod_choice
+    case "$prod_choice" in
+      1) SYSDIG_PRODUCT="monitor";  break ;;
+      2) SYSDIG_PRODUCT="secure";   break ;;
+      3) SYSDIG_PRODUCT="platform"; break ;;
+      *) printf "  ${_C_WARN}Please select 1, 2, or 3.${_C_RESET}\n" ;;
+    esac
+  done
+  log_activity "Sysdig product selected: $SYSDIG_PRODUCT"
+}
+
+# Prompt for the Kubernetes orchestrator CLI (kubectl/oc). Sets $k8sCmd.
+# Includes a soft warning if the selected CLI looks mismatched against the
+# current kubeconfig context (e.g., picked kubectl but cluster is OpenShift).
+# Returns 0 on selection, 1 if the user picked "Back" (caller decides what
+# "back" means — e.g., re-prompt platform mode).
+function select_orchestration_cli() {
+  while true; do
+    printf "\n  ${_C_BOLD}Which Orchestration distribution are you running?${_C_RESET}\n"
+    printf "    ${_C_KEY}[1]${_C_RESET} Kubernetes   ${_C_DIM}(kubectl)${_C_RESET}\n"
+    printf "    ${_C_KEY}[2]${_C_RESET} OpenShift    ${_C_DIM}(oc)${_C_RESET}\n"
+    printf "    ${_C_KEY}[0]${_C_RESET} Back\n"
+    local cli_choice
+    while true; do
+      printf "\n  >> Select [0-2]: "
+      read -r cli_choice
+      case "$cli_choice" in
+        0) return 1 ;;
+        1) k8sCmd="kubectl"; BASE_K8S_CMD="kubectl"; break ;;
+        2) k8sCmd="oc";      BASE_K8S_CMD="oc";      break ;;
+        *) printf "  ${_C_WARN}Please select 0, 1, or 2.${_C_RESET}\n" ;;
+      esac
+    done
+
+    # Hard check: the selected CLI must be installed and on PATH. Without this,
+    # every downstream command would silently fail and produce an empty archive.
+    if ! command -v "$k8sCmd" >/dev/null 2>&1; then
+      printf "\n  ${_C_ERR}Error: '%s' is not installed or not in PATH.${_C_RESET}\n" "$k8sCmd"
+      printf "  Install it and try again, or pick the other CLI.\n"
+      log_activity "Selected CLI '$k8sCmd' not found in PATH."
+      continue
+    fi
+
+    # Soft check: probe the cluster for OpenShift-specific APIs.
+    # Use kubectl for the probe when available (it works against both K8s
+    # and OpenShift); fall back to oc only if kubectl is absent. This way
+    # the probe is independent of the user's selection, so we can still
+    # detect "user picked oc but cluster is vanilla K8s".
+    local _probe_cli=""
+    if command -v kubectl >/dev/null 2>&1; then
+      _probe_cli="kubectl"
+    elif command -v oc >/dev/null 2>&1; then
+      _probe_cli="oc"
+    fi
+
+    if [[ -n "$_probe_cli" ]]; then
+      local _probe_output _probe_rc=1
+      _probe_output=$($_probe_cli api-resources --api-group=project.openshift.io 2>/dev/null) && _probe_rc=0
+
+      if [[ $_probe_rc -eq 0 ]]; then
+        local _is_ocp=false
+        echo "$_probe_output" | grep -q project && _is_ocp=true
+
+        local _mismatch=false _expected=""
+        if [[ "$BASE_K8S_CMD" == "kubectl" && "$_is_ocp" == "true" ]]; then
+          _mismatch=true; _expected="OpenShift (oc)"
+        elif [[ "$BASE_K8S_CMD" == "oc" && "$_is_ocp" == "false" ]]; then
+          _mismatch=true; _expected="Kubernetes (kubectl)"
+        fi
+
+        if [[ "$_mismatch" == "true" ]]; then
+          printf "\n  ${_C_WARN}WARNING: Your kubeconfig context appears to be %s,${_C_RESET}\n" "$_expected"
+          printf "  but you selected '%s'. Collection may still work,\n" "$k8sCmd"
+          printf "  but the matching CLI is recommended.\n"
+          if ! prompt_yn "  Continue with $k8sCmd anyway?"; then
+            log_activity "User declined CLI mismatch ($k8sCmd vs detected $_expected); re-selecting."
+            continue
+          fi
+          log_activity "User override: proceeding with $k8sCmd despite cluster type mismatch."
+        fi
+      fi
+    fi
+
+    break
+  done
+  log_activity "Orchestration CLI selected: $k8sCmd"
+  export k8sCmd
+  return 0
+}
+
+# Stubs for the on-prem-only platform collectors. Real implementations TBD.
+# ─────────────────────────────────────────────
+#  On-premises platform collection (legacy support-bundle parity)
+# ─────────────────────────────────────────────
+
+# Group non-Job pods by their `role` label; if the role label is missing,
+# fall back to the owner workload name (Deployment / StatefulSet / DaemonSet).
+# For ReplicaSet-owned pods, the trailing -<hash> is stripped to give the
+# Deployment name. Keeps the summary consistent with SYSDIGCLOUD_PODS and
+# the browse-paginated view (Job pods excluded from both).
+function display_platform_summary() {
+  local total="$1"
+  printf "\n  On-prem platform components in namespace '%s':\n" "$namespace"
+  $k8sCmd get pods -n "$namespace" --no-headers \
+    -o custom-columns="ROLE:metadata.labels.role,OWNER_KIND:metadata.ownerReferences[0].kind,OWNER_NAME:metadata.ownerReferences[0].name" 2>/dev/null \
+    | awk '$2 != "Job" {
+        role = $1
+        owner_kind = $2
+        owner_name = $3
+        if (role != "<none>" && role != "") {
+          print role
+        } else if (owner_kind == "ReplicaSet") {
+          sub(/-[a-z0-9]{8,10}$/, "", owner_name)
+          sub(/-deployment$/, "", owner_name)
+          print owner_name
+        } else if (owner_kind == "StatefulSet" || owner_kind == "DaemonSet") {
+          sub(/-deployment$/, "", owner_name)
+          print owner_name
+        } else {
+          print "(unlabeled)"
+        }
+      }' \
+    | sort | uniq -c | sort -rn \
+    | while read -r count label; do
+        local _suf="s"
+        [[ "$count" -eq 1 ]] && _suf=""
+        printf "    - %-38s %s pod%s\n" "$label" "$count" "$_suf"
+      done
+  printf "    ------------------------------------------------\n"
+  printf "    Total pods: %d\n" "$total"
+}
+
+# Tabular snapshot of every pod in the platform namespace (matches Phase 1's
+# running_pods.txt). Useful at-a-glance: STATUS, RESTARTS, IP, NODE. Not
+# filtered by the option-5 scope picker on purpose — it provides namespace
+# context that helps interpret what was vs wasn't collected.
+function collectPlatformRunningPods() {
+  _kubectl_to_file_logged "$PLATFORM_LOG_DIR/running_pods.txt" "running_pods" \
+    $k8sCmd get po --sort-by='.status.containerStatuses[0].restartCount' --no-headers -n "$namespace" -o wide
+}
+
+# Backend version: read sysdigcloud-api image tag, write backend_version.txt.
+function collectPlatformBackendVersion() {
+  printf "Detecting backend version...\n"
+  [[ -z "$BACKEND_VERSION_TAG" ]] && detect_platform_backend_version
+  echo "$BACKEND_VERSION_TAG" > "$PLATFORM_LOG_DIR/backend_version.txt"
+  log_activity "Backend version: $BACKEND_VERSION (tag: $BACKEND_VERSION_TAG)"
+}
+
+# Per-container worker: kubectl logs + support-files.tgz via tar exec.
+# Designed to be invoked via run_bg from the orchestrator. Each call handles
+# exactly one (pod, container) tuple.
+# Args: pod_name container_name dest_dir
+function _collect_container_logs() {
+  local pod="$1" container="$2" dest_dir="$3"
+  local support_cmd='tar czf - /logs/ /opt/draios/ /var/log/sysdigcloud/ /var/log/cassandra/ /tmp/redis.log /var/log/redis-server/redis.log /opt/prod.conf 2>/dev/null || true'
+  local _out="$dest_dir/${container}-support-files.tgz"
+  local _logs="$dest_dir/${container}-kubectl-logs.txt"
+
+  # Worker-only debug: each background job picks up MANUAL_DEBUG from exported env.
+  [[ "${MANUAL_DEBUG:-false}" == "true" ]] && set -x
+
+  # Per-container lifecycle entry — mirrors Phase 1's _phase1_collect_one_pod_logs
+  # pattern. Both activity.log AND /dev/tty get the start marker so the operator
+  # sees per-container progress in real time (matches the success/partial/error
+  # outcome lines below, which also go to both).
+  log_activity "Collecting logs for $pod/$container."
+  [[ -w /dev/tty ]] && printf "Collecting logs for %s/%s...\n" "$pod" "$container" > /dev/tty
+
+  # 1) kubectl logs capture — independent of the support-files tarball below.
+  # Honors MANUAL_SINCE_OPTS so manual-mode --since= flags propagate.
+  $k8sCmd logs ${MANUAL_SINCE_OPTS} "$pod" -c "$container" -n "$namespace" \
+    > "$_logs" 2>/dev/null || true
+
+  # 2) Pick a shell once. If neither bash nor sh works (scratch/distroless
+  # images), the in-container tar invocation isn't possible — skip the .tgz
+  # step instead of writing an empty file. Outcome depends on whether the
+  # earlier kubectl-logs capture produced content: partial if yes, ERROR if no.
+  local _shell=""
+  if $k8sCmd exec "$pod" -c "$container" -n "$namespace" -- bash -c "echo" >/dev/null 2>&1; then
+    _shell="bash"
+  elif $k8sCmd exec "$pod" -c "$container" -n "$namespace" -- sh -c "echo" >/dev/null 2>&1; then
+    _shell="sh"
+  else
+    log_activity "$pod/$container has no bash or sh; support-files.tgz skipped."
+    if [[ -s "$_logs" ]]; then
+      log_activity "Logs for $pod/$container partially collected (kubectl-logs only; no shell for support-files)."
+      [[ -w /dev/tty ]] && printf "${_C_WARN}Logs for %s/%s partially collected (kubectl-logs only; no shell).${_C_RESET}\n" \
+        "$pod" "$container" > /dev/tty
+    else
+      [[ -n "$PLATFORM_FAIL_DIR" ]] && touch "$PLATFORM_FAIL_DIR/${pod}__${container}" 2>/dev/null
+      log_activity "ERROR: no logs collected for $pod/$container (no shell, kubectl-logs empty)."
+      [[ -w /dev/tty ]] && printf "${_C_ERR}Error: no logs collected for %s/%s (no shell, kubectl-logs empty).${_C_RESET}\n" \
+        "$pod" "$container" > /dev/tty
+    fi
+    return 0
+  fi
+
+  # 3) Exec tar with integrity-check + retry. Mirrors the Phase 1 agent path
+  # (commit b86bd78): the apiserver exec stream can be cut mid-transfer on
+  # flaky networks, producing a truncated .tgz the legacy code accepted
+  # silently via '|| true'. tar tzf walks the whole gzip+tar structure
+  # end-to-end; on failure we retry. A clean exec that returns zero bytes is
+  # the legitimate "container has no files at the target paths" case (typical
+  # for stateless API/UI/scanning pods) — not retried.
+  local _attempt=1 _ok=0 _rc _err _tarerr _reason
+  while (( _attempt <= PLATFORM_TAR_RETRY )); do
+    rm -f "$_out"
+    # Capture the exec's stderr (the real failure text) while its stdout — the
+    # binary .tgz stream — still goes to the file. `2>&1 1>"$_out"` inside the
+    # substitution sends stderr to the capture pipe, then stdout to the file.
+    _err=$($k8sCmd exec "$pod" -c "$container" -n "$namespace" -- $_shell -c "$support_cmd" 2>&1 1>"$_out")
+    _rc=$?
+    if (( _rc == 0 )); then
+      if [[ ! -s "$_out" ]]; then
+        # exec succeeded with no output → no data to collect, not a failure
+        _ok=1
+        break
+      fi
+      # Capture tar/gzip's own message so a truncated archive reports the real
+      # cause (e.g. "gzip: stdin: unexpected end of file") rather than a guess.
+      if _tarerr=$(tar tzf "$_out" 2>&1 >/dev/null); then
+        _ok=1
+        break
+      fi
+    fi
+    if (( _attempt < PLATFORM_TAR_RETRY )); then
+      # Surface the actual underlying error, mirroring the Phase 1 cp .tgz path
+      # (which logs the real cpError). A non-zero exec → the exec's stderr; a
+      # clean exec with an unreadable archive → tar/gzip's stderr. Newlines are
+      # flattened to " | " so the line stays single-line in activity.log.
+      if (( _rc != 0 )); then
+        _reason="${_err:-collection command exited $_rc}"
+      else
+        _reason="${_tarerr:-archive truncated or unreadable}"
+      fi
+      _reason="${_reason//$'\n'/ | }"
+      log_activity "Retrying collecting logs for $pod/$container (attempt $_attempt/$PLATFORM_TAR_RETRY): $_reason."
+      # Phase 2 dispatch uses run_bg (buffered to .out), so a plain printf to
+      # the worker's stdout wouldn't surface to the live terminal. Write the
+      # retry warning directly to the controlling tty so the user sees it in
+      # real time. Guarded so non-interactive runs (CI/piped) silently drop it.
+      # The terminal line stays short (no reason); the real cause is in activity.log.
+      [[ -w /dev/tty ]] && printf "${_C_WARN}Retrying collecting logs for %s/%s (attempt %d/%d)...${_C_RESET}\n" \
+        "$pod" "$container" "$_attempt" "$PLATFORM_TAR_RETRY" > /dev/tty
+      sleep 2
+    fi
+    ((_attempt++))
+  done
+
+  # 4) Outcome: green success, yellow partial (.tgz failed but kubectl-logs
+  # survived), or red ERROR (both failed). All three go to activity.log and
+  # /dev/tty (success too — user explicitly asked for visible confirmation
+  # per container in addition to the step-level "complete" line).
+  if (( _ok )); then
+    log_activity "Logs for $pod/$container collected successfully."
+    [[ -w /dev/tty ]] && printf "${_C_OK}Logs for %s/%s collected successfully.${_C_RESET}\n" \
+      "$pod" "$container" > /dev/tty
+  else
+    rm -f "$_out"
+    [[ -n "$PLATFORM_FAIL_DIR" ]] && touch "$PLATFORM_FAIL_DIR/${pod}__${container}" 2>/dev/null
+    if [[ -s "$_logs" ]]; then
+      log_activity "Logs for $pod/$container partially collected (support-files failed after $PLATFORM_TAR_RETRY attempts; kubectl-logs collected)."
+      [[ -w /dev/tty ]] && printf "${_C_WARN}Logs for %s/%s partially collected (support-files failed; kubectl-logs collected).${_C_RESET}\n" \
+        "$pod" "$container" > /dev/tty
+    else
+      log_activity "ERROR: no logs collected for $pod/$container (support-files + kubectl-logs both failed)."
+      [[ -w /dev/tty ]] && printf "${_C_ERR}Error: no logs collected for %s/%s (support-files + kubectl-logs both failed).${_C_RESET}\n" \
+        "$pod" "$container" > /dev/tty
+    fi
+  fi
+}
+
+# Read the marker files written by _collect_container_logs's failure path
+# and emit a yellow per-container summary so the user sees which pods are
+# missing from the bundle without having to dig through activity.log.
+# Removes PLATFORM_FAIL_DIR afterwards so it doesn't ship in the bundle.
+function _emit_platform_pod_logs_summary() {
+  [[ -z "$PLATFORM_FAIL_DIR" ]] && return 0
+  [[ ! -d "$PLATFORM_FAIL_DIR" ]] && return 0
+  local _failed=() _f _name
+  for _f in "$PLATFORM_FAIL_DIR"/*; do
+    [[ -f "$_f" ]] || continue
+    _name="$(basename "$_f")"
+    # Marker filename is "<pod>__<container>"; display as "<pod>/<container>".
+    _failed+=("${_name//__//}")
+  done
+  if (( ${#_failed[@]} > 0 )); then
+    # Build the header as plain text (no color codes) so the bottom rule can be
+    # sized to match its exact visible width regardless of the container count.
+    local _hdr="--- WARNING: could not fully collect logs for ${#_failed[@]} container(s) ---"
+    local _rule; _rule=$(printf '%*s' "${#_hdr}" ''); _rule="${_rule// /-}"
+    printf "\n${_C_WARN}%s${_C_RESET}\n" "$_hdr"
+    local _e
+    for _e in "${_failed[@]}"; do
+      printf "    - %s\n" "$_e"
+    done
+    printf -- "%s\n" "$_rule"
+    log_activity "Could not fully collect logs for ${#_failed[@]} container(s): ${_failed[*]}"
+  fi
+  rm -rf "$PLATFORM_FAIL_DIR"
+  PLATFORM_FAIL_DIR=""
+}
+
+# Schedule per-container log + support-file collection in parallel.
+# Phase 1 (serial): mkdir per pod, fetch container lists.
+# Phase 2 (parallel): launch _collect_container_logs in background per container.
+# Caller is responsible for calling wait_all afterwards.
+function collectPlatformPodsLogs() {
+  if [[ "${MANUAL_SKIP_LOGS:-false}" == "true" ]]; then
+    printf "${_C_WARN}Skipping log + support-files collection (--skip-logs).${_C_RESET}\n"
+    log_activity "MANUAL_SKIP_LOGS=true; log collection skipped."
+    return 0
+  fi
+  printf "Scheduling per-container log + support-files collection (parallelized)...\n"
+  log_activity "Scheduling per-container log + support-files collection (parallelized)."
+
+  # Single-shot container-list discovery: one apiserver round-trip for the
+  # whole namespace instead of one 'kubectl get pod' per pod (was 10-30 s of
+  # serial latency before any worker even started on a 100-pod platform).
+  # Output format is one line per pod: "<pod-name>\t<c1> <c2> <c3> ...".
+  local _all_pods_containers
+  _all_pods_containers=$($k8sCmd get pods -n "$namespace" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].name}{"\n"}{end}' 2>/dev/null)
+
+  # Membership test for SYSDIGCLOUD_PODS via space-bordered string match
+  # (bash 3 safe; pod names are RFC 1123 alphanumeric+dash so no space
+  # collisions). Pods in the namespace that aren't in scope are skipped.
+  local _scope=" ${SYSDIGCLOUD_PODS[*]} "
+  local pod containers container dest _total=0
+  while IFS=$'\t' read -r pod containers; do
+    [[ -z "$pod" ]] && continue
+    [[ "$_scope" != *" $pod "* ]] && continue
+    dest=$(_pod_log_dir "$pod")
+    mkdir -p "$dest"
+    for container in $containers; do
+      run_bg "pod-${pod}-${container}" _collect_container_logs "$pod" "$container" "$dest"
+      throttle
+      _total=$((_total + 1))
+    done
+  done <<< "$_all_pods_containers"
+
+  log_activity "Dispatched $_total container workers across ${#SYSDIGCLOUD_PODS[@]} pods."
+}
+
+# Per-pod worker: dumps a single pod's JSON. Designed for run_bg.
+function _collect_pod_describe() {
+  [[ "${MANUAL_DEBUG:-false}" == "true" ]] && set -x
+  local pod="$1" dest
+  dest=$(_pod_describe_dir "$pod")
+  mkdir -p "$dest"
+  $k8sCmd get pod "$pod" -n "$namespace" -o json > "$dest/kubectl-describe.json" 2>/dev/null \
+    || log_activity "describe failed for pod $pod"
+}
+
+# Per-pod kubectl-describe.json fan-out. Mirrors collectPlatformNodes /
+# _collect_node_info: workers run in parallel via run_bg/throttle, then
+# wait_all internally so callers can rely on all describes being on disk
+# before they return. Each call is cheap (~50 ms) but with ~100 pods the
+# serial loop was ~5 s of walltime; parallel runs it in ~1 s.
+function collectPlatformPodsDescribe() {
+  printf "Collecting pod details...\n"
+  log_activity "Collecting per-pod kubectl describe JSONs (parallelized)."
+  local pod
+  for pod in "${SYSDIGCLOUD_PODS[@]}"; do
+    run_bg "describe-${pod}" _collect_pod_describe "$pod"
+    throttle
+  done
+  wait_all
+  printf "${_C_OK}Pod details collected.${_C_RESET}\n"
+  log_activity "Per-pod kubectl describe JSON collection complete."
+}
+
+# Per-node worker: dumps a single node's JSON. Designed for run_bg.
+function _collect_node_info() {
+  [[ "${MANUAL_DEBUG:-false}" == "true" ]] && set -x
+  local node="$1"
+  $k8sCmd get node "$node" -ojson > "$PLATFORM_LOG_DIR/nodes/${node}-kubectl.json" 2>/dev/null || true
+}
+
+# Schedule node info collection. describe-nodes is serial (one cluster-wide
+# call); per-node JSONs are launched in parallel via run_bg. Caller
+# wait_all's afterwards.
+function collectPlatformNodes() {
+  printf "Collecting describe-nodes + scheduling per-node JSON (parallelized)...\n"
+  log_activity "Collecting describe-nodes + scheduling per-node JSON (parallelized)."
+  $k8sCmd describe nodes > "$PLATFORM_LOG_DIR/describe_node_output.log" 2>/dev/null \
+    || log_activity "No permission to describe nodes."
+  mkdir -p "$PLATFORM_LOG_DIR/nodes"
+  local node
+  for node in $($k8sCmd get nodes --no-headers -o custom-columns=NAME:metadata.name 2>/dev/null); do
+    run_bg "node-${node}" _collect_node_info "$node"
+    throttle
+  done
+}
+
+# PV / PVC (sysdig-filtered) / StorageClass.
+function collectPlatformStorage() {
+  printf "Collecting storage info (PV/PVC/SC)...\n"
+  log_activity "Collecting storage info (PV/PVC/SC)."
+  $k8sCmd get pv 2>/dev/null | grep sysdig > "$PLATFORM_LOG_DIR/pv_output.log" || true
+  $k8sCmd get pvc -n "$namespace" 2>/dev/null | grep sysdig > "$PLATFORM_LOG_DIR/pvc_output.log" || true
+  $k8sCmd get storageclass > "$PLATFORM_LOG_DIR/sc_output.log" 2>/dev/null \
+    || log_activity "No permission to get StorageClasses."
+  printf "${_C_OK}Storage info collected.${_C_RESET}\n"
+  log_activity "Storage info collection complete."
+}
+
+# Per-resource-type worker: dumps all items of one object kind. Designed for run_bg.
+function _collect_resource_manifests() {
+  [[ "${MANUAL_DEBUG:-false}" == "true" ]] && set -x
+  local obj="$1"
+  local items item
+  items=$($k8sCmd get "$obj" -n "$namespace" -o jsonpath="{.items[*]['metadata.name']}" 2>/dev/null)
+  [[ -z "$items" ]] && return 0
+  for item in $items; do
+    $k8sCmd get "$obj" "$item" -n "$namespace" -o json > "$PLATFORM_LOG_DIR/$obj/${item}-kubectl.json" 2>/dev/null || true
+  done
+}
+
+# Schedule per-object-type manifest collection. Pre-creates all dirs, then
+# launches one background job per object type. Caller wait_all's afterwards.
+# Object set matches legacy v2 (svc/deploy/sts/pvc/ds/ingress/rs/networkpolicy/
+# cronjob/cm/pdb + OCP routes if available). Job manifests are intentionally
+# omitted — they're ephemeral and the spawning CronJob is already captured.
+function collectPlatformManifests() {
+  printf "Scheduling manifest collection (parallelized)...\n"
+  log_activity "Scheduling manifest collection (parallelized)."
+  local objects=("svc" "deployment" "sts" "pvc" "daemonset" "ingress" "replicaset" "networkpolicy" "cronjob" "configmap" "pdb")
+  if $k8sCmd api-resources 2>/dev/null | grep -q "routes"; then
+    objects+=("routes")
+  fi
+  local obj
+  for obj in "${objects[@]}"; do
+    mkdir -p "$PLATFORM_LOG_DIR/$obj"
+  done
+  for obj in "${objects[@]}"; do
+    run_bg "manifests-${obj}" _collect_resource_manifests "$obj"
+    throttle
+  done
+}
+
+# Container density per node.
+function collectPlatformContainerDensity() {
+  printf "Collecting container density per node...\n"
+  log_activity "Collecting container density per node."
+  local out="$PLATFORM_LOG_DIR/container_density.txt"
+  local num_nodes=0 num_pods=0 num_running=0 num_total=0
+  printf "%-30s %-10s %-20s %-10s\n" "Node" "Pods" "Running Containers" "Total Containers" > "$out"
+
+  # Fetch the cluster-wide pod list once, not three times per node. Match the
+  # NODE column (column 8 in `-o wide` output) by exact equality with awk so
+  # nodes sharing a prefix (e.g. worker-1 / worker-10) are not double-counted.
+  local all_pods_wide
+  all_pods_wide=$($k8sCmd get pods -A --no-headers -o wide 2>/dev/null)
+
+  local node node_rows total_pods running_containers total_containers
+  for node in $($k8sCmd get nodes --no-headers -o custom-columns=node:.metadata.name 2>/dev/null); do
+    node_rows=$(echo "$all_pods_wide" | awk -v n="$node" '$8 == n')
+    total_pods=$(echo "$node_rows" | grep -c .)
+    running_containers=$(echo "$node_rows" | awk '{print $3}' | cut -f 1 -d/ | awk '{ SUM += $1 } END { print SUM+0 }')
+    total_containers=$(echo "$node_rows" | awk '{print $3}' | cut -f 2 -d/ | awk '{ SUM += $1 } END { print SUM+0 }')
+    printf "%-30s %-10s %-20s %-10s\n" "$node" "$total_pods" "$running_containers" "$total_containers" >> "$out"
+    num_nodes=$(( num_nodes + 1 ))
+    num_pods=$(( num_pods + ${total_pods:-0} ))
+    num_running=$(( num_running + ${running_containers:-0} ))
+    num_total=$(( num_total + ${total_containers:-0} ))
+  done
+  printf "\nTotals\n-----\n" >> "$out"
+  printf "Nodes: %s\n" "$num_nodes" >> "$out"
+  printf "Pods: %s\n" "$num_pods" >> "$out"
+  printf "Running Containers: %s\n" "$num_running" >> "$out"
+  printf "Containers: %s\n" "$num_total" >> "$out"
+  printf "${_C_OK}Container density collected.${_C_RESET}\n"
+  log_activity "Container density collection complete."
+}
+
+# Common platform ConfigMap, filtered to drop password lines.
+# Modern installers (6.x+) use sysdigcloud-common; pre-6.x used sysdigcloud-config.
+# Try the version-appropriate name first and fall back to the other if missing.
+# The resulting file is always written to config.yaml at PLATFORM_LOG_DIR root.
+function collectPlatformConfigMap() {
+  local _primary _fallback _cm _tmp _err
+  if [[ "$BACKEND_VERSION" =~ ^(7|6)$ ]]; then
+    _primary="sysdigcloud-common"
+    _fallback="sysdigcloud-config"
+  else
+    _primary="sysdigcloud-config"
+    _fallback="sysdigcloud-common"
+  fi
+
+  for _cm in "$_primary" "$_fallback"; do
+    _tmp=$(mktemp 2>/dev/null) || _tmp="/tmp/.sysdig_cm.$$"
+    printf "Collecting %s ConfigMap (filtered)...\n" "$_cm"
+    # Capture stderr so a real failure (RBAC, NotFound) shows up in activity.log.
+    _err=$($k8sCmd get configmap "$_cm" -n "$namespace" -o yaml 2>&1 1>"$_tmp")
+    if [[ -s "$_tmp" ]]; then
+      grep -v password "$_tmp" | grep -v apiVersion > "$PLATFORM_LOG_DIR/config.yaml"
+      rm -f "$_tmp"
+      printf "${_C_OK}%s ConfigMap collected.${_C_RESET}\n" "$_cm"
+      log_activity "Platform ConfigMap '$_cm' collected (backend v${BACKEND_VERSION:-?})."
+      return 0
+    fi
+    log_activity "ConfigMap $_cm not collected: ${_err:-no output}"
+    rm -f "$_tmp"
+  done
+
+  : > "$PLATFORM_LOG_DIR/config.yaml"
+  log_activity "Neither $_primary nor $_fallback found in namespace '$namespace'."
+}
+
+# ───────── Component-derived collection (manual mode, narrow scope) ─────────
+# Used in components/pods scope modes to pull only the K8s resources tied
+# to the selected pods — RBAC-friendly (namespace-scoped only) and avoids
+# the full-namespace manifest dump.
+
+# Derive the component name for a pod using the same bucketing as
+# _discover_platform_components: role label → owner workload name → "unlabeled".
+# Echoes the component name (single token, safe as a directory name).
+function _derive_component_for_pod() {
+  local _pod="$1" _row _role _owner_kind _owner_name
+  _row=$($k8sCmd get pod "$_pod" -n "$namespace" --no-headers \
+    -o custom-columns="ROLE:metadata.labels.role,OWNER_KIND:metadata.ownerReferences[0].kind,OWNER_NAME:metadata.ownerReferences[0].name" 2>/dev/null)
+  _role=$(echo "$_row" | awk '{print $1}')
+  _owner_kind=$(echo "$_row" | awk '{print $2}')
+  _owner_name=$(echo "$_row" | awk '{print $3}')
+  if [[ -n "$_role" && "$_role" != "<none>" ]]; then
+    echo "$_role"
+  elif [[ "$_owner_kind" == "ReplicaSet" ]]; then
+    echo "$_owner_name" | sed -E 's/-[a-z0-9]{8,10}$//' | sed -E 's/-deployment$//'
+  elif [[ "$_owner_kind" == "StatefulSet" || "$_owner_kind" == "DaemonSet" ]]; then
+    echo "$_owner_name" | sed -E 's/-deployment$//'
+  else
+    echo "unlabeled"
+  fi
+}
+
+# Resolve a pod's top-level workload. Walks ReplicaSet → Deployment.
+# Echoes: "<kind>/<name>" or empty if the pod has no ownerReference.
+function _owner_workload_for_pod() {
+  local _pod="$1" _kind _name _dk _dn
+  _kind=$($k8sCmd get pod "$_pod" -n "$namespace" -o jsonpath='{.metadata.ownerReferences[0].kind}' 2>/dev/null)
+  _name=$($k8sCmd get pod "$_pod" -n "$namespace" -o jsonpath='{.metadata.ownerReferences[0].name}' 2>/dev/null)
+  [[ -z "$_kind" || -z "$_name" ]] && return 0
+  if [[ "$_kind" == "ReplicaSet" ]]; then
+    _dk=$($k8sCmd get replicaset "$_name" -n "$namespace" -o jsonpath='{.metadata.ownerReferences[0].kind}' 2>/dev/null)
+    _dn=$($k8sCmd get replicaset "$_name" -n "$namespace" -o jsonpath='{.metadata.ownerReferences[0].name}' 2>/dev/null)
+    if [[ -n "$_dk" && -n "$_dn" ]]; then
+      echo "$_dk/$_dn"
+    else
+      echo "ReplicaSet/$_name"
+    fi
+  else
+    echo "$_kind/$_name"
+  fi
+}
+
+# Emit ConfigMap names referenced by a pod (volumes + envFrom + env.valueFrom,
+# across containers and initContainers). One name per line.
+function _configmaps_for_pod() {
+  local _pod="$1"
+  {
+    $k8sCmd get pod "$_pod" -n "$namespace" -o jsonpath='{range .spec.volumes[*]}{.configMap.name}{"\n"}{end}'                              2>/dev/null
+    $k8sCmd get pod "$_pod" -n "$namespace" -o jsonpath='{range .spec.containers[*].envFrom[*]}{.configMapRef.name}{"\n"}{end}'             2>/dev/null
+    $k8sCmd get pod "$_pod" -n "$namespace" -o jsonpath='{range .spec.containers[*].env[*]}{.valueFrom.configMapKeyRef.name}{"\n"}{end}'    2>/dev/null
+    $k8sCmd get pod "$_pod" -n "$namespace" -o jsonpath='{range .spec.initContainers[*].envFrom[*]}{.configMapRef.name}{"\n"}{end}'         2>/dev/null
+    $k8sCmd get pod "$_pod" -n "$namespace" -o jsonpath='{range .spec.initContainers[*].env[*]}{.valueFrom.configMapKeyRef.name}{"\n"}{end}' 2>/dev/null
+  } | grep -v '^$' | sort -u
+}
+
+# Emit PVC names referenced by a pod's volumes. One name per line.
+function _pvcs_for_pod() {
+  local _pod="$1"
+  $k8sCmd get pod "$_pod" -n "$namespace" \
+    -o jsonpath='{range .spec.volumes[*]}{.persistentVolumeClaim.claimName}{"\n"}{end}' 2>/dev/null \
+    | grep -v '^$' | sort -u
+}
+
+# Convert kubectl jsonpath map output to a kubectl label selector
+# ("k1=v1,k2=v2"). Handles both kubectl encodings:
+#   - JSON form (modern kubectl):  {"k1":"v1","k2":"v2"}
+#   - Go-map form (older kubectl): map[k1:v1 k2:v2]
+# Echoes empty for empty / "<none>" / "{}" / "map[]" inputs.
+function _selector_from_map() {
+  local _in="$1"
+  [[ -z "$_in" || "$_in" == "<none>" || "$_in" == "{}" || "$_in" == "map[]" ]] && return 0
+  if [[ "${_in:0:1}" == "{" ]]; then
+    # JSON: strip braces + quotes, swap ':' → '='.
+    echo "$_in" | sed -E 's/^\{//; s/\}$//; s/"//g; s/:/=/g'
+  else
+    # Go-map: strip "map[" + "]", spaces → commas, ':' → '='.
+    echo "$_in" | sed -E 's/^map\[//; s/\]$//' | sed 's/ /,/g' | sed 's/:/=/g'
+  fi
+}
+
+# Check whether every k=v in $1 (comma-separated label-selector form) is
+# present in $2 (comma-separated pod-labels form). Pure shell, no kubectl.
+# Comma-padding ensures we don't match a prefix of a longer key/value.
+function _selector_matches_labels() {
+  local _selector="$1" _labels="$2"
+  [[ -z "$_selector" || -z "$_labels" ]] && return 1
+  local _padded=",$_labels,"
+  local _kv _IFS_save="$IFS"
+  IFS=','
+  for _kv in $_selector; do
+    if [[ "$_padded" != *",$_kv,"* ]]; then
+      IFS="$_IFS_save"; return 1
+    fi
+  done
+  IFS="$_IFS_save"; return 0
+}
+
+# Build a namespace-wide cache used by every selector-join helper below.
+# One pass per resource type, replacing N kubectl calls per worker with N
+# local string comparisons. Read-only; cache lives in PLATFORM_LOG_DIR/.ns_cache
+# (hidden — does not ship). Best-effort: kubectl failures leave the file empty
+# and downstream helpers return zero matches (same behavior as restricted RBAC).
+function _build_ns_caches() {
+  local _dir="$PLATFORM_LOG_DIR/.ns_cache"
+  mkdir -p "$_dir"
+
+  # Pod labels: "<name>|<k1=v1,k2=v2,...>"  (one kubectl call for the whole namespace)
+  $k8sCmd get pods -n "$namespace" -o jsonpath='{range .items[*]}{.metadata.name}|{.metadata.labels}{"\n"}{end}' 2>/dev/null \
+    | while IFS='|' read -r _name _raw; do
+        [[ -z "$_name" ]] && continue
+        printf '%s|%s\n' "$_name" "$(_selector_from_map "$_raw")"
+      done > "$_dir/pod_labels"
+
+  # Service selectors: "<name>|<k1=v1,...>"  (selectorless services excluded)
+  $k8sCmd get svc -n "$namespace" -o jsonpath='{range .items[*]}{.metadata.name}|{.spec.selector}{"\n"}{end}' 2>/dev/null \
+    | while IFS='|' read -r _name _raw; do
+        [[ -z "$_name" ]] && continue
+        local _sel; _sel=$(_selector_from_map "$_raw")
+        [[ -z "$_sel" ]] && continue
+        printf '%s|%s\n' "$_name" "$_sel"
+      done > "$_dir/svc_selectors"
+
+  # PDB selectors: same shape as services
+  $k8sCmd get pdb -n "$namespace" -o jsonpath='{range .items[*]}{.metadata.name}|{.spec.selector.matchLabels}{"\n"}{end}' 2>/dev/null \
+    | while IFS='|' read -r _name _raw; do
+        [[ -z "$_name" ]] && continue
+        local _sel; _sel=$(_selector_from_map "$_raw")
+        [[ -z "$_sel" ]] && continue
+        printf '%s|%s\n' "$_name" "$_sel"
+      done > "$_dir/pdb_selectors"
+
+  # NetworkPolicy selectors: same shape; empty podSelector ("{}") means "apply
+  # to every pod in the namespace" — stored as sentinel "*" so helpers
+  # short-circuit instead of falling into the empty-selector skip rule.
+  $k8sCmd get networkpolicy -n "$namespace" -o jsonpath='{range .items[*]}{.metadata.name}|{.spec.podSelector.matchLabels}{"\n"}{end}' 2>/dev/null \
+    | while IFS='|' read -r _name _raw; do
+        [[ -z "$_name" ]] && continue
+        local _sel; _sel=$(_selector_from_map "$_raw")
+        [[ -z "$_sel" ]] && _sel="*"
+        printf '%s|%s\n' "$_name" "$_sel"
+      done > "$_dir/np_selectors"
+
+  # Ingress backends: "<name>|<svc1> <svc2> ..."  (paths + defaultBackend)
+  $k8sCmd get ingress -n "$namespace" -o jsonpath='{range .items[*]}{.metadata.name}|{range .spec.rules[*].http.paths[*]}{.backend.service.name}{" "}{end}{.spec.defaultBackend.service.name}{"\n"}{end}' 2>/dev/null \
+    > "$_dir/ing_backends"
+
+  # OCP routes (probe was done once in collectPlatformComponentRelated).
+  if [[ "${_PLATFORM_HAS_ROUTES:-0}" == "1" ]]; then
+    $k8sCmd get routes -n "$namespace" -o jsonpath='{range .items[*]}{.metadata.name}|{.spec.to.name}{" "}{range .spec.alternateBackends[*]}{.name}{" "}{end}{"\n"}{end}' 2>/dev/null \
+      > "$_dir/rt_backends"
+  fi
+}
+
+# Read pod_labels cache and emit pod names whose labels include every k=v in
+# $1 (comma-separated selector). Empty cache or empty selector → no matches.
+function _pods_matching_selector() {
+  local _selector="$1"
+  local _cache="$PLATFORM_LOG_DIR/.ns_cache/pod_labels"
+  [[ ! -f "$_cache" ]] && return 0
+  [[ -z "$_selector" ]] && return 0
+  local _name _labels
+  while IFS='|' read -r _name _labels; do
+    [[ -z "$_name" ]] && continue
+    _selector_matches_labels "$_selector" "$_labels" && echo "$_name"
+  done < "$_cache"
+}
+
+# Emit Service names whose selector matches at least one pod in $@.
+# Reads svc_selectors + pod_labels caches built by _build_ns_caches; pure
+# string ops, no kubectl. Empty caches → no matches (safe fallback).
+function _services_for_pods() {
+  local _pods=("$@")
+  local _cache="$PLATFORM_LOG_DIR/.ns_cache/svc_selectors"
+  [[ ! -f "$_cache" ]] && return 0
+  local _name _selector _m _p _hit
+  while IFS='|' read -r _name _selector; do
+    [[ -z "$_name" ]] && continue
+    _hit=0
+    while IFS= read -r _m; do
+      [[ -z "$_m" ]] && continue
+      for _p in "${_pods[@]}"; do
+        if [[ "$_p" == "$_m" ]]; then _hit=1; break 2; fi
+      done
+    done < <(_pods_matching_selector "$_selector")
+    [[ $_hit -eq 1 ]] && echo "$_name"
+  done < "$_cache"
+}
+
+# Emit PDB names whose .spec.selector.matchLabels intersect at least one pod
+# in $@. matchExpressions is not honored — the Sysdig PDBs use matchLabels only.
+function _pdbs_for_pods() {
+  local _pods=("$@")
+  local _cache="$PLATFORM_LOG_DIR/.ns_cache/pdb_selectors"
+  [[ ! -f "$_cache" ]] && return 0
+  local _name _selector _m _p _hit
+  while IFS='|' read -r _name _selector; do
+    [[ -z "$_name" ]] && continue
+    _hit=0
+    while IFS= read -r _m; do
+      [[ -z "$_m" ]] && continue
+      for _p in "${_pods[@]}"; do
+        if [[ "$_p" == "$_m" ]]; then _hit=1; break 2; fi
+      done
+    done < <(_pods_matching_selector "$_selector")
+    [[ $_hit -eq 1 ]] && echo "$_name"
+  done < "$_cache"
+}
+
+# Emit OpenShift Route names whose backends are in the given service set.
+# Caller is responsible for only invoking when the routes API exists.
+function _routes_for_services() {
+  local _svcs=("$@")
+  [[ ${#_svcs[@]} -eq 0 ]] && return 0
+  local _cache="$PLATFORM_LOG_DIR/.ns_cache/rt_backends"
+  [[ ! -f "$_cache" ]] && return 0
+  local _name _backends _b _s _hit
+  while IFS='|' read -r _name _backends; do
+    [[ -z "$_name" ]] && continue
+    _hit=0
+    for _b in $_backends; do
+      for _s in "${_svcs[@]}"; do
+        if [[ "$_b" == "$_s" ]]; then _hit=1; break 2; fi
+      done
+    done
+    [[ $_hit -eq 1 ]] && echo "$_name"
+  done < "$_cache"
+}
+
+# Emit NetworkPolicy names whose .spec.podSelector.matchLabels intersect at
+# least one pod in $@. The "*" sentinel in the cache marks a policy with an
+# empty podSelector — "applies to every pod in the namespace" — so we include
+# it whenever the caller has any pods to dump for.
+function _networkpolicies_for_pods() {
+  local _pods=("$@")
+  [[ ${#_pods[@]} -eq 0 ]] && return 0
+  local _cache="$PLATFORM_LOG_DIR/.ns_cache/np_selectors"
+  [[ ! -f "$_cache" ]] && return 0
+  local _name _selector _m _p _hit
+  while IFS='|' read -r _name _selector; do
+    [[ -z "$_name" ]] && continue
+    if [[ "$_selector" == "*" ]]; then
+      echo "$_name"; continue
+    fi
+    _hit=0
+    while IFS= read -r _m; do
+      [[ -z "$_m" ]] && continue
+      for _p in "${_pods[@]}"; do
+        if [[ "$_p" == "$_m" ]]; then _hit=1; break 2; fi
+      done
+    done < <(_pods_matching_selector "$_selector")
+    [[ $_hit -eq 1 ]] && echo "$_name"
+  done < "$_cache"
+}
+
+# Emit Ingress names whose backend services intersect the given service set.
+# Checks both rules[*].http.paths[*].backend.service.name and defaultBackend.
+function _ingresses_for_services() {
+  local _svcs=("$@")
+  [[ ${#_svcs[@]} -eq 0 ]] && return 0
+  local _cache="$PLATFORM_LOG_DIR/.ns_cache/ing_backends"
+  [[ ! -f "$_cache" ]] && return 0
+  local _name _backends _b _s _hit
+  while IFS='|' read -r _name _backends; do
+    [[ -z "$_name" ]] && continue
+    _hit=0
+    for _b in $_backends; do
+      for _s in "${_svcs[@]}"; do
+        if [[ "$_b" == "$_s" ]]; then _hit=1; break 2; fi
+      done
+    done
+    [[ $_hit -eq 1 ]] && echo "$_name"
+  done < "$_cache"
+}
+
+# Per-component worker. Runs in a background subshell (one job per
+# component bucket) so different components collect in parallel. Within
+# a single job all writes target the same component/<name>/ subtree,
+# so the existing serial dedup logic (file-existence checks) stays correct.
+# Args: comp_name pod1 [pod2 ...]
+function _collect_component_bucket() {
+  [[ "${MANUAL_DEBUG:-false}" == "true" ]] && set -x
+  local _comp="$1"
+  shift
+  local -a _comp_pods=("$@")
+  local _comp_dir="$PLATFORM_LOG_DIR/component/$_comp"
+  mkdir -p "$_comp_dir/workload" "$_comp_dir/configmaps" "$_comp_dir/pvcs" "$_comp_dir/services" "$_comp_dir/pdbs" "$_comp_dir/ingress" "$_comp_dir/networkpolicy"
+
+  local _pod _workload _kind _name _cm _pvc _svc _pdb _ing _np _rt _rs _rsname _wfile _cmfile _pvcfile _rsfile
+  local -a _comp_svcs=()
+  [[ "${_PLATFORM_HAS_ROUTES:-0}" == "1" ]] && mkdir -p "$_comp_dir/routes"
+
+  for _pod in "${_comp_pods[@]}"; do
+    # ── Owner workload (dedup by filename existence) ──
+    _workload=$(_owner_workload_for_pod "$_pod")
+    if [[ -n "$_workload" ]]; then
+      _kind="${_workload%%/*}"
+      _name="${_workload##*/}"
+      _wfile="$_comp_dir/workload/${_kind}_${_name}.json"
+      if [[ ! -f "$_wfile" ]]; then
+        $k8sCmd get "$_kind" "$_name" -n "$namespace" -o json > "$_wfile" 2>/dev/null \
+          || log_activity "Failed to fetch workload $_kind/$_name for $_pod."
+      fi
+      _rs=$($k8sCmd get pod "$_pod" -n "$namespace" -o jsonpath='{.metadata.ownerReferences[0].kind}' 2>/dev/null)
+      if [[ "$_rs" == "ReplicaSet" ]]; then
+        _rsname=$($k8sCmd get pod "$_pod" -n "$namespace" -o jsonpath='{.metadata.ownerReferences[0].name}' 2>/dev/null)
+        _rsfile="$_comp_dir/workload/ReplicaSet_${_rsname}.json"
+        if [[ ! -f "$_rsfile" && -n "$_rsname" ]]; then
+          $k8sCmd get replicaset "$_rsname" -n "$namespace" -o json > "$_rsfile" 2>/dev/null || true
+        fi
+      fi
+    fi
+
+    # ── ConfigMaps (dedup; skip common platform CMs — they're collected at top level) ──
+    while IFS= read -r _cm; do
+      [[ -z "$_cm" ]] && continue
+      [[ "$_cm" == "sysdigcloud-config" || "$_cm" == "sysdigcloud-common" ]] && continue
+      _cmfile="$_comp_dir/configmaps/${_cm}.yaml"
+      [[ -f "$_cmfile" ]] && continue
+      $k8sCmd get configmap "$_cm" -n "$namespace" -o yaml 2>/dev/null \
+        | grep -v password \
+        > "$_cmfile" \
+        || log_activity "ConfigMap $_cm fetch failed (component=$_comp)."
+    done < <(_configmaps_for_pod "$_pod")
+
+    # ── PVCs (dedup) ──
+    while IFS= read -r _pvc; do
+      [[ -z "$_pvc" ]] && continue
+      _pvcfile="$_comp_dir/pvcs/${_pvc}.json"
+      [[ -f "$_pvcfile" ]] && continue
+      $k8sCmd get pvc "$_pvc" -n "$namespace" -o json > "$_pvcfile" 2>/dev/null || true
+    done < <(_pvcs_for_pod "$_pod")
+  done
+
+  # ── Services (selector-matched over all pods in this component) ──
+  # Names are also captured into _comp_svcs so the ingress join below can
+  # reuse them without re-running the selector match.
+  while IFS= read -r _svc; do
+    [[ -z "$_svc" ]] && continue
+    _comp_svcs+=("$_svc")
+    $k8sCmd get svc "$_svc" -n "$namespace" -o json > "$_comp_dir/services/${_svc}.json" 2>/dev/null || true
+  done < <(_services_for_pods "${_comp_pods[@]}")
+
+  # ── Ingresses (backend-service join over this component's services) ──
+  while IFS= read -r _ing; do
+    [[ -z "$_ing" ]] && continue
+    $k8sCmd get ingress "$_ing" -n "$namespace" -o json > "$_comp_dir/ingress/${_ing}.json" 2>/dev/null || true
+  done < <(_ingresses_for_services "${_comp_svcs[@]}")
+
+  # ── OCP Routes (same backend-service join; OpenShift-only) ──
+  if [[ "${_PLATFORM_HAS_ROUTES:-0}" == "1" ]]; then
+    while IFS= read -r _rt; do
+      [[ -z "$_rt" ]] && continue
+      $k8sCmd get route "$_rt" -n "$namespace" -o json > "$_comp_dir/routes/${_rt}.json" 2>/dev/null || true
+    done < <(_routes_for_services "${_comp_svcs[@]}")
+  fi
+
+  # ── PDBs (selector-matched over all pods in this component) ──
+  while IFS= read -r _pdb; do
+    [[ -z "$_pdb" ]] && continue
+    $k8sCmd get pdb "$_pdb" -n "$namespace" -o json > "$_comp_dir/pdbs/${_pdb}.json" 2>/dev/null || true
+  done < <(_pdbs_for_pods "${_comp_pods[@]}")
+
+  # ── NetworkPolicies (podSelector-matched over this component's pods) ──
+  while IFS= read -r _np; do
+    [[ -z "$_np" ]] && continue
+    $k8sCmd get networkpolicy "$_np" -n "$namespace" -o json > "$_comp_dir/networkpolicy/${_np}.json" 2>/dev/null || true
+  done < <(_networkpolicies_for_pods "${_comp_pods[@]}")
+
+  # ── Events (one section per pod) ──
+  : > "$_comp_dir/events.log"
+  for _pod in "${_comp_pods[@]}"; do
+    printf "── events for pod: %s ──\n" "$_pod" >> "$_comp_dir/events.log"
+    $k8sCmd get events -n "$namespace" --field-selector "involvedObject.name=$_pod" 2>/dev/null \
+      >> "$_comp_dir/events.log" || true
+    printf "\n" >> "$_comp_dir/events.log"
+  done
+}
+
+# Orchestrator: walk MANUAL_PODS_FILTER, bucket pods by derived component,
+# and fan out one background job per component. Cheap no-op if filter is empty.
+function collectPlatformComponentRelated() {
+  [[ ${#MANUAL_PODS_FILTER[@]} -eq 0 ]] && return 0
+  printf "Collecting component-related K8s resources (parallelized per component)...\n"
+
+  # Probe the OCP routes API once so each parallel bucket worker doesn't repeat it.
+  # Exported so background subshells (run_bg) inherit the flag.
+  if $k8sCmd api-resources 2>/dev/null | grep -q "routes"; then
+    export _PLATFORM_HAS_ROUTES=1
+  else
+    export _PLATFORM_HAS_ROUTES=0
+  fi
+
+  # Build the namespace-wide selector / label cache once, before fanout. Each
+  # parallel _collect_component_bucket worker then resolves
+  # services / pdbs / ingresses / networkpolicies / routes locally instead of
+  # making ~200 kubectl calls per worker.
+  _build_ns_caches
+
+  # ── Pre-pass: build component → pods map. Parallel arrays for bash 3.2. ──
+  local _pod _comp _i _seen
+  local -a _comps=() _comp_pods_joined=()
+
+  for _pod in "${MANUAL_PODS_FILTER[@]}"; do
+    _comp=$(_derive_component_for_pod "$_pod")
+    _seen=-1
+    for _i in "${!_comps[@]}"; do
+      if [[ "${_comps[$_i]}" == "$_comp" ]]; then _seen=$_i; break; fi
+    done
+    if [[ $_seen -eq -1 ]]; then
+      _comps+=("$_comp")
+      _comp_pods_joined+=("$_pod")
+    else
+      _comp_pods_joined[$_seen]="${_comp_pods_joined[$_seen]} $_pod"
+    fi
+  done
+
+  # ── Fan out: one bg job per component, throttled by MAX_JOBS. ──
+  local -a _pods_for_comp
+  for _i in "${!_comps[@]}"; do
+    _comp="${_comps[$_i]}"
+    read -ra _pods_for_comp <<< "${_comp_pods_joined[$_i]}"
+    run_bg "component-$_comp" _collect_component_bucket "$_comp" "${_pods_for_comp[@]}"
+    throttle
+  done
+  wait_all
+
+  rm -rf "$PLATFORM_LOG_DIR/.ns_cache" 2>/dev/null
+
+  log_activity "Component-related collection complete (${#_comps[@]} component(s))."
+}
+
+# Cassandra nodetool stats (8 commands per pod). `sed 's/$/\r/'` normalizes
+# line endings for compatibility with the health-check script. No -it flag
+# (non-interactive contexts). Designed to be invoked via run_bg.
+function collectPlatformCassandraStats() {
+  [[ "${MANUAL_DEBUG:-false}" == "true" ]] && set -x
+  local pods
+  pods=$($k8sCmd get pods -l role=cassandra -n "$namespace" --no-headers -o custom-columns=NAME:metadata.name 2>/dev/null)
+  [[ -z "$pods" ]] && return 0
+  log_activity "Collecting Cassandra stats."
+  [[ -w /dev/tty ]] && printf "Collecting Cassandra stats...\n" > /dev/tty
+  printf "Fetching Cassandra statistics\n"
+  local pod dest
+  for pod in $pods; do
+    _pod_in_filter "$pod" || continue
+    dest=$(_datastore_dir_for_pod "$pod" cassandra)
+    mkdir -p "$dest"
+    $k8sCmd exec "$pod" -c cassandra -n "$namespace" -- nodetool info                                  2>/dev/null | sed 's/$/\r/' > "$dest/nodetool_info.log" || true
+    $k8sCmd exec "$pod" -c cassandra -n "$namespace" -- nodetool status                                2>/dev/null | sed 's/$/\r/' > "$dest/nodetool_status.log" || true
+    $k8sCmd exec "$pod" -c cassandra -n "$namespace" -- nodetool getcompactionthroughput               2>/dev/null | sed 's/$/\r/' > "$dest/nodetool_getcompactionthroughput.log" || true
+    $k8sCmd exec "$pod" -c cassandra -n "$namespace" -- nodetool cfstats                               2>/dev/null | sed 's/$/\r/' > "$dest/nodetool_cfstats.log" || true
+    $k8sCmd exec "$pod" -c cassandra -n "$namespace" -- nodetool cfhistograms draios message_data10    2>/dev/null | sed 's/$/\r/' > "$dest/nodetool_cfhistograms.log" || true
+    $k8sCmd exec "$pod" -c cassandra -n "$namespace" -- nodetool proxyhistograms                       2>/dev/null | sed 's/$/\r/' > "$dest/nodetool_proxyhistograms.log" || true
+    $k8sCmd exec "$pod" -c cassandra -n "$namespace" -- nodetool tpstats                               2>/dev/null | sed 's/$/\r/' > "$dest/nodetool_tpstats.log" || true
+    $k8sCmd exec "$pod" -c cassandra -n "$namespace" -- nodetool compactionstats                       2>/dev/null | sed 's/$/\r/' > "$dest/nodetool_compactionstats.log" || true
+  done
+  [[ -w /dev/tty ]] && printf "${_C_OK}Cassandra stats complete.${_C_RESET}\n" > /dev/tty
+  log_activity "Cassandra stats complete."
+}
+
+# Collect a datastore's on-disk usage: `du -ch <path>` inside each role-matched
+# pod's container, writing "<pod>\n<total>" to <label>_storage.log under the
+# pod's datastore dir. Used by the simple datastore collectors whose only
+# telemetry is a storage du (Postgres/Kafka/Zookeeper). Args: role, container,
+# du_path, label (dir/file stem), pretty (display name).
+function _collect_datastore_storage_du() {
+  local _role="$1" _container="$2" _path="$3" _label="$4" _pretty="$5"
+  local pods pod dest
+  pods=$($k8sCmd get pods -l "role=$_role" -n "$namespace" --no-headers -o custom-columns=NAME:metadata.name 2>/dev/null)
+  [[ -z "$pods" ]] && return 0
+  log_activity "Collecting $_pretty telemetry."
+  [[ -w /dev/tty ]] && printf "Collecting %s telemetry...\n" "$_pretty" > /dev/tty
+  for pod in $pods; do
+    _pod_in_filter "$pod" || continue
+    printf "Checking Used %s Storage - %s\n" "$_pretty" "$pod"
+    dest=$(_datastore_dir_for_pod "$pod" "$_label")
+    mkdir -p "$dest"
+    printf "%s\n" "$pod" > "$dest/${_label}_storage.log"
+    $k8sCmd exec "$pod" -c "$_container" -n "$namespace" -- du -ch "$_path" 2>/dev/null \
+      | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' \
+      >> "$dest/${_label}_storage.log" || true
+  done
+  [[ -w /dev/tty ]] && printf "${_C_OK}%s telemetry complete.${_C_RESET}\n" "$_pretty" > /dev/tty
+  log_activity "$_pretty telemetry complete."
+}
+
+# Cassandra storage du. Separated from nodetool so the two can run in parallel.
+function collectPlatformCassandraStorage() {
+  [[ "${MANUAL_DEBUG:-false}" == "true" ]] && set -x
+  local pods mountpath pod dest
+  pods=$($k8sCmd get pods -l role=cassandra -n "$namespace" --no-headers -o custom-columns=NAME:metadata.name 2>/dev/null)
+  [[ -z "$pods" ]] && return 0
+  log_activity "Collecting Cassandra storage."
+  [[ -w /dev/tty ]] && printf "Collecting Cassandra storage...\n" > /dev/tty
+  mountpath=$($k8sCmd get sts sysdigcloud-cassandra -n "$namespace" -ojsonpath='{.spec.template.spec.containers[].volumeMounts[?(@.name == "data")].mountPath}' 2>/dev/null)
+  for pod in $pods; do
+    _pod_in_filter "$pod" || continue
+    printf "Checking Used Cassandra Storage - %s\n" "$pod"
+    dest=$(_datastore_dir_for_pod "$pod" cassandra)
+    mkdir -p "$dest"
+    printf "%s\n" "$pod" > "$dest/cassandra_storage.log"
+    if [[ -n "$mountpath" ]]; then
+      $k8sCmd exec "$pod" -c cassandra -n "$namespace" -- du -ch "$mountpath" 2>/dev/null \
+        | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' \
+        >> "$dest/cassandra_storage.log" || true
+    else
+      printf "Error getting Cassandra %s mount path\n" "$pod" >> "$dest/cassandra_storage.log"
+    fi
+  done
+  [[ -w /dev/tty ]] && printf "${_C_OK}Cassandra storage complete.${_C_RESET}\n" > /dev/tty
+  log_activity "Cassandra storage complete."
+}
+
+# Elasticsearch / OpenSearch telemetry: health, indices, nodes, allocation,
+# index versions, cert expiry, storage du. TLS auto-detected via env or image.
+function collectPlatformElasticsearch() {
+  [[ "${MANUAL_DEBUG:-false}" == "true" ]] && set -x
+  local pods first_pod es_image cert_dir es_tls elastic_curl
+  pods=$($k8sCmd get pods -l role=elasticsearch -n "$namespace" --no-headers -o custom-columns=NAME:metadata.name 2>/dev/null)
+  [[ -z "$pods" ]] && { log_activity "No Elasticsearch pods found."; return 0; }
+
+  first_pod=$(echo "$pods" | head -1)
+  log_activity "Collecting Elasticsearch telemetry (probe: $first_pod)."
+  [[ -w /dev/tty ]] && printf "Collecting Elasticsearch telemetry (probe: %s)...\n" "$first_pod" > /dev/tty
+  printf "Collecting Elasticsearch telemetry (probe: %s)...\n" "$first_pod"
+
+  es_image=$($k8sCmd get pod "$first_pod" -n "$namespace" -ojsonpath='{.spec.containers[?(@.name == "elasticsearch")].image}' 2>/dev/null | awk -F '/' '{print $NF}' | cut -f 1 -d ':')
+
+  es_tls="false"
+  if [[ "$es_image" == "opensearch"* ]]; then
+    cert_dir="/usr/share/opensearch/config"
+    es_tls="true"
+  else
+    cert_dir="/usr/share/elasticsearch/config"
+    local _env_out
+    _env_out=$($k8sCmd exec "$first_pod" -c elasticsearch -n "$namespace" -- env 2>/dev/null | grep -i ELASTICSEARCH_TLS_ENCRYPTION) || true
+    if [[ "$_env_out" == *"ELASTICSEARCH_TLS_ENCRYPTION=true"* ]]; then
+      es_tls="true"
+    fi
+  fi
+
+  if [[ "$es_tls" == "true" ]]; then
+    # Vars inside the curl string are escaped so they're expanded by the IN-CONTAINER shell,
+    # not by our outer bash.
+    elastic_curl="curl -s --cacert ${cert_dir}/root-ca.pem https://\${ELASTICSEARCH_ADMINUSER}:\${ELASTICSEARCH_ADMIN_PASSWORD}@\$(hostname):9200"
+  else
+    elastic_curl='curl -s -k http://$(hostname):9200'
+  fi
+
+  local mountpath
+  mountpath=$($k8sCmd get sts sysdigcloud-elasticsearch -n "$namespace" -ojsonpath='{.spec.template.spec.containers[].volumeMounts[?(@.name == "data")].mountPath}' 2>/dev/null)
+
+  local pod dest
+  for pod in $pods; do
+    _pod_in_filter "$pod" || continue
+    printf "  %s\n" "$pod"
+    dest=$(_datastore_dir_for_pod "$pod" elasticsearch)
+    mkdir -p "$dest"
+
+    $k8sCmd exec "$pod" -c elasticsearch -n "$namespace" -- /bin/bash -c "${elastic_curl}/_cat/health"                    > "$dest/elasticsearch_health.log" 2>/dev/null || true
+    $k8sCmd exec "$pod" -c elasticsearch -n "$namespace" -- /bin/bash -c "${elastic_curl}/_cat/indices"                   > "$dest/elasticsearch_indices.log" 2>/dev/null || true
+    $k8sCmd exec "$pod" -c elasticsearch -n "$namespace" -- /bin/bash -c "${elastic_curl}/_cat/nodes?v"                   > "$dest/elasticsearch_nodes.log" 2>/dev/null || true
+    $k8sCmd exec "$pod" -c elasticsearch -n "$namespace" -- /bin/bash -c "${elastic_curl}/_cluster/allocation/explain?pretty" > "$dest/elasticsearch_index_allocation.log" 2>/dev/null || true
+
+    $k8sCmd exec "$pod" -c elasticsearch -n "$namespace" -- openssl x509 -in "${cert_dir}/node.pem"     -noout -enddate    > "$dest/elasticsearch_node_pem_expiration.log" 2>/dev/null || true
+    $k8sCmd exec "$pod" -c elasticsearch -n "$namespace" -- openssl x509 -in "${cert_dir}/admin.pem"    -noout -enddate    > "$dest/elasticsearch_admin_pem_expiration.log" 2>/dev/null || true
+    $k8sCmd exec "$pod" -c elasticsearch -n "$namespace" -- openssl x509 -in "${cert_dir}/root-ca.pem"  -noout -enddate    > "$dest/elasticsearch_root_ca_pem_expiration.log" 2>/dev/null || true
+
+    $k8sCmd exec "$pod" -c elasticsearch -n "$namespace" -- bash -c "${elastic_curl}/_all/_settings/index.version\*?pretty" > "$dest/elasticsearch_index_versions.log" 2>/dev/null || true
+
+    if [[ -n "$mountpath" ]]; then
+      $k8sCmd exec "$pod" -c elasticsearch -n "$namespace" -- du -ch "$mountpath" 2>/dev/null \
+        | grep -i total | awk '{printf "%-13s %10s\n",$1,$2}' \
+        > "$dest/elasticsearch_storage.log" || true
+    else
+      printf "Error getting ElasticSearch %s mount path\n" "$pod" > "$dest/elasticsearch_storage.log"
+    fi
+  done
+  [[ -w /dev/tty ]] && printf "${_C_OK}Elasticsearch telemetry complete.${_C_RESET}\n" > /dev/tty
+  log_activity "Elasticsearch telemetry complete."
+}
+
+# PostgreSQL storage du.
+function collectPlatformPostgres() {
+  [[ "${MANUAL_DEBUG:-false}" == "true" ]] && set -x
+  _collect_datastore_storage_du postgresql postgresql /var/lib/postgresql postgresql PostgreSQL
+}
+
+# Kafka storage du (container name: broker; role label: cp-kafka).
+function collectPlatformKafka() {
+  [[ "${MANUAL_DEBUG:-false}" == "true" ]] && set -x
+  _collect_datastore_storage_du cp-kafka broker /opt/kafka/data kafka Kafka
+}
+
+# Zookeeper storage du (container name: server).
+function collectPlatformZookeeper() {
+  [[ "${MANUAL_DEBUG:-false}" == "true" ]] && set -x
+  _collect_datastore_storage_du zookeeper server /var/lib/zookeeper/data zookeeper Zookeeper
+}
+
+# Neo4j cypher-shell health probes. Reads the ingestion_admin password from a
+# K8s Secret (tries neo4jdb-user-secrets first, then neo4j-user-secrets).
+# If the password can't be retrieved, writes a skip log and exits cleanly.
+function collectPlatformNeo4j() {
+  [[ "${MANUAL_DEBUG:-false}" == "true" ]] && set -x
+  log_activity "Collecting Neo4j telemetry."
+  [[ -w /dev/tty ]] && printf "Collecting Neo4j telemetry...\n" > /dev/tty
+  printf "Fetching Neo4j health info\n"
+  local pwd
+  pwd=$($k8sCmd get secret neo4jdb-user-secrets -n "$namespace" \
+    -o jsonpath='{.data.INGESTION_ADMIN_PASSWORD}' 2>/dev/null | base64 -d 2>/dev/null) || true
+  if [[ -z "$pwd" ]]; then
+    pwd=$($k8sCmd get secret neo4j-user-secrets -n "$namespace" \
+      -o jsonpath='{.data.INGESTION_ADMIN_PASSWORD}' 2>/dev/null | base64 -d 2>/dev/null) || true
+  fi
+  if [[ -z "$pwd" ]]; then
+    mkdir -p "$PLATFORM_LOG_DIR/neo4j"
+    printf "Skipping Neo4j cypher-shell checks: unable to retrieve ingestion_admin password from secrets\n" \
+      > "$PLATFORM_LOG_DIR/neo4j/neo4j_cypher_status_skipped.log"
+    log_activity "Neo4j skipped: ingestion_admin password unavailable."
+    return 0
+  fi
+
+  # Suppress xtrace through the cypher invocations: when MANUAL_DEBUG=true the
+  # password would otherwise be expanded into the trace and land in
+  # _background_jobs/neo4j.err inside the support bundle. Restore after.
+  local _xtrace_was_on=false
+  case $- in *x*) _xtrace_was_on=true; set +x ;; esac
+
+  local cypher="cypher-shell -a neo4j+ssc://neo4j-internals.${namespace}.svc.cluster.local:7687 -u ingestion_admin -p ${pwd}"
+  local pod dest
+  for pod in $($k8sCmd get pods -l app=neo4j-cluster -n "$namespace" --no-headers -o custom-columns=NAME:metadata.name 2>/dev/null); do
+    _pod_in_filter "$pod" || continue
+    dest=$(_datastore_dir_for_pod "$pod" neo4j)
+    mkdir -p "$dest"
+    $k8sCmd exec "$pod" -c neo4j -n "$namespace" -- bash -c "${cypher} 'SHOW SERVERS;'"   > "$dest/cypher_show_servers.txt"   2>/dev/null || true
+    $k8sCmd exec "$pod" -c neo4j -n "$namespace" -- bash -c "${cypher} 'SHOW DATABASES;'" > "$dest/cypher_show_databases.txt" 2>/dev/null || true
+  done
+
+  [[ "$_xtrace_was_on" == "true" ]] && set -x
+  [[ -w /dev/tty ]] && printf "${_C_OK}Neo4j telemetry complete.${_C_RESET}\n" > /dev/tty
+  log_activity "Neo4j telemetry complete."
+}
+
+# Ask which team is requesting the bundle. Sysdig Support typically doesn't
+# need API-backed data (license/settings/metrics/scanning); Professional
+# Services does. Drives whether prompt_api_keys is invoked downstream.
+# Returns 0 on selection, 1 if user cancels.
+function select_requesting_team() {
+  printf "\n  ${_C_BOLD}Which team is requesting these logs?${_C_RESET}\n"
+  printf "    ${_C_KEY}[1]${_C_RESET} Sysdig Support\n"
+  printf "    ${_C_KEY}[2]${_C_RESET} Sysdig Professional Services\n"
+  printf "    ${_C_KEY}[0]${_C_RESET} Back\n"
+  while true; do
+    printf "\n  >> Select [0-2]: "
+    local team_choice
+    read -r team_choice
+    case "$team_choice" in
+      0) return 1 ;;
+      1) REQUESTING_TEAM="support";               break ;;
+      2) REQUESTING_TEAM="professional_services"; break ;;
+      *) printf "  ${_C_WARN}Please select 0, 1, or 2.${_C_RESET}\n" ;;
+    esac
+  done
+  log_activity "Requesting team: $REQUESTING_TEAM"
+  return 0
+}
+
+# Probe /api/license with the given Bearer token. Returns 0 if the API
+# accepts the key (HTTP 2xx via curl -f), 1 otherwise.
+function _validate_api_key() {
+  local key="$1"
+  [[ -z "$API_URL" ]] && return 1
+  curl -fks --max-time 10 \
+    -H "Authorization: Bearer ${key}" \
+    -H "Content-Type: application/json" \
+    "${API_URL}/api/license" >/dev/null 2>&1
+}
+
+# Ensure API_URL is set and reachable. Tries the configmap-discovered URL
+# first (legacy default), falls back to port-forward (legacy -la equivalent).
+# Returns 1 if neither path works.
+function _ensure_api_url() {
+  if discover_platform_api_url && _platform_api_reachable; then
+    printf "\n  ${_C_OK}API reachable at %s${_C_RESET}\n" "$API_URL"
+    log_activity "Using direct API URL for validation and collection."
+    return 0
+  fi
+  printf "\n  ${_C_WARN}Direct API URL unreachable; setting up kubectl port-forward...${_C_RESET}\n"
+  log_activity "Direct API URL unreachable; starting port-forward."
+  start_platform_portforward
+}
+
+# Prompt for SuperUser API keys based on SYSDIG_PRODUCT.
+# Mandatory for Professional Services — empty input rejected, "0" cancels.
+# Each key is validated against ${API_URL}/api/license right after entry;
+# on rejection, only THAT key is re-prompted (independent retry).
+# Maps to legacy script flags documented in support_bundle/README.md:
+#   -a  /  --api-key         → Monitor SuperUser key (license/settings/metrics)
+#   -sa /  --secure-api-key  → Secure SuperUser key  (scanning v1/v2)
+# Returns 0 once all required keys are non-empty and validated, 1 if cancelled.
+function prompt_api_keys() {
+  local need_monitor=false need_secure=false
+  case "$SYSDIG_PRODUCT" in
+    monitor)  need_monitor=true ;;
+    secure)   need_secure=true ;;
+    platform) need_monitor=true; need_secure=true ;;
+  esac
+
+  if [[ "$need_monitor" == "true" ]]; then
+    while true; do
+      printf "\n  Monitor SuperUser API key (or 0 to cancel): "
+      read -rs MONITOR_API_KEY
+      printf "\n"
+      if [[ "$MONITOR_API_KEY" == "0" ]]; then
+        MONITOR_API_KEY=""
+        log_activity "User cancelled at Monitor API key prompt."
+        return 1
+      fi
+      if [[ -z "$MONITOR_API_KEY" ]]; then
+        printf "  ${_C_WARN}Key cannot be empty.${_C_RESET}\n"
+        continue
+      fi
+      printf "  Validating Monitor key against %s/api/license...\n" "$API_URL"
+      if _validate_api_key "$MONITOR_API_KEY"; then
+        printf "  ${_C_OK}Monitor key validated.${_C_RESET}\n"
+        log_activity "Monitor API key validated."
+        break
+      fi
+      printf "  ${_C_ERR}Monitor API key rejected by the platform. Please try again.${_C_RESET}\n"
+      log_activity "Monitor API key validation failed; re-prompting."
+    done
+  fi
+
+  if [[ "$need_secure" == "true" ]]; then
+    while true; do
+      printf "\n  Secure SuperUser API key (or 0 to cancel): "
+      read -rs SECURE_API_KEY
+      printf "\n"
+      if [[ "$SECURE_API_KEY" == "0" ]]; then
+        MONITOR_API_KEY=""
+        SECURE_API_KEY=""
+        log_activity "User cancelled at Secure API key prompt."
+        return 1
+      fi
+      if [[ -z "$SECURE_API_KEY" ]]; then
+        printf "  ${_C_WARN}Key cannot be empty.${_C_RESET}\n"
+        continue
+      fi
+      printf "  Validating Secure key against %s/api/license...\n" "$API_URL"
+      if _validate_api_key "$SECURE_API_KEY"; then
+        printf "  ${_C_OK}Secure key validated.${_C_RESET}\n"
+        log_activity "Secure API key validated."
+        break
+      fi
+      printf "  ${_C_ERR}Secure API key rejected by the platform. Please try again.${_C_RESET}\n"
+      log_activity "Secure API key validation failed; re-prompting."
+    done
+  fi
+  log_activity "API keys provided & validated for product=$SYSDIG_PRODUCT."
+  return 0
+}
+
+# Detect backend version (sets BACKEND_VERSION + BACKEND_VERSION_TAG) without
+# writing to a file. Cheap probe used before PLATFORM_LOG_DIR exists.
+function detect_platform_backend_version() {
+  local _img
+  _img=$($k8sCmd get deployment sysdigcloud-api -n "$namespace" -ojsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+  # Strip any "@sha256:..." digest suffix before extracting the tag, so
+  # digest-pinned images (common with ArgoCD/Flux) still resolve to a version.
+  _img="${_img%@sha256:*}"
+  BACKEND_VERSION_TAG="${_img##*:}"
+  BACKEND_VERSION="${BACKEND_VERSION_TAG%%.*}"
+}
+
+# Discover the on-prem API URL from the appropriate ConfigMap, branched on
+# backend version (matches legacy direct-URL default). Sets API_URL.
+# Returns 1 if the configmap is missing or the URL field is empty.
+function discover_platform_api_url() {
+  if [[ "$BACKEND_VERSION" =~ ^(7|6)$ ]]; then
+    API_URL=$($k8sCmd get cm sysdigcloud-collector-config -n "$namespace" -ojsonpath='{.data.collector-config\.conf}' 2>/dev/null \
+      | grep serverName | head -1 | awk '{print $3}' | sed 's/"//g')
+  elif [[ "$BACKEND_VERSION" =~ ^(5|4|3)$ ]]; then
+    API_URL=$($k8sCmd get cm sysdigcloud-config -n "$namespace" -o yaml 2>/dev/null \
+      | grep -i api.url: | head -1 | awk '{print $2}')
+  else
+    API_URL=""
+    log_activity "Unknown backend version '${BACKEND_VERSION}'; API URL discovery skipped."
+    return 1
+  fi
+  if [[ -z "$API_URL" ]]; then
+    log_activity "API URL discovery returned empty for backend v${BACKEND_VERSION}."
+    return 1
+  fi
+  log_activity "Discovered direct API URL: ${API_URL}"
+  return 0
+}
+
+# Probe the discovered API URL for reachability. curl returns 0 on any HTTP
+# response (including 401/403/500) — we only care that something is listening.
+# Returns 1 on connect/timeout/dns errors.
+function _platform_api_reachable() {
+  [[ -z "$API_URL" ]] && return 1
+  curl -sk --max-time 5 -o /dev/null "${API_URL}/api/license" 2>/dev/null
+}
+
+# Start kubectl port-forward to sysdigcloud-api:8080 (legacy -la equivalent).
+# Used by option 4 as a fallback when the direct API URL is unreachable.
+# Sets API_URL + API_PORTFORWARD_PID. Returns 0 on success, 1 on failure.
+function start_platform_portforward() {
+  # Clean up any previously tracked port-forward before starting a new one.
+  # Without this, repeated stage re-entry (team → api_keys → back → api_keys)
+  # leaks the prior kubectl process: the new one can't bind localhost:8080,
+  # exits immediately, and overwrites API_PORTFORWARD_PID with its dead PID.
+  stop_platform_portforward
+
+  $k8sCmd port-forward -n "$namespace" service/sysdigcloud-api 8080 > /dev/null 2>&1 &
+  API_PORTFORWARD_PID=$!
+  local attempts=0
+  while ! curl -s localhost:8080 > /dev/null 2>&1; do
+    sleep 0.2
+    attempts=$(( attempts + 1 ))
+    if [[ $attempts -gt 50 ]]; then
+      kill "$API_PORTFORWARD_PID" 2>/dev/null
+      API_PORTFORWARD_PID=""
+      log_activity "Port-forward to sysdigcloud-api failed after 10s."
+      return 1
+    fi
+  done
+  API_URL="http://127.0.0.1:8080"
+  log_activity "Port-forward established: ${API_URL} (PID $API_PORTFORWARD_PID)"
+  return 0
+}
+
+function stop_platform_portforward() {
+  if [[ -n "$API_PORTFORWARD_PID" ]]; then
+    kill "$API_PORTFORWARD_PID" 2>/dev/null
+    log_activity "Port-forward stopped (PID $API_PORTFORWARD_PID)."
+    API_PORTFORWARD_PID=""
+  fi
+}
+
+# Global signal handler. Set at script startup, fires for INT/TERM/TSTP/HUP.
+# Each action is conditional: it does work only if the corresponding state is
+# set, so the same handler covers Phase 1 (where most fields are empty) and
+# Phase 2 (where bg jobs / port-forward / API keys may be live). Partial
+# collected files are intentionally left on disk for inspection.
+function _cleanup_on_signal() {
+  local _sig="${1:-SIGNAL}"
+  printf "\n\n  ${_C_WARN}Interrupted (%s).${_C_RESET}\n" "$_sig"
+  log_activity "Script interrupted by $_sig."
+
+  # Count what actually needs cleaning so the message reflects reality.
+  local _ephemeral=0
+  [[ "${#BACKGROUND_PIDS[@]}" -gt 0 ]] && _ephemeral=1
+  [[ -n "$API_PORTFORWARD_PID" ]]     && _ephemeral=1
+  [[ -n "$MONITOR_API_KEY" || -n "$SECURE_API_KEY" ]] && _ephemeral=1
+
+  if (( _ephemeral )); then
+    printf "  ${_C_WARN}Stopping background tasks and clearing in-memory secrets...${_C_RESET}\n"
+  fi
+
+  # Kill any in-flight background jobs spawned by run_bg (Phase 2 only).
+  local _pid
+  for _pid in "${BACKGROUND_PIDS[@]+"${BACKGROUND_PIDS[@]}"}"; do
+    kill "$_pid" 2>/dev/null
+  done
+  BACKGROUND_PIDS=()
+
+  # Stop port-forward if active (Phase 2 PS path only).
+  if [[ -n "$API_PORTFORWARD_PID" ]]; then
+    kill "$API_PORTFORWARD_PID" 2>/dev/null
+    API_PORTFORWARD_PID=""
+  fi
+
+  # Wipe API keys from memory (Phase 2 PS path only).
+  MONITOR_API_KEY=""
+  SECURE_API_KEY=""
+
+  # Tell the user where the partial output lives. Files on disk (activity.log,
+  # config artifacts, per-pod logs collected before the interrupt) are
+  # preserved on purpose — same convention as kubectl / tar / docker. Only
+  # surface this when a run is actually in flight (LOG_PHASE=run-active); in
+  # bootstrap or run-prep nothing has been written for this session yet, and
+  # a leftover directory from a prior run would make the message lie.
+  if [[ "$LOG_PHASE" == "run-active" && -n "$DEST_DIR" && -n "$SYSDIG_SUPPORT_DIR" && -d "$DEST_DIR/$SYSDIG_SUPPORT_DIR" ]]; then
+    printf "  ${_C_OK}Partial output preserved at:${_C_RESET} %s\n" "$DEST_DIR/$SYSDIG_SUPPORT_DIR"
+  fi
+  printf "  ${_C_OK}Goodbye.${_C_RESET}\n"
+  log_activity "Script exit on $_sig."
+  exit 130
+}
+
+# Single metric query (matches legacy get_metrics). Args: metric, segment_by, from_epoch, to_epoch.
+function _platform_get_metric() {
+  local metric="$1" segment_by="$2" from="$3" to="$4"
+  curl -sk --location --request POST "${API_URL}/api/data/batch?metricCompatibilityValidation=true&emptyValuesAsNull=true" \
+    --header "X-Sysdig-Product: SDC" \
+    --header "Authorization: Bearer ${MONITOR_API_KEY}" \
+    --header "Content-Type: application/json" \
+    -d "{\"requests\":[{\"format\":{\"type\":\"data\"},\"time\":{\"from\":${from}000000,\"to\":${to}000000,\"sampling\":600000000},\"metrics\":{\"v0\":\"${metric}\",\"k0\":\"timestamp\",\"k1\":\"${segment_by}\"},\"group\":{\"aggregations\":{\"v0\":\"avg\"},\"groupAggregations\":{\"v0\":\"avg\"},\"by\":[{\"metric\":\"k0\",\"value\":600000000},{\"metric\":\"k1\"}],\"configuration\":{\"groups\":[{\"groupBy\":[]}]}},\"paging\":{\"from\":0,\"to\":9999},\"sort\":[{\"v0\":\"desc\"}],\"scope\":null,\"compareTo\":null}]}" \
+    > "$PLATFORM_LOG_DIR/metrics/${metric}_${segment_by}.json" 2>/dev/null \
+    || log_activity "Curl failed for metric ${metric}_${segment_by}"
+}
+
+# Agent-version + metric-count query (matches legacy get_agent_version_metric_limits).
+function _platform_get_agent_version_metric_limits() {
+  local from="$1" to="$2"
+  curl -sk --location --request POST "${API_URL}/api/data/batch?metricCompatibilityValidation=true&emptyValuesAsNull=true" \
+    --header "X-Sysdig-Product: SDC" \
+    --header "Authorization: Bearer ${MONITOR_API_KEY}" \
+    --header "Content-Type: application/json" \
+    -d "{\"requests\":[{\"format\":{\"type\":\"data\"},\"time\":{\"from\":${from}000000,\"to\":${to}000000,\"sampling\":600000000},\"metrics\":{\"v0\":\"agent.version\",\"v1\":\"agent.mode\",\"v2\":\"metricCount.statsd\",\"v3\":\"metricCount.prometheus\",\"v4\":\"metricCount.appCheck\",\"v5\":\"metricCount.jmx\",\"k1\":\"host.hostName\",\"k2\":\"host.mac\"},\"group\":{\"aggregations\":{\"v0\":\"concat\",\"v1\":\"concat\",\"v2\":\"max\",\"v3\":\"max\",\"v4\":\"avg\",\"v5\":\"avg\"},\"groupAggregations\":{\"v0\":\"concat\",\"v1\":\"concat\",\"v2\":\"sum\",\"v3\":\"sum\",\"v4\":\"avg\",\"v5\":\"avg\"},\"by\":[{\"metric\":\"k1\"},{\"metric\":\"k2\"}],\"configuration\":{\"groups\":[{\"groupBy\":[]}]}},\"paging\":{\"from\":0,\"to\":9999},\"sort\":[{\"v0\":\"desc\"},{\"v1\":\"desc\"},{\"v2\":\"desc\"},{\"v3\":\"desc\"},{\"v4\":\"desc\"},{\"v5\":\"desc\"}],\"scope\":null,\"compareTo\":null}]}" \
+    > "$PLATFORM_LOG_DIR/metrics/agent_version_metric_limits.json" 2>/dev/null \
+    || log_activity "Curl failed for agent_version_metric_limits"
+}
+
+# Compute the last-24h window aligned to the current hour boundary (matches legacy).
+function _platform_time_window() {
+  local _to
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    _to=$(date -jf "%H:%M:%S" "$(date +%H):00:00" +%s)
+  else
+    _to=$(date -d "$(date +%H):00:00" +%s)
+  fi
+  printf "%s %s" "$((_to - 86400))" "$_to"
+}
+
+# GET a Monitor API endpoint with the standard Bearer + JSON headers and append
+# the (non-fatal) response body to a file. Args: api_path (no leading slash),
+# outfile.
+function _monitor_api_get() {
+  curl -ks -H "Authorization: Bearer ${MONITOR_API_KEY}" -H "Content-Type: application/json" "${API_URL}/$1" >> "$2" 2>/dev/null || true
+}
+
+# Monitor API collection: license, settings, users/teams, alerts, metrics,
+# agent_version_metric_limits, plus version-specific settings (meerkat vs
+# fastPath/index). Validates the key against /api/license first.
+function collectPlatformMonitorApi() {
+  [[ -z "$MONITOR_API_KEY" ]] && { log_activity "Monitor API key not provided; skipping Monitor API collection."; return 0; }
+
+  if ! _validate_api_key "$MONITOR_API_KEY"; then
+    printf "  ${_C_WARN}WARNING: Monitor API key validation failed. Skipping Monitor data.${_C_RESET}\n"
+    log_activity "Monitor API key invalid; skipping Monitor data."
+    return 0
+  fi
+
+  printf "Collecting Monitor API data (backend %s)...\n" "$BACKEND_VERSION"
+
+  # Version-specific settings
+  if [[ "$BACKEND_VERSION" =~ ^(7|6)$ ]]; then
+    _monitor_api_get "api/admin/customer/1/meerkatSettings"  "$PLATFORM_LOG_DIR/meerkat_settings.json"
+  elif [[ "$BACKEND_VERSION" =~ ^(5|4|3)$ ]]; then
+    _monitor_api_get "api/admin/customer/1/fastPathSettings" "$PLATFORM_LOG_DIR/fastPath_settings.json"
+    _monitor_api_get "api/admin/customer/1/indexSettings"    "$PLATFORM_LOG_DIR/index_settings.json"
+  fi
+
+  # Common endpoints
+  _monitor_api_get "api/license"                              "$PLATFORM_LOG_DIR/license.json"
+  _monitor_api_get "api/agents/connected?checkStatus=true"    "$PLATFORM_LOG_DIR/agents_connected.json"
+  _monitor_api_get "api/admin/customer/1/storageSettings"     "$PLATFORM_LOG_DIR/storage_settings.json"
+  _monitor_api_get "api/admin/customer/1/streamsnapSettings"  "$PLATFORM_LOG_DIR/streamSnap_settings.json"
+  _monitor_api_get "api/admin/customers/1/snapshotSettings"   "$PLATFORM_LOG_DIR/snapshot_settings.json"
+  _monitor_api_get "api/admin/customer/1/planSettings"        "$PLATFORM_LOG_DIR/plan_settings.json"
+  _monitor_api_get "api/admin/customer/1/dataRetentionSettings" "$PLATFORM_LOG_DIR/dataRetention_settings.json"
+  _monitor_api_get "api/v2/users/light"                       "$PLATFORM_LOG_DIR/users.json"
+  _monitor_api_get "api/v2/teams/light"                       "$PLATFORM_LOG_DIR/teams.json"
+  _monitor_api_get "api/admin/auth/settings"                  "$PLATFORM_LOG_DIR/sso_settings.json"
+  _monitor_api_get "api/alerts"                               "$PLATFORM_LOG_DIR/alerts.json"
+
+  # Metrics — last 24h aligned to current hour, with 10-minute sampling
+  printf "Collecting Monitor metrics (last 24h)...\n"
+  mkdir -p "$PLATFORM_LOG_DIR/metrics"
+  local _from _to
+  read -r _from _to <<< "$(_platform_time_window)"
+  local _default_segment="host.hostName"
+  local _syscall_segments=("host.hostName" "proc.name")
+  local _metrics=("syscall.count" "dragent.analyzer.sr" "container.count" "dragent.analyzer.n_drops_buffer" "dragent.analyzer.n_evts")
+  local _metric _segment
+  for _metric in "${_metrics[@]}"; do
+    if [[ "$_metric" == "syscall.count" ]]; then
+      for _segment in "${_syscall_segments[@]}"; do
+        _platform_get_metric "$_metric" "$_segment" "$_from" "$_to"
+      done
+    else
+      _platform_get_metric "$_metric" "$_default_segment" "$_from" "$_to"
+    fi
+  done
+  _platform_get_agent_version_metric_limits "$_from" "$_to"
+  log_activity "Monitor API collection complete."
+}
+
+# Secure API collection: detect scanningV1/V2 enablement, collect results.
+function collectPlatformSecureApi() {
+  [[ -z "$SECURE_API_KEY" ]] && { log_activity "Secure API key not provided; skipping Secure API collection."; return 0; }
+
+  if ! _validate_api_key "$SECURE_API_KEY"; then
+    printf "  ${_C_WARN}WARNING: Secure API key validation failed. Skipping Secure data.${_C_RESET}\n"
+    log_activity "Secure API key invalid; skipping Secure data."
+    return 0
+  fi
+
+  printf "Collecting Secure API data...\n"
+  mkdir -p "$PLATFORM_LOG_DIR/scanning"
+
+  local _settings
+  _settings=$(curl -ks "${API_URL}/api/secure/customerSettings" -H "Authorization: Bearer ${SECURE_API_KEY}" 2>/dev/null) || true
+
+  if echo "$_settings" | grep -Eq "\"scanningV1Enabled\":true"; then
+    printf "  Scanning v1 enabled; collecting...\n"
+    curl -ks "${API_URL}/api/scanning/v1/resultsDirect?limit=1" -H "Authorization: Bearer ${SECURE_API_KEY}" >> "$PLATFORM_LOG_DIR/scanning/scanningv1.txt" 2>/dev/null || true
+  else
+    log_activity "Scanning v1 not detected."
+  fi
+
+  if echo "$_settings" | grep -Eq "\"scanningV2Enabled\":true"; then
+    printf "  Scanning v2 enabled; collecting...\n"
+    curl -ks "${API_URL}/api/scanning/scanresults/v2/results" -H "Authorization: Bearer ${SECURE_API_KEY}" >> "$PLATFORM_LOG_DIR/scanning/scanningv2.txt" 2>/dev/null || true
+  else
+    log_activity "Scanning v2 not detected."
+  fi
+
+  log_activity "Secure API collection complete."
+}
+
+# Archive the platform work dir into ${epoch}_sysdig_cloud_support_bundle.tgz
+# (matches legacy bundle name), optionally upload to S3, then clean up.
+function createPlatformArchive() {
+  [[ -z "$PLATFORM_LOG_DIR" || ! -d "$PLATFORM_LOG_DIR" ]] && {
+    printf "${_C_ERR}Error: No platform work directory to archive.${_C_RESET}\n"
+    log_activity "Platform archive creation failed: working directory missing."
+    return 1
+  }
+
+  local orig_dir archive_name work_dir platform_basename
+  orig_dir=$(pwd)
+  archive_name="$(date +%s)_sysdig_cloud_support_bundle.tgz"
+  work_dir="$DEST_DIR/$SYSDIG_SUPPORT_DIR"
+  platform_basename=$(basename "$PLATFORM_LOG_DIR")
+
+  cd "$work_dir" || { printf "${_C_ERR}Cannot access output directory: %s${_C_RESET}\n" "$work_dir"; return 1; }
+
+  # Include the work dir + activity.log (so support gets the run context)
+  local tar_targets=("$platform_basename")
+  [[ -f "activity.log" ]] && tar_targets+=("activity.log")
+
+  _redact_targets "${tar_targets[@]}"
+
+  printf "\nCreating archive %s...\n" "$archive_name"
+  log_activity "Creating platform archive: $archive_name"
+
+  local errorMessage rc
+  errorMessage=$(tar czf "$archive_name" "${tar_targets[@]}" 2>&1)
+  rc=$?
+  if [[ $rc -ge 2 ]]; then
+    printf "${_C_ERR}Error creating archive: %s${_C_RESET}\n" "$errorMessage"
+    log_activity "Platform archive creation failed: $errorMessage"
+    cd "$orig_dir"
+    return 1
+  fi
+  [[ $rc -eq 1 ]] && log_activity "Archive created with warnings: $errorMessage"
+
+  printf "${_C_OK}Archive created:${_C_RESET} %s\n" "$archive_name"
+  log_activity "Platform archive $archive_name created."
+
+  # Drop the raw work directory; keep the archive (+ activity.log standalone)
+  rm -rf "$PLATFORM_LOG_DIR"
+  PLATFORM_LOG_DIR=""
+
+  _upload_archive_to_s3 "$archive_name" "$work_dir"
+
+  if [[ ${#FAILED_PODS[@]} -gt 0 ]]; then
+    printf "\n${_C_WARN}--- WARNING: SOME PODS HAD COLLECTION ISSUES ---${_C_RESET}\n"
+    printf "  Pod list:\n"
+    printf "    - %s\n" "${FAILED_PODS[@]}"
+    printf "----------------------------------------------\n"
+    FAILED_PODS=()
+  fi
+
+  local archive_size="(uploaded)"
+  if [[ -f "$archive_name" ]]; then
+    archive_size=$(du -h "$archive_name" 2>/dev/null | awk '{print $1}')
+  fi
+
+  printf "\nSaved to : %s\n" "$work_dir"
+  printf "Archive  : %s (%s)\n" "$archive_name" "$archive_size"
+  printf "Retained : activity.log"
+  [[ -f "$archive_name" ]] && printf " + %s" "$archive_name"
+  printf "\n"
+  log_activity "Platform archive cleanup complete. Archive size: $archive_size."
+
+  cd "$orig_dir"
+  return 0
+}
+
+# Populate SYSDIGCLOUD_PODS with all non-Job pods in $namespace. Pods owned
+# by Jobs (transient, often Completed) are excluded — matches legacy v2's
+# manifest collection (which also omits Job manifests).
+function _populate_sysdigcloud_pods() {
+  SYSDIGCLOUD_PODS=()
+  local _line
+  # All non-Job pods in the namespace. Manual mode narrows further via
+  # MANUAL_PODS_FILTER (set by the component or pod picker).
+  while IFS= read -r _line; do
+    [[ -n "$_line" ]] && SYSDIGCLOUD_PODS+=("$_line")
+  done < <($k8sCmd get pods -n "$namespace" --no-headers \
+    -o custom-columns="NAME:metadata.name,OWNER:metadata.ownerReferences[0].kind" 2>/dev/null \
+    | awk '$2 != "Job" { print $1 }')
+
+  # Manual mode: explicit pod list restricts further (intersection).
+  if [[ ${#MANUAL_PODS_FILTER[@]} -gt 0 ]]; then
+    local _kept=() _p _f
+    for _p in "${SYSDIGCLOUD_PODS[@]}"; do
+      for _f in "${MANUAL_PODS_FILTER[@]}"; do
+        if [[ "$_p" == "$_f" ]]; then
+          _kept+=("$_p")
+          break
+        fi
+      done
+    done
+    SYSDIGCLOUD_PODS=("${_kept[@]}")
+  fi
+}
+
+# True in narrow modes (components/pods). Used to gate cluster-wide
+# collectors that either need cluster-scoped RBAC the user may not have,
+# or that produce bulky output unrelated to the picked component(s).
+function _manual_scope_is_narrow() {
+  case "${MANUAL_SCOPE_MODE:-all}" in
+    components|pods) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# True if pod is in MANUAL_PODS_FILTER, or the filter is empty (broad mode).
+# Datastore collectors use this to skip pods outside the narrow scope.
+function _pod_in_filter() {
+  local _pod="$1" _f
+  [[ ${#MANUAL_PODS_FILTER[@]} -eq 0 ]] && return 0
+  for _f in "${MANUAL_PODS_FILTER[@]}"; do
+    [[ "$_pod" == "$_f" ]] && return 0
+  done
+  return 1
+}
+
+# Destination dir for a pod's logs+describe artifacts.
+#   narrow: component/<derived>/pods/<pod>/
+#   broad:  pod_logs/<pod>/ (logs) — describes use _pod_describe_dir instead
+function _pod_log_dir() {
+  local _pod="$1"
+  if _manual_scope_is_narrow; then
+    local _comp; _comp=$(_derive_component_for_pod "$_pod")
+    echo "$PLATFORM_LOG_DIR/component/$_comp/pods/$_pod"
+  else
+    echo "$PLATFORM_LOG_DIR/pod_logs/$_pod"
+  fi
+}
+
+# Destination dir for a pod's kubectl-describe.json.
+# In narrow mode, co-located with logs under component/<derived>/pods/<pod>/.
+# In broad mode, kept at the legacy top-level <pod>/ path.
+function _pod_describe_dir() {
+  local _pod="$1"
+  if _manual_scope_is_narrow; then
+    local _comp; _comp=$(_derive_component_for_pod "$_pod")
+    echo "$PLATFORM_LOG_DIR/component/$_comp/pods/$_pod"
+  else
+    echo "$PLATFORM_LOG_DIR/$_pod"
+  fi
+}
+
+# Destination dir for a datastore's per-pod telemetry.
+# Args: pod_name, datastore_label (e.g. "cassandra", "postgresql")
+#   narrow: component/<derived>/datastore/<pod>/
+#   broad:  <datastore_label>/<pod>/
+function _datastore_dir_for_pod() {
+  local _pod="$1" _label="$2"
+  if _manual_scope_is_narrow; then
+    local _comp; _comp=$(_derive_component_for_pod "$_pod")
+    echo "$PLATFORM_LOG_DIR/component/$_comp/datastore/$_pod"
+  else
+    echo "$PLATFORM_LOG_DIR/$_label/$_pod"
+  fi
+}
+
+# Decide whether a datastore collector should run under manual scope.
+# Args: label_selector (e.g. "role=cassandra", "app=neo4j-cluster")
+# Returns 0 if telemetry should be collected, 1 if it should be skipped.
+#   - all / health / unset → always collect (health mode explicitly wants DB stats)
+#   - components / pods   → collect only if MANUAL_PODS_FILTER intersects pods
+#                           carrying the given label
+function _manual_datastore_in_scope() {
+  local _selector="$1"
+  case "${MANUAL_SCOPE_MODE:-all}" in
+    ""|all|health) return 0 ;;
+  esac
+  [[ ${#MANUAL_PODS_FILTER[@]} -eq 0 ]] && return 0
+  local _pods _p _f
+  _pods=$($k8sCmd get pods -l "$_selector" -n "$namespace" --no-headers \
+    -o custom-columns=NAME:metadata.name 2>/dev/null)
+  [[ -z "$_pods" ]] && return 1
+  while IFS= read -r _p; do
+    for _f in "${MANUAL_PODS_FILTER[@]}"; do
+      [[ "$_p" == "$_f" ]] && return 0
+    done
+  done <<< "$_pods"
+  return 1
+}
+
+# Schedule every datastore-telemetry collector as a parallel background job.
+# Each is gated by _manual_datastore_in_scope, which is a no-op (always 0) under
+# all/health/unset scope, so this is unconditional in the automatic collector and
+# scope-filtered in the manual / CLI collectors. Caller is responsible for wait_all.
+function _dispatch_datastore_collectors() {
+  _manual_datastore_in_scope "role=cassandra"     && run_bg "cassandra-stats"   collectPlatformCassandraStats
+  _manual_datastore_in_scope "role=cassandra"     && run_bg "cassandra-storage" collectPlatformCassandraStorage
+  _manual_datastore_in_scope "role=elasticsearch" && run_bg "elasticsearch"     collectPlatformElasticsearch
+  _manual_datastore_in_scope "role=postgresql"    && run_bg "postgresql"        collectPlatformPostgres
+  _manual_datastore_in_scope "role=cp-kafka"      && run_bg "kafka"             collectPlatformKafka
+  _manual_datastore_in_scope "role=zookeeper"     && run_bg "zookeeper"         collectPlatformZookeeper
+  _manual_datastore_in_scope "app=neo4j-cluster"  && run_bg "neo4j"             collectPlatformNeo4j
+}
+
+# Create the legacy-style platform working directory
+# (sysdigcloud-support-bundle-XXXX) under DEST_DIR/SYSDIG_SUPPORT_DIR, setting
+# the global PLATFORM_LOG_DIR. Also creates the per-run failure-tracker dir
+# PLATFORM_FAIL_DIR and exports the tunables background subshells inherit.
+# Returns 1 (after printing an error) if the directory can't be created. Callers
+# print their own PLATFORM_LOG_DIR log line / "Working directory" notice after.
+function _setup_platform_workdir() {
+  PLATFORM_LOG_DIR=$(mktemp -d "${DEST_DIR}/${SYSDIG_SUPPORT_DIR}/sysdigcloud-support-bundle-XXXX") || {
+    printf "${_C_ERR}Error: Could not create working directory.${_C_RESET}\n"
+    log_activity "Failed to create PLATFORM_LOG_DIR."
+    return 1
+  }
+  PLATFORM_FAIL_DIR="$PLATFORM_LOG_DIR/.failed_containers"
+  mkdir -p "$PLATFORM_FAIL_DIR"
+  export MANUAL_SINCE_OPTS MANUAL_DEBUG PLATFORM_FAIL_DIR
+}
+
+function automatic_platform_collector() {
+  trap 'stop_platform_portforward; trap - INT TERM RETURN' RETURN
+  prepare_platform_context || return 1
+
+  _populate_sysdigcloud_pods
+
+  if [[ ${#SYSDIGCLOUD_PODS[@]} -eq 0 ]]; then
+    printf "\n  ${_C_WARN}No collectable pods found in namespace '%s' (Job pods are excluded).${_C_RESET}\n" "$namespace"
+    return 1
+  fi
+
+  # Reset shared knobs at entry — never inherit from a prior invocation (e.g.
+  # a previous option-5 run could leave MANUAL_SCOPE_MODE non-empty, which
+  # would flip option-4 into narrow-scope behavior). FAILED_PODS is also
+  # reset so a Phase-1 (option 1/2/3) run interrupted before its archive
+  # step can't leak its failed-pod list into this run's archive warning.
+  MANUAL_COMPONENTS=""
+  MANUAL_PODS_FILTER=()
+  MANUAL_SCOPE_MODE=""
+  MANUAL_SINCE=""
+  MANUAL_SINCE_OPTS=""
+  MANUAL_SKIP_LOGS=false
+  MANUAL_DEBUG=false
+  FAILED_PODS=()
+
+  # Stage-based navigation so Back at each step goes to the previous one
+  # rather than to the main menu. Stages: preview → tune → team → (api_keys
+  # if PS) → delivery → collect. Only the preview's "Return to main menu"
+  # and the delivery card's "Return to main menu" exit directly to the main
+  # menu.
+  local _stage="preview" _proceed=false _rc _p4_action
+  while true; do
+    case "$_stage" in
+      preview)
+        display_platform_summary "${#SYSDIGCLOUD_PODS[@]}"
+        printf "\n    ${_C_KEY}[1]${_C_RESET} Proceed with collection\n"
+        printf "    ${_C_KEY}[2]${_C_RESET} Browse pods\n"
+        printf "    ${_C_KEY}[3]${_C_RESET} Change namespace\n"
+        printf "    ${_C_KEY}[0]${_C_RESET} Return to main menu\n"
+        printf "\n  >> Select [0-3]: "
+        read -r _p4_action
+        case "$_p4_action" in
+          0) return 1 ;;
+          1) _stage="tune" ;;
+          2) browse_pods_paginated "${SYSDIGCLOUD_PODS[@]}" ;;
+          3)
+            if prepare_platform_context; then
+              _populate_sysdigcloud_pods
+              if [[ ${#SYSDIGCLOUD_PODS[@]} -eq 0 ]]; then
+                printf "\n  ${_C_WARN}No collectable pods found in namespace '%s'.${_C_RESET}\n" "$namespace"
+                return 1
+              fi
+            else
+              return 1
+            fi
+            ;;
+          *) printf "  ${_C_WARN}Please select 0, 1, 2, or 3.${_C_RESET}\n" ;;
+        esac
+        ;;
+      tune)
+        prompt_manual_options; _rc=$?
+        case "$_rc" in
+          0) _stage="team" ;;
+          1) _stage="preview" ;;  # Back → preview
+        esac
+        ;;
+      team)
+        select_requesting_team; _rc=$?
+        if [[ $_rc -eq 0 ]]; then
+          detect_platform_backend_version
+          if [[ "$REQUESTING_TEAM" == "professional_services" ]]; then
+            _stage="api_keys"
+          else
+            log_activity "Sysdig Support team requesting; skipping API key prompts."
+            _stage="delivery"
+          fi
+        else
+          _stage="tune"  # Back → tune
+        fi
+        ;;
+      api_keys)
+        if ! _ensure_api_url; then
+          printf "\n  ${_C_ERR}Could not establish API access (direct URL or port-forward).${_C_RESET}\n"
+          printf "  ${_C_ERR}Professional Services collection requires API access. Aborting.${_C_RESET}\n"
+          log_activity "Aborted: API_URL setup failed."
+          return 1
+        fi
+        prompt_api_keys; _rc=$?
+        if [[ $_rc -eq 0 ]]; then
+          _stage="delivery"
+        else
+          _stage="team"  # Back → team
+        fi
+        ;;
+      delivery)
+        prompt_delivery allow_back; _rc=$?
+        case "$_rc" in
+          0) _proceed=true; break ;;
+          1) return 1 ;;
+          3)
+            if [[ "$REQUESTING_TEAM" == "professional_services" ]]; then
+              _stage="api_keys"
+            else
+              _stage="team"
+            fi
+            ;;
+        esac
+        ;;
+    esac
+  done
+
+  [[ "$_proceed" != "true" ]] && return 1
+
+  # Create the legacy-style working directory: sysdigcloud-support-bundle-XXXX
+  _setup_platform_workdir || return 1
+  log_activity "PLATFORM_LOG_DIR: $PLATFORM_LOG_DIR  MAX_JOBS: $MAX_JOBS  SINCE: $MANUAL_SINCE  SKIP_LOGS: $MANUAL_SKIP_LOGS  DEBUG: $MANUAL_DEBUG"
+  printf "\n  Working directory: %s  (%d parallel collector workers)\n\n" "$PLATFORM_LOG_DIR" "$MAX_JOBS"
+
+  # ── kubectl-side collection (parallelized, matches new legacy support-bundle) ──
+
+  # Cheap sequential bits first.
+  collectPlatformBackendVersion
+  collectPlatformRunningPods
+
+  # Cluster-info dump runs in background alongside everything else.
+  # --namespaces= overrides kubectl's default (default + kube-system only) so the
+  # platform namespace's events / pods / services / replicasets land in the bundle.
+  printf "Starting cluster-info dump in background\n"
+  log_activity "Starting cluster-info dump (background)."
+  run_bg "cluster-info-dump" $k8sCmd cluster-info dump --namespaces="kube-system,$namespace" --output-directory="$PLATFORM_LOG_DIR/kubectl-cluster-dump"
+
+  # Per-container log + support-files (parallelized, MAX_JOBS bounded).
+  collectPlatformPodsLogs
+  wait_all
+  printf "${_C_OK}Cluster-info dump complete.${_C_RESET}\n"
+  log_activity "Cluster-info dump complete."
+  log_activity "Per-container log + support-files collection complete."
+  _emit_platform_pod_logs_summary
+
+  # Per-pod describe JSONs (parallelized internally).
+  collectPlatformPodsDescribe
+
+  # Describe-nodes + per-node JSON (per-node parallelized).
+  collectPlatformNodes
+  wait_all
+  printf "${_C_OK}Describe-nodes + per-node JSON collected.${_C_RESET}\n"
+  log_activity "Describe-nodes + per-node JSON collection complete."
+
+  # PV/PVC/SC (cheap, serial).
+  collectPlatformStorage
+
+  # Workload manifests (per-object-type parallelized).
+  collectPlatformManifests
+  wait_all
+  printf "${_C_OK}Manifest collection complete.${_C_RESET}\n"
+  log_activity "Manifest collection complete."
+
+  # Container density (depends on full pod list; serial).
+  collectPlatformContainerDensity
+
+  # Filtered common config map: sysdigcloud-common (6.x+) or sysdigcloud-config (pre-6.x). Cheap, serial.
+  collectPlatformConfigMap
+
+  # ── Database telemetry — all run as parallel background jobs ──
+  log_activity "Scheduling datastore telemetry (parallelized)."
+  _dispatch_datastore_collectors
+  wait_all
+  log_activity "Datastore telemetry complete."
+
+  # ── API endpoint collection (if keys were provided) ──
+  # API_URL was established earlier (during validation); port-forward (if any)
+  # is still alive. No need to redo setup.
+  if [[ -n "$MONITOR_API_KEY" || -n "$SECURE_API_KEY" ]]; then
+    case "$SYSDIG_PRODUCT" in
+      monitor)  collectPlatformMonitorApi ;;
+      secure)   collectPlatformSecureApi ;;
+      platform) collectPlatformMonitorApi; collectPlatformSecureApi ;;
+    esac
+    stop_platform_portforward
+  else
+    log_activity "No API keys provided; API collection skipped entirely."
+    stop_platform_portforward
+  fi
+
+  # Wipe key material from memory; the archive does not contain it.
+  MONITOR_API_KEY=""
+  SECURE_API_KEY=""
+
+  # ── Step 5: archive + optional S3 upload + cleanup ──
+  createPlatformArchive
+
+  log_activity "Automatic platform collection complete."
+  return 0
+}
+
+# Discover the on-prem platform components present in the current namespace,
+# matching the bucketing display_platform_summary uses for option 4:
+#   1) role label, if set
+#   2) owner workload name (Deployment / StatefulSet / DaemonSet) with the
+#      trailing -<hash> and -deployment suffixes stripped
+#   3) "(unlabeled)" for bare pods or pods with custom owner kinds
+# Job-owned pods are excluded throughout.
+#
+# Outputs (globals — parallel indexed arrays for bash 3.2 portability):
+#   PLATFORM_COMPONENTS           — component names (sorted, deduped)
+#   PLATFORM_COMPONENT_PODS_STR   — space-joined pod names at the same index
+function _discover_platform_components() {
+  PLATFORM_COMPONENTS=()
+  PLATFORM_COMPONENT_PODS_STR=()
+
+  local _comp _pod _last_comp="" _last_idx=-1
+  while IFS=$'\t' read -r _comp _pod; do
+    [[ -z "$_comp" || -z "$_pod" ]] && continue
+    if [[ "$_comp" == "$_last_comp" ]]; then
+      # Same component as previous row (input is sorted), append to its bucket.
+      PLATFORM_COMPONENT_PODS_STR[$_last_idx]+=" $_pod"
+    else
+      PLATFORM_COMPONENTS+=("$_comp")
+      PLATFORM_COMPONENT_PODS_STR+=("$_pod")
+      _last_comp="$_comp"
+      _last_idx=$(( ${#PLATFORM_COMPONENTS[@]} - 1 ))
+    fi
+  done < <($k8sCmd get pods -n "$namespace" --no-headers \
+    -o custom-columns="NAME:metadata.name,ROLE:metadata.labels.role,OWNER_KIND:metadata.ownerReferences[0].kind,OWNER_NAME:metadata.ownerReferences[0].name" 2>/dev/null \
+    | awk '$3 != "Job" {
+        pod_name = $1
+        role = $2
+        owner_kind = $3
+        owner_name = $4
+        if (role != "<none>" && role != "") {
+          comp = role
+        } else if (owner_kind == "ReplicaSet") {
+          sub(/-[a-z0-9]{8,10}$/, "", owner_name)
+          sub(/-deployment$/, "", owner_name)
+          comp = owner_name
+        } else if (owner_kind == "StatefulSet" || owner_kind == "DaemonSet") {
+          sub(/-deployment$/, "", owner_name)
+          comp = owner_name
+        } else {
+          comp = "(unlabeled)"
+        }
+        print comp "\t" pod_name
+      }' \
+    | sort)
+}
+
+# Render command groups as aligned, headered columns with bold-cyan keys —
+# the picker/browser hint block. Args come in (header, entries) pairs, one per
+# column; entries is a newline-separated list of "key|description" lines.
+# Columns whose entries are empty are skipped, and each column is widened to
+# fit its header and longest "key  desc" cell. Keys are colored without
+# affecting alignment (padding is computed from the visible text only).
+function _print_cmd_columns() {
+  local -a _hdr=() _blk=()
+  while (( $# >= 2 )); do
+    [[ -n "$2" ]] && { _hdr+=("$1"); _blk+=("$2"); }
+    shift 2
+  done
+  local _nc=${#_hdr[@]}
+  (( _nc == 0 )) && return 0
+
+  # Pass 1: per-column visible width (header vs widest "key  desc") and row count.
+  local -a _w=()
+  local _maxrows=0 _c _ln
+  for ((_c = 0; _c < _nc; _c++)); do
+    local _wd=${#_hdr[$_c]} _n=0
+    while IFS= read -r _ln; do
+      [[ -z "$_ln" ]] && continue
+      _n=$((_n + 1))
+      local _cell="${_ln%%|*}  ${_ln#*|}"
+      (( ${#_cell} > _wd )) && _wd=${#_cell}
+    done <<< "${_blk[$_c]}"
+    _w[$_c]=$_wd
+    (( _n > _maxrows )) && _maxrows=$_n
+  done
+
+  local _gap="   " _out="" _seg _hpad
+  # Header row — pad by character count, not printf %-*s: %-*s pads by BYTES,
+  # which would misalign the multibyte "──" headers in a UTF-8 terminal. The
+  # bold escape is added AFTER the width math so it doesn't affect alignment.
+  for ((_c = 0; _c < _nc; _c++)); do
+    _hpad=$(( ${_w[$_c]} - ${#_hdr[$_c]} )); (( _hpad < 0 )) && _hpad=0
+    printf -v _seg "%*s" "$_hpad" ""
+    _seg="${_C_BOLD}${_hdr[$_c]}${_C_RESET}${_seg}"
+    _out+="$_seg"; (( _c < _nc - 1 )) && _out+="$_gap"
+  done
+  _out="${_out%"${_out##*[![:space:]]}"}"
+  printf "  %s\n" "$_out"
+
+  # Data rows: pull the _r-th entry of each column block.
+  local _r _i _entry
+  for ((_r = 0; _r < _maxrows; _r++)); do
+    _out=""
+    for ((_c = 0; _c < _nc; _c++)); do
+      _entry=""; _i=0
+      while IFS= read -r _ln; do
+        [[ -z "$_ln" ]] && continue
+        if (( _i == _r )); then _entry="$_ln"; break; fi
+        _i=$((_i + 1))
+      done <<< "${_blk[$_c]}"
+      if [[ -n "$_entry" ]]; then
+        local _k="${_entry%%|*}" _d="${_entry#*|}"
+        local _pad=$(( ${_w[$_c]} - ${#_k} - 2 - ${#_d} )); (( _pad < 0 )) && _pad=0
+        printf -v _seg "%*s" "$_pad" ""
+        _seg="${_C_KEY}${_k}${_C_RESET}  ${_d}${_seg}"
+      else
+        printf -v _seg "%-*s" "${_w[$_c]}" ""
+      fi
+      _out+="$_seg"; (( _c < _nc - 1 )) && _out+="$_gap"
+    done
+    _out="${_out%"${_out##*[![:space:]]}"}"
+    printf "  %s\n" "$_out"
+  done
+}
+
+# Unified paginated multi-select picker (toggle UX).
+# Selection persists across pages and filter changes (tracked by item name,
+# not by visible row index). Each row shows [x]/[ ] and a "selected: N"
+# counter is displayed in the header. Typing numbers TOGGLES; [d]one or
+# Enter finalizes; [a] unions all in current filter; [i] inverts within
+# the filter; [x] clears all picks; [b] backs out.
+#
+# Args:
+#   $1   : label_singular  (e.g. "component", "pod")
+#   $2   : caps_plural     (e.g. "Components", "Pods")
+#   $@>2 : candidate items
+#
+# Output: populates global _PICKED_ITEMS with the final selection.
+# Returns: 0 if user pressed [d]one with non-empty picks, 1 on [b]ack.
+function _select_items_paginated() {
+  local _label="$1" _caps="$2"
+  shift 2
+  local source_items=("$@")
+  local filter=""
+  local filtered=()
+  local page=0
+  local page_size=20
+  local input
+  # Persisted across redraws — each loop starts with `clear`, so a message
+  # printed before read would be wiped before the user sees it. Stash it here
+  # and render it just above the prompt on the next redraw instead.
+  local _msg=""
+
+  _PICKED_ITEMS=()
+
+  if [[ ${#source_items[@]} -eq 0 ]]; then
+    printf "  No %ss to select.\n" "$_label"
+    return 1
+  fi
+
+  __picker_is_picked() {
+    local _x="$1" _p
+    for _p in "${_PICKED_ITEMS[@]+"${_PICKED_ITEMS[@]}"}"; do
+      [[ "$_p" == "$_x" ]] && return 0
+    done
+    return 1
+  }
+
+  __picker_toggle() {
+    local _x="$1" _p _found=0
+    local -a _new=()
+    for _p in "${_PICKED_ITEMS[@]+"${_PICKED_ITEMS[@]}"}"; do
+      if [[ "$_p" == "$_x" ]]; then
+        _found=1
+      else
+        _new+=("$_p")
+      fi
+    done
+    [[ $_found -eq 0 ]] && _new+=("$_x")
+    _PICKED_ITEMS=("${_new[@]+"${_new[@]}"}")
+  }
+
+  while true; do
+    clear
+    filtered=()
+    local r
+    for r in "${source_items[@]}"; do
+      if [[ -z "$filter" || "$r" == *"$filter"* ]]; then
+        filtered+=("$r")
+      fi
+    done
+
+    local total=${#filtered[@]}
+    local pages=1
+    [[ $total -gt 0 ]] && pages=$(( (total + page_size - 1) / page_size ))
+    [[ $page -ge $pages ]] && page=0
+
+    local start=$(( page * page_size ))
+    local end=$(( start + page_size ))
+    [[ $end -gt $total ]] && end=$total
+
+    printf "\n  %s — %d total" "$_caps" "$total"
+    [[ -n "$filter" ]] && printf " · filter: '%s'" "$filter"
+    [[ $pages -gt 1 ]] && printf " · page %d/%d" $((page + 1)) "$pages"
+    printf " · %d selected\n" "${#_PICKED_ITEMS[@]}"
+
+    if [[ $total -eq 0 ]]; then
+      printf "    (no %ss match filter)\n" "$_label"
+    else
+      local i
+      for ((i = start; i < end; i++)); do
+        # Selected rows render entirely green ([✓] + number + name); unselected
+        # rows stay plain.
+        if __picker_is_picked "${filtered[$i]}"; then
+          printf "    ${_C_OK}[✓] %3d) %s${_C_RESET}\n" $((i + 1)) "${filtered[$i]}"
+        else
+          printf "    [ ] %3d) %s\n" $((i + 1)) "${filtered[$i]}"
+        fi
+      done
+    fi
+
+    printf "\n"
+    # Three command groups. Navigation keys appear only when there's more than
+    # one page; Selection collapses to just "clear" when nothing is listed.
+    # 'd' (done) lives in the intro line rather than a column.
+    local _sel _nav _oth
+    if [[ $total -gt 0 ]]; then
+      printf "  Select %ss by number (space-separated, e.g. '1 3 5') from all pages, then press ${_C_KEY}d${_C_RESET} when done, or use:\n\n" "$_label"
+      _sel=$'a|select all\ni|invert selection\nx|clear selection'
+    else
+      printf "\n"
+      _sel=$'x|clear selection'
+    fi
+    _nav=""
+    [[ $pages -gt 1 ]] && _nav=$'n|next page\np|previous page\ng|go to page'
+    _oth=$'f|filter\nc|clear filter\nb|back (prev. menu)'
+    _print_cmd_columns "── Selection ──" "$_sel" "── Navigation ──" "$_nav" "── Other ──" "$_oth"
+    [[ -n "$_msg" ]] && printf "\n  %s\n" "$_msg"
+    _msg=""
+    printf "\n  >> Enter selection or command: "
+    read -r input
+    input="${input#"${input%%[![:space:]]*}"}"
+    input="${input%"${input##*[![:space:]]}"}"
+
+    case "$input" in
+      b|B) _PICKED_ITEMS=(); return 1 ;;
+      d|D|"")
+        if [[ ${#_PICKED_ITEMS[@]} -eq 0 ]]; then
+          _msg="No ${_label}s selected yet — pick at least one, or 'b' to cancel."
+        else
+          return 0
+        fi
+        ;;
+      n|N)
+        if [[ $pages -gt 1 ]]; then page=$(( (page + 1) % pages )); else _msg="Already on the only page."; fi
+        ;;
+      p|P)
+        if [[ $pages -gt 1 ]]; then page=$(( (page - 1 + pages) % pages )); else _msg="Already on the only page."; fi
+        ;;
+      g|G)
+        if [[ $pages -gt 1 ]]; then
+          printf "  Go to page [1-%d]: " "$pages"
+          local _np
+          read -r _np
+          if [[ "$_np" =~ ^[0-9]+$ ]] && (( _np >= 1 && _np <= pages )); then
+            page=$(( _np - 1 ))
+          else
+            _msg="${_C_WARN}Invalid page number.${_C_RESET}"
+          fi
+        else
+          _msg="Already on the only page."
+        fi
+        ;;
+      f|F)
+        printf "  Filter (substring, empty to clear): "
+        read -r filter
+        page=0
+        ;;
+      c|C) filter=""; page=0 ;;
+      x|X)
+        if [[ ${#_PICKED_ITEMS[@]} -gt 0 ]]; then
+          _PICKED_ITEMS=()
+          _msg="Cleared all selections."
+        fi
+        ;;
+      a|A)
+        if [[ $total -gt 0 ]]; then
+          local _it _added=0
+          for _it in "${filtered[@]}"; do
+            if ! __picker_is_picked "$_it"; then
+              _PICKED_ITEMS+=("$_it")
+              _added=$(( _added + 1 ))
+            fi
+          done
+          printf -v _msg "Added %d %s(s) (total selected: %d)." "$_added" "$_label" "${#_PICKED_ITEMS[@]}"
+        else
+          _msg="No ${_label}s to add."
+        fi
+        ;;
+      i|I)
+        if [[ $total -gt 0 ]]; then
+          local _it _p _kept _wasp
+          local -a _new=()
+          # Keep already-picked items that are NOT in the current filter.
+          for _p in "${_PICKED_ITEMS[@]+"${_PICKED_ITEMS[@]}"}"; do
+            _kept=1
+            for _it in "${filtered[@]}"; do
+              [[ "$_p" == "$_it" ]] && { _kept=0; break; }
+            done
+            [[ $_kept -eq 1 ]] && _new+=("$_p")
+          done
+          # Add filtered items that were NOT previously picked.
+          for _it in "${filtered[@]}"; do
+            _wasp=0
+            for _p in "${_PICKED_ITEMS[@]+"${_PICKED_ITEMS[@]}"}"; do
+              [[ "$_p" == "$_it" ]] && { _wasp=1; break; }
+            done
+            [[ $_wasp -eq 0 ]] && _new+=("$_it")
+          done
+          _PICKED_ITEMS=("${_new[@]+"${_new[@]}"}")
+          printf -v _msg "Inverted selection within filter (total selected: %d)." "${#_PICKED_ITEMS[@]}"
+        fi
+        ;;
+      *)
+        local valid=true sel
+        local -a selections
+        read -ra selections <<< "$input"
+        for sel in "${selections[@]}"; do
+          if [[ ! "$sel" =~ ^[0-9]+$ ]] || (( sel < 1 || sel > total )); then
+            printf -v _msg "${_C_WARN}'%s' isn't a valid choice.${_C_RESET} Enter numbers 1-%d (e.g. 1 3 5), or a command key listed above." "$sel" "$total"
+            valid=false
+            break
+          fi
+        done
+        if [[ "$valid" == "true" ]]; then
+          for sel in "${selections[@]}"; do
+            __picker_toggle "${filtered[$(( sel - 1 ))]}"
+          done
+        fi
+        ;;
+    esac
+  done
+}
+
+# Paginated component picker. Thin wrapper around _select_items_paginated;
+# adapts the result variable name to _PICKED_COMPONENTS for back-compat.
+function _select_components_paginated() {
+  _PICKED_COMPONENTS=()
+  _PICKED_ITEMS=()
+  if _select_items_paginated "component" "Components" "$@"; then
+    _PICKED_COMPONENTS=("${_PICKED_ITEMS[@]+"${_PICKED_ITEMS[@]}"}")
+    return 0
+  fi
+  return 1
+}
+
+function select_platform_components() {
+  # Optional resume hint: when set to "2" or "3", skips the scope-mode prompt
+  # on the first iteration and jumps directly into "Pick components" or
+  # "Pick pods" respectively. Used by Modify to re-enter the same sub-picker
+  # the user previously chose. Pressing back inside the sub-picker falls
+  # through to the normal scope-mode prompt on the next iteration.
+  local _resume="${1:-}"
+
+  MANUAL_COMPONENTS=""
+  MANUAL_PODS_FILTER=()
+  MANUAL_SKIP_LOGS=false
+  MANUAL_SCOPE_MODE=""
+
+  local scope_choice
+  while true; do
+    if [[ -n "$_resume" ]]; then
+      scope_choice="$_resume"
+      _resume=""   # one-shot
+    else
+      printf "\n  ${_C_BOLD}Select scope of logs:${_C_RESET}\n"
+      printf "    ${_C_KEY}[1]${_C_RESET} All components       (every Sysdig pod + full cluster state)\n"
+      printf "    ${_C_KEY}[2]${_C_RESET} Pick components      (logs + related K8s resources, namespace-scoped)\n"
+      printf "    ${_C_KEY}[3]${_C_RESET} Pick pods            (logs + related K8s resources, namespace-scoped)\n"
+      printf "    ${_C_KEY}[4]${_C_RESET} Only platform health (cluster-wide K8s + DB stats, skip per-pod logs)\n"
+      printf "    ${_C_KEY}[0]${_C_RESET} Back\n"
+      printf "\n  >> Select [0-4]: "
+      read -r scope_choice
+    fi
+    case "$scope_choice" in
+      0) return 1 ;;
+      1)
+        MANUAL_SCOPE_MODE="all"
+        log_activity "Manual scope: all components (no filter)."
+        return 0
+        ;;
+      2)
+        _discover_platform_components
+        if [[ ${#PLATFORM_COMPONENTS[@]} -eq 0 ]]; then
+          printf "  No components found in '%s'. Use option 3 (pick pods) instead.\n" "$namespace"
+          continue
+        fi
+        if _select_components_paginated "${PLATFORM_COMPONENTS[@]}"; then
+          # If the user selected every discovered component (e.g. pressed [a]ll),
+          # treat it as "All components" — clear the filter so all pods are
+          # collected (no client-side intersection).
+          if [[ ${#_PICKED_COMPONENTS[@]} -eq ${#PLATFORM_COMPONENTS[@]} ]]; then
+            MANUAL_COMPONENTS=""
+            MANUAL_PODS_FILTER=()
+            MANUAL_SCOPE_MODE="all"
+            log_activity "Manual scope: all components (every discovered component picked; filter dropped)."
+            return 0
+          fi
+          # Build the display string (comma-joined component names) and resolve
+          # each picked component to its pod list via the parallel arrays.
+          local _joined="" i _comp _idx _pods_arr=() _p
+          for i in "${!_PICKED_COMPONENTS[@]}"; do
+            [[ -n "$_joined" ]] && _joined+=","
+            _joined+="${_PICKED_COMPONENTS[$i]}"
+          done
+          MANUAL_COMPONENTS="$_joined"
+          MANUAL_PODS_FILTER=()
+          for _comp in "${_PICKED_COMPONENTS[@]}"; do
+            for _idx in "${!PLATFORM_COMPONENTS[@]}"; do
+              if [[ "${PLATFORM_COMPONENTS[$_idx]}" == "$_comp" ]]; then
+                read -ra _pods_arr <<< "${PLATFORM_COMPONENT_PODS_STR[$_idx]}"
+                for _p in "${_pods_arr[@]}"; do
+                  [[ -n "$_p" ]] && MANUAL_PODS_FILTER+=("$_p")
+                done
+                break
+              fi
+            done
+          done
+          MANUAL_SCOPE_MODE="components"
+          log_activity "Manual scope: components=$MANUAL_COMPONENTS (${#MANUAL_PODS_FILTER[@]} pods)"
+          return 0
+        fi
+        ;;
+      3)
+        # Pull the full pod list (no filters yet) and let the user pick.
+        local _save_components="$MANUAL_COMPONENTS"
+        MANUAL_COMPONENTS=""
+        _populate_sysdigcloud_pods
+        MANUAL_COMPONENTS="$_save_components"
+        if [[ ${#SYSDIGCLOUD_PODS[@]} -eq 0 ]]; then
+          printf "  ${_C_WARN}No collectable pods found in namespace '%s'.${_C_RESET}\n" "$namespace"
+          continue
+        fi
+        # podNames is the contract of select_pods_paginated.
+        local _save_pods=("${podNames[@]+"${podNames[@]}"}")
+        podNames=()
+        if select_pods_paginated "${SYSDIGCLOUD_PODS[@]}"; then
+          MANUAL_PODS_FILTER=("${podNames[@]}")
+          podNames=("${_save_pods[@]+"${_save_pods[@]}"}")
+          MANUAL_SCOPE_MODE="pods"
+          log_activity "Manual scope: ${#MANUAL_PODS_FILTER[@]} pods picked."
+          return 0
+        fi
+        podNames=("${_save_pods[@]+"${_save_pods[@]}"}")
+        ;;
+      4)
+        MANUAL_SKIP_LOGS=true
+        MANUAL_SCOPE_MODE="health"
+        log_activity "Manual scope: platform health only (logs skipped)."
+        return 0
+        ;;
+      *) printf "  ${_C_WARN}Please select 0, 1, 2, 3, or 4.${_C_RESET}\n" ;;
+    esac
+  done
+}
+
+# Collection tunables card (edit-by-number). Reads/writes globals:
+# MANUAL_SINCE, MANUAL_SINCE_OPTS, MAX_JOBS, MANUAL_DEBUG.
+# Used by both option 4 (platform automated) and option 5 (platform manual).
+# Note: MANUAL_SKIP_LOGS is set by the scope picker (option 5 health-only scope),
+# not here — if it's true, the log-window line shows n/a and refuses edits.
+# Returns 0 on continue, 1 on back.
+function prompt_manual_options() {
+  local _since_display _debug_display
+  while true; do
+    _since_display="full"
+    [[ -n "$MANUAL_SINCE" ]] && _since_display="$MANUAL_SINCE"
+    [[ "$MANUAL_SKIP_LOGS" == "true" ]] && _since_display="n/a (logs skipped)"
+    _debug_display="off"
+    [[ "$MANUAL_DEBUG" == "true" ]] && _debug_display="on"
+
+    printf "\n  Collection Tunables\n"
+    printf "  ───────────────────────────────────────\n"
+    printf "    1) Log window                 : %s\n" "$_since_display"
+    printf "    2) Debug (set -x)             : %s\n" "$_debug_display"
+    printf "    3) Parallel collector workers : %s\n" "$MAX_JOBS"
+    printf "  ───────────────────────────────────────\n"
+    printf "  [1-3]=edit  [Enter]=continue  [0]=back\n"
+    printf "  Choice: "
+    local tun_choice
+    read -r tun_choice
+
+    case "$tun_choice" in
+      "") return 0 ;;
+      0)  return 1 ;;
+      1)
+        if [[ "$MANUAL_SKIP_LOGS" == "true" ]]; then
+          printf "  Log window is n/a — scope is 'Only platform health' (no pod logs).\n"
+          printf "  Change scope (back to picker) if you want to collect logs.\n"
+          continue
+        fi
+        while true; do
+          printf "  Log window (e.g. 30m, 1h, 24h, 7d, or 'full' for no limit): "
+          local since_in
+          read -r since_in
+          if [[ -z "$since_in" ]]; then
+            printf "  Cannot be empty.\n"
+            continue
+          fi
+          if [[ "$since_in" == "full" ]]; then
+            MANUAL_SINCE=""
+            MANUAL_SINCE_OPTS=""
+            break
+          fi
+          if [[ "$since_in" =~ ^[0-9]+[smhd]$ ]]; then
+            MANUAL_SINCE="$since_in"
+            MANUAL_SINCE_OPTS="--since=$since_in"
+            break
+          fi
+          printf "  ${_C_WARN}Invalid format.${_C_RESET} Use Nm, Nh, Nd (e.g. 1h, 24h, 7d) or 'full'.\n"
+        done
+        ;;
+      3)
+        while true; do
+          printf "  Parallel collector workers [%d-%d, current %s]: " "$MAX_JOBS_MIN" "$MAX_JOBS_MAX" "$MAX_JOBS"
+          local mj_in
+          read -r mj_in
+          if [[ -z "$mj_in" ]]; then
+            printf "  Cannot be empty.\n"
+            continue
+          fi
+          if ! [[ "$mj_in" =~ ^[0-9]+$ ]] || (( mj_in < MAX_JOBS_MIN || mj_in > MAX_JOBS_MAX )); then
+            printf "  ${_C_WARN}Invalid value.${_C_RESET} Enter an integer between %d and %d.\n" "$MAX_JOBS_MIN" "$MAX_JOBS_MAX"
+            continue
+          fi
+          # Above the safe baseline (MAX_JOBS_DEFAULT): surface the apiserver-
+          # stress warning and require explicit confirmation. At or below:
+          # accept silently. Mirrors prompt_max_jobs (Phase 1).
+          if (( mj_in > MAX_JOBS_DEFAULT )); then
+            printf "\n  ${_C_WARN}Higher values on small or constrained clusters can overload the apiserver and lead to partial log collection.${_C_RESET}\n"
+            printf "  ${_C_WARN}Proceed with %d workers?${_C_RESET}\n" "$mj_in"
+            printf "    1) No  - choose a different value\n"
+            printf "    2) Yes - continue\n"
+            local _confirm
+            while true; do
+              printf "  Choice [1-2]: "
+              read -r _confirm
+              case "$_confirm" in
+                1) break 1 ;;       # leave inner loop → outer loop re-prompts for value
+                2) MAX_JOBS="$mj_in"
+                   log_activity "Parallel collection workers set to $MAX_JOBS (user-confirmed above default of $MAX_JOBS_DEFAULT)."
+                   break 2 ;;
+                *) printf "    ${_C_ERR}Please enter 1 or 2.${_C_RESET}\n" ;;
+              esac
+            done
+            continue
+          fi
+          MAX_JOBS="$mj_in"
+          log_activity "Parallel collection workers set to $MAX_JOBS (user-selected)."
+          break
+        done
+        ;;
+      2)
+        while true; do
+          printf "  Enable debug (set -x in worker jobs)? [y/n]: "
+          local dbg_in
+          read -r dbg_in
+          case "$dbg_in" in
+            y|Y|yes|YES) MANUAL_DEBUG=true;  break ;;
+            n|N|no|NO)   MANUAL_DEBUG=false; break ;;
+            *) printf "  Please answer y or n.\n" ;;
+          esac
+        done
+        ;;
+      *) printf "  Please select 0, 1, 2, 3, or press Enter.\n" ;;
+    esac
+  done
+}
+
+# Show the selected scope and pod list, with a chance to confirm or modify.
+# Called between the scope picker and the tunables prompt in Option 5.
+# Returns:
+#   0 = continue, 2 = modify (caller re-enters picker).
+function _confirm_manual_scope() {
+  local _scope_desc
+  if [[ "$MANUAL_SKIP_LOGS" == "true" ]]; then
+    _scope_desc="platform health only  (no pod logs)"
+  elif [[ -n "$MANUAL_COMPONENTS" ]]; then
+    _scope_desc="components=$MANUAL_COMPONENTS  (${#SYSDIGCLOUD_PODS[@]} pods)"
+  elif [[ ${#MANUAL_PODS_FILTER[@]} -gt 0 ]]; then
+    _scope_desc="${#SYSDIGCLOUD_PODS[@]} specific pods"
+  else
+    _scope_desc="all components  (${#SYSDIGCLOUD_PODS[@]} pods)"
+  fi
+
+  printf "\n  ${_C_BOLD}Selected scope:${_C_RESET} %s\n" "$_scope_desc"
+
+  if [[ "$MANUAL_SKIP_LOGS" != "true" ]]; then
+    printf "\n  Pods to be collected:\n"
+    local _max_show=20 _shown=0 _p
+    for _p in "${SYSDIGCLOUD_PODS[@]}"; do
+      if [[ $_shown -ge $_max_show ]]; then
+        printf "    ... and %d more\n" $(( ${#SYSDIGCLOUD_PODS[@]} - _max_show ))
+        break
+      fi
+      printf "    - %s\n" "$_p"
+      (( _shown++ ))
+    done
+  fi
+
+  while true; do
+    printf "\n    ${_C_KEY}[1]${_C_RESET} Continue\n"
+    printf "    ${_C_KEY}[2]${_C_RESET} Modify selection\n"
+    printf "\n  >> Select [1-2]: "
+    local _ans
+    read -r _ans
+    case "$_ans" in
+      1) return 0 ;;
+      2) return 2 ;;
+      *) printf "  ${_C_WARN}Please select 1 or 2.${_C_RESET}\n" ;;
+    esac
+  done
+}
+
+# Summary card shown right before kicking off the run. Returns:
+#   0 = proceed, 1 = back to main menu, 2 = modify (caller re-enters picker).
+function _manual_summary_confirm() {
+  local _scope_display
+  if [[ "$MANUAL_SKIP_LOGS" == "true" ]]; then
+    _scope_display="platform health only  (no pod logs)"
+  elif [[ -n "$MANUAL_COMPONENTS" ]]; then
+    _scope_display="components=$MANUAL_COMPONENTS  (${#SYSDIGCLOUD_PODS[@]} pods)"
+  elif [[ ${#MANUAL_PODS_FILTER[@]} -gt 0 ]]; then
+    _scope_display="pods=${#MANUAL_PODS_FILTER[@]} explicit  (${#SYSDIGCLOUD_PODS[@]} after filter)"
+  else
+    _scope_display="all components  (${#SYSDIGCLOUD_PODS[@]} pods)"
+  fi
+  local _logs_display="full"
+  [[ -n "$MANUAL_SINCE" ]] && _logs_display="since=$MANUAL_SINCE"
+  [[ "$MANUAL_SKIP_LOGS" == "true" ]] && _logs_display="skipped"
+  local _debug_display="off"
+  [[ "$MANUAL_DEBUG" == "true" ]] && _debug_display="on"
+  local _api_display="none (Sysdig Support team)"
+  if [[ "$REQUESTING_TEAM" == "professional_services" ]]; then
+    _api_display="Professional Services ("
+    [[ -n "$MONITOR_API_KEY" ]] && _api_display+="Monitor"
+    [[ -n "$MONITOR_API_KEY" && -n "$SECURE_API_KEY" ]] && _api_display+=" + "
+    [[ -n "$SECURE_API_KEY" ]] && _api_display+="Secure"
+    _api_display+=")"
+  fi
+  local _ctx_short="${K8S_CONTEXT:-<default>}"
+  if (( ${#_ctx_short} > 25 )); then
+    _ctx_short="${_ctx_short:0:12}…${_ctx_short: -12}"
+  fi
+
+  local _layout_display
+  if _manual_scope_is_narrow; then
+    _layout_display="component/<name>/{workload,pods,configmaps,pvcs,services,datastore,events}  (namespace-scoped)"
+  else
+    _layout_display="cluster-wide: kubectl-cluster-dump/, nodes/, manifests, datastores, pod_logs/"
+  fi
+
+  printf "\n  Manual Platform Collection\n"
+  printf "  ──────────────────────────\n"
+  printf "    Namespace : %s\n" "$namespace"
+  printf "    Context   : %s\n" "$_ctx_short"
+  printf "    Scope     : %s\n" "$_scope_display"
+  printf "    Logs      : %s\n" "$_logs_display"
+  printf "    Layout    : %s\n" "$_layout_display"
+  printf "    Parallel  : %s jobs\n" "$MAX_JOBS"
+  printf "    Debug     : %s\n" "$_debug_display"
+  printf "    API data  : %s\n" "$_api_display"
+  printf "  ──────────────────────────\n"
+  printf "    ${_C_KEY}[1]${_C_RESET} Proceed\n"
+  printf "    ${_C_KEY}[2]${_C_RESET} Modify\n"
+  printf "    ${_C_KEY}[0]${_C_RESET} Back\n"
+  while true; do
+    printf "\n  >> Select [0-2]: "
+    local conf
+    read -r conf
+    case "$conf" in
+      0) return 1 ;;
+      1) return 0 ;;
+      2) return 2 ;;
+      *) printf "  ${_C_WARN}Please select 0, 1, or 2.${_C_RESET}\n" ;;
+    esac
+  done
+}
+
+function manual_platform_collector() {
+  trap 'stop_platform_portforward; trap - INT TERM RETURN' RETURN
+
+  prepare_platform_context || return 1
+
+  # Reset manual knobs at entry — never inherit from a prior invocation.
+  # FAILED_PODS is also reset so a Phase-1 (option 1/2/3) run interrupted
+  # before its archive step can't leak its failed-pod list into this run's
+  # archive warning.
+  MANUAL_COMPONENTS=""
+  MANUAL_PODS_FILTER=()
+  MANUAL_SCOPE_MODE=""
+  MANUAL_SINCE=""
+  MANUAL_SINCE_OPTS=""
+  MANUAL_SKIP_LOGS=false
+  MANUAL_DEBUG=false
+  FAILED_PODS=()
+
+  # Stage-based navigation so Back at each step goes to the previous one
+  # rather than all the way to the main menu. Stages: team → (api_keys if
+  # PS) → scope picker → scope confirm → tunables → summary → delivery.
+  # Back at "team" returns to the main menu (nothing meaningful precedes
+  # it in this flow); Back / Modify on later stages step backward.
+  # _pick_resume lets Modify jump back into the same sub-picker the user
+  # was on (component picker / pod picker) instead of restarting at the
+  # scope-mode prompt; cleared after each consumption.
+  local _stage="team" _proceed=false _rc _pick_resume=""
+  while true; do
+    case "$_stage" in
+      team)
+        select_requesting_team; _rc=$?
+        if [[ $_rc -eq 0 ]]; then
+          detect_platform_backend_version
+          if [[ "$REQUESTING_TEAM" == "professional_services" ]]; then
+            _stage="api_keys"
+          else
+            log_activity "Sysdig Support team requesting; skipping API key prompts."
+            _stage="pick"
+          fi
+        else
+          return 1  # Back at team → main menu
+        fi
+        ;;
+      api_keys)
+        if ! _ensure_api_url; then
+          printf "\n  ${_C_ERR}Could not establish API access (direct URL or port-forward).${_C_RESET}\n"
+          printf "  ${_C_ERR}Professional Services collection requires API access. Aborting.${_C_RESET}\n"
+          log_activity "Aborted: API_URL setup failed."
+          return 1
+        fi
+        prompt_api_keys; _rc=$?
+        if [[ $_rc -eq 0 ]]; then
+          _stage="pick"
+        else
+          _stage="team"  # Back → team
+        fi
+        ;;
+      pick)
+        select_platform_components "$_pick_resume"; _rc=$?
+        _pick_resume=""   # consume one-shot hint
+        if [[ $_rc -ne 0 ]]; then
+          # Back at the scope picker → previous stage (api_keys for PS, else team)
+          if [[ "$REQUESTING_TEAM" == "professional_services" ]]; then
+            _stage="api_keys"
+          else
+            _stage="team"
+          fi
+          continue
+        fi
+        _populate_sysdigcloud_pods
+        if [[ ${#SYSDIGCLOUD_PODS[@]} -eq 0 ]]; then
+          printf "\n  ${_C_WARN}No pods match the selected scope. Adjust your selection.${_C_RESET}\n"
+          continue
+        fi
+        _stage="confirm"
+        ;;
+      confirm)
+        _confirm_manual_scope; _rc=$?
+        case "$_rc" in
+          0) _stage="tune" ;;
+          2)
+            # Modify → resume directly into the sub-picker that was used,
+            # so the user doesn't lose their place at the scope-mode prompt.
+            case "$MANUAL_SCOPE_MODE" in
+              components) _pick_resume="2" ;;
+              pods)       _pick_resume="3" ;;
+              *)          _pick_resume=""  ;;   # all / health → fall back to full scope prompt
+            esac
+            _stage="pick"
+            ;;
+        esac
+        ;;
+      tune)
+        prompt_manual_options; _rc=$?
+        case "$_rc" in
+          0) _stage="summary" ;;
+          1) _stage="confirm" ;;  # Back → scope confirm
+        esac
+        ;;
+      summary)
+        _manual_summary_confirm; _rc=$?
+        case "$_rc" in
+          0) _stage="delivery" ;;
+          1) _stage="tune" ;;   # Back → tunables
+          2)
+            case "$MANUAL_SCOPE_MODE" in
+              components) _pick_resume="2" ;;
+              pods)       _pick_resume="3" ;;
+              *)          _pick_resume=""  ;;
+            esac
+            _stage="pick"
+            ;;
+        esac
+        ;;
+      delivery)
+        prompt_delivery allow_back; _rc=$?
+        case "$_rc" in
+          0) _proceed=true; break ;;
+          1) return 1 ;;
+          3) _stage="summary" ;;  # Back → summary card
+        esac
+        ;;
+    esac
+  done
+
+  [[ "$_proceed" != "true" ]] && return 1
+
+  _setup_platform_workdir || return 1
+  log_activity "PLATFORM_LOG_DIR: $PLATFORM_LOG_DIR  MAX_JOBS: $MAX_JOBS  COMPONENTS: $MANUAL_COMPONENTS  PODS_FILTER: ${#MANUAL_PODS_FILTER[@]}  SINCE: $MANUAL_SINCE  SKIP_LOGS: $MANUAL_SKIP_LOGS  DEBUG: $MANUAL_DEBUG"
+  printf "\n  Working directory: %s  (%d parallel collector workers)\n\n" "$PLATFORM_LOG_DIR" "$MAX_JOBS"
+
+  # ── Collection pipeline ──
+  # In narrow modes (components/pods) we skip cluster-scoped collectors and the
+  # full-namespace manifest dump — they require broader RBAC than narrow-scope
+  # users typically have, and produce content unrelated to the picked scope.
+  # collectPlatformComponentRelated replaces them with workload-derived artifacts.
+  collectPlatformBackendVersion
+  collectPlatformRunningPods
+
+  if _manual_scope_is_narrow; then
+    log_activity "Narrow scope: skipping cluster-info dump / nodes / storage / full manifests / container-density."
+  else
+    printf "Starting cluster-info dump in background\n"
+    log_activity "Starting cluster-info dump (background)."
+    run_bg "cluster-info-dump" $k8sCmd cluster-info dump --namespaces="kube-system,$namespace" --output-directory="$PLATFORM_LOG_DIR/kubectl-cluster-dump"
+  fi
+
+  collectPlatformPodsLogs
+  wait_all
+  if ! _manual_scope_is_narrow; then
+    printf "${_C_OK}Cluster-info dump complete.${_C_RESET}\n"
+    log_activity "Cluster-info dump complete."
+  fi
+  log_activity "Per-container log + support-files collection complete."
+  _emit_platform_pod_logs_summary
+
+  collectPlatformPodsDescribe
+  if ! _manual_scope_is_narrow; then
+    collectPlatformNodes
+    wait_all
+    printf "${_C_OK}Describe-nodes + per-node JSON collected.${_C_RESET}\n"
+    log_activity "Describe-nodes + per-node JSON collection complete."
+    collectPlatformStorage
+    collectPlatformManifests
+    wait_all
+    printf "${_C_OK}Manifest collection complete.${_C_RESET}\n"
+    log_activity "Manifest collection complete."
+    collectPlatformContainerDensity
+  else
+    collectPlatformComponentRelated
+  fi
+  collectPlatformConfigMap
+
+  log_activity "Scheduling datastore telemetry (parallelized, narrow-scope-aware)."
+  _dispatch_datastore_collectors
+  wait_all
+  log_activity "Datastore telemetry complete."
+
+  if [[ -n "$MONITOR_API_KEY" || -n "$SECURE_API_KEY" ]]; then
+    case "$SYSDIG_PRODUCT" in
+      monitor)  collectPlatformMonitorApi ;;
+      secure)   collectPlatformSecureApi ;;
+      platform) collectPlatformMonitorApi; collectPlatformSecureApi ;;
+    esac
+    stop_platform_portforward
+  else
+    log_activity "No API keys provided; API collection skipped entirely."
+    stop_platform_portforward
+  fi
+
+  MONITOR_API_KEY=""
+  SECURE_API_KEY=""
+
+  createPlatformArchive
+
+  log_activity "Manual platform collection complete."
+  return 0
+}
+
+# ─────────────────────────────────────────────
+#  Init
+# ─────────────────────────────────────────────
+
+# Rebuild $k8sCmd so that all downstream kubectl/oc calls honor the selected
+# context. Word-splitting on the unquoted "$k8sCmd ... args ..." invocations
+# picks up the extra --context= token automatically.
+function _apply_kube_context() {
+  if [[ -n "$K8S_CONTEXT" ]]; then
+    k8sCmd="$BASE_K8S_CMD --context=$K8S_CONTEXT"
+  else
+    k8sCmd="$BASE_K8S_CMD"
+  fi
+}
+
+# Let the user choose which kubectl/oc context to target. Equivalent to legacy
+# `-c CONTEXT` flag from get_support_bundle.sh; applied to all options.
+# Auto-selects when there's only one context. Returns 1 on cancel.
+function select_kube_context() {
+  local contexts=() current
+  current=$($BASE_K8S_CMD config current-context 2>/dev/null) || current=""
+  local ctx
+  while IFS= read -r ctx; do
+    [[ -n "$ctx" ]] && contexts+=("$ctx")
+  done < <($BASE_K8S_CMD config get-contexts -o name 2>/dev/null)
+
+  if [[ ${#contexts[@]} -eq 0 ]]; then
+    printf "  No kubectl contexts found in kubeconfig; using CLI default.\n"
+    K8S_CONTEXT=""
+    _apply_kube_context
+    log_activity "No contexts in kubeconfig; using CLI default."
+    return 0
+  fi
+
+  if [[ ${#contexts[@]} -eq 1 ]]; then
+    K8S_CONTEXT="${contexts[0]}"
+    _apply_kube_context
+    log_activity "Single context auto-selected: $K8S_CONTEXT"
+    return 0
+  fi
+
+  printf "\n  ${_C_BOLD}Select kubectl context${_C_RESET}   ${_C_DIM}(active: %s)${_C_RESET}\n" "${current:-<none>}"
+  local i marker
+  for i in "${!contexts[@]}"; do
+    marker=""
+    [[ "${contexts[$i]}" == "$current" ]] && marker="   ${_C_DIM}(current)${_C_RESET}"
+    printf "    ${_C_KEY}[%d]${_C_RESET} %s%s\n" $(( i + 1 )) "${contexts[$i]}" "$marker"
+  done
+  printf "    ${_C_KEY}[0]${_C_RESET} Back\n"
+
+  local enter_hint=""
+  [[ -n "$current" ]] && enter_hint=", Enter for current"
+
+  while true; do
+    printf "\n  >> Select [0-%d%s]: " "${#contexts[@]}" "$enter_hint"
+    local ctx_choice
+    read -r ctx_choice
+    if [[ -z "$ctx_choice" ]]; then
+      if [[ -n "$current" ]]; then
+        K8S_CONTEXT="$current"
+        _apply_kube_context
+        log_activity "kubectl context (current) auto-selected: $K8S_CONTEXT"
+        return 0
+      fi
+      printf "  ${_C_WARN}No current context to default to. Please pick a number.${_C_RESET}\n"
+      continue
+    fi
+    if [[ "$ctx_choice" == "0" ]]; then
+      return 1
+    elif [[ "$ctx_choice" =~ ^[0-9]+$ ]] && (( ctx_choice >= 1 && ctx_choice <= ${#contexts[@]} )); then
+      K8S_CONTEXT="${contexts[$(( ctx_choice - 1 ))]}"
+      _apply_kube_context
+      log_activity "kubectl context selected: $K8S_CONTEXT"
+      return 0
+    else
+      printf "  ${_C_WARN}Please select 0 or a number between 1 and %d.${_C_RESET}\n" "${#contexts[@]}"
+    fi
+  done
+}
+
+function select_namespace() {
+  namespace=""
+  printf "\n  Searching for Sysdig namespaces...\n"
+  local ns_list=()
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && ns_list+=("$line")
+  # Match Sysdig namespaces plus the IBM Cloud Monitoring default 'ibm-observe',
+  # where the Sysdig agent ships as part of IBM's offering.
+  done < <($k8sCmd get namespaces --no-headers 2>/dev/null | awk '{print $1}' | grep -iE 'sysdig|ibm-observe')
+
+  if [[ ${#ns_list[@]} -gt 0 ]]; then
+    printf "\n  ${_C_BOLD}Sysdig namespaces found:${_C_RESET}\n"
+    local i
+    for i in "${!ns_list[@]}"; do
+      printf "    ${_C_KEY}[%d]${_C_RESET} %s\n" $(( i + 1 )) "${ns_list[$i]}"
+    done
+    printf "    ${_C_KEY}[%d]${_C_RESET} Enter manually\n" $(( ${#ns_list[@]} + 1 ))
+    printf "    ${_C_KEY}[0]${_C_RESET} Back\n"
+
+    local manual_opt=$(( ${#ns_list[@]} + 1 ))
+    while true; do
+      printf "\n  >> Select [0-%d]: " "$manual_opt"
+      read -r ns_choice
+      if [[ "$ns_choice" == "0" ]]; then
+        return 1
+      elif [[ "$ns_choice" =~ ^[0-9]+$ ]] && (( ns_choice >= 1 && ns_choice < manual_opt )); then
+        namespace="${ns_list[$(( ns_choice - 1 ))]}"
+        break
+      elif [[ "$ns_choice" == "$manual_opt" ]]; then
+        while [[ -z "$namespace" ]]; do
+          printf "  >> Namespace (or 0 to cancel): "
+          read -r namespace
+          [[ "$namespace" == "0" ]] && { namespace=""; return 1; }
+          [[ -z "$namespace" ]] && printf "  ${_C_WARN}Namespace cannot be empty.${_C_RESET}\n"
+        done
+        break
+      else
+        printf "  ${_C_WARN}Please select 0 or a number between 1 and %d.${_C_RESET}\n" "$manual_opt"
+      fi
+    done
+  else
+    printf "  ${_C_WARN}No Sysdig namespaces found.${_C_RESET} Enter the namespace manually (or 0 to cancel).\n"
+    while [[ -z "$namespace" ]]; do
+      printf "  >> Namespace: "
+      read -r namespace
+      [[ "$namespace" == "0" ]] && { namespace=""; return 1; }
+      [[ -z "$namespace" ]] && printf "  ${_C_WARN}Namespace cannot be empty.${_C_RESET}\n"
+    done
+  fi
+  log_activity "Namespace selected: $namespace"
+  return 0
+}
+
+function initVar() {
+  DEST_DIR=$(pwd)
+  # No disk file yet. log_activity buffers into SESSION_BOOTSTRAP_LINES until
+  # prompt_output_path confirms a destination and replays the buffer into the
+  # run's activity.log. This prevents the old 'mv' migration from ripping the
+  # log out of a prior bundle dir when a second option runs in the same session.
+  LOG_PHASE="bootstrap"
+  SESSION_BOOTSTRAP_LINES=()
+  RUN_BUFFER_LINES=()
+  ACTIVITY_LOG=""
+  log_activity "Initialized activity log buffer."
+
+  local CURR_DATE
+  CURR_DATE=$(date '+%Y-%m-%d_%H%M%S')
+  ARCHIVE_NAME="support-util-${CURR_DATE}.tar.gz"
+
+  export DEST_DIR ARCHIVE_NAME ERR_RC_TAR ERR_RC_CURL AGENT_LOG_DIR SYSDIG_CS_DIR IS_AIRGAPPED
+
+  log_activity "Initialization complete."
+}
+
+# Reset only the discovery-related vars (prefixes, app names, counters, CS_POD_IP).
+# Leaves $namespace untouched. Used before re-running discoverComponents in a
+# different namespace during cross-namespace flows.
+function resetDiscoveryVars() {
+  SYSDIG_DS_NAME=""
+  SYSDIG_DEPLOY_NAME=""
+  DS_COUNTER_RETRY=0
+  DP_COUNTER_RETRY=0
+  SYSDIG_AGENT_APP_NAME=""
+  SYSDIG_NA_APP_NAME=""
+  SYSDIG_CS_APP_NAME=""
+  SYSDIG_KSPM_COLLECTOR_APP_NAME=""
+  SYSDIG_AC_APP_NAME=""
+  SYSDIG_CSCAN_APP_NAME=""
+  SYSDIG_RR_APP_NAME=""
+  SYSDIG_AGENT_PREFIX=""
+  SYSDIG_NA_PREFIX=""
+  SYSDIG_CS_PREFIX=""
+  SYSDIG_KSPMC_PREFIX=""
+  SYSDIG_AC_PREFIX=""
+  SYSDIG_CSCAN_PREFIX=""
+  SYSDIG_RR_PREFIX=""
+  SYSDIG_INSTANCE_LABELS=""
+  SYSDIG_AGENT_IS_SHIELD_HOST=0
+  CS_POD_IP=""
+}
+
+function discoverComponents() {
+  printf "Discovering Sysdig components in namespace '%s'...\n" "$namespace"
+
+  while [[ -z $SYSDIG_DS_NAME ]] && [[ $DS_COUNTER_RETRY -le $DS_FIND_ATTEMPT_RETRY ]]; do
+    DS_LIST=$(
+      $k8sCmd get ds -l "${SYSDIG_SHIELD_IMMUTABLE_LABEL}" -n "$namespace" -o=jsonpath="${JSONPATH_SEARCH}" 2>/dev/null
+      $k8sCmd get ds -l "${SYSDIG_AGENT_IMMUTABLE_LABEL}" -n "$namespace" -o=jsonpath="${JSONPATH_SEARCH}" 2>/dev/null
+      $k8sCmd get ds -l "${SYSDIG_NA_IMMUTABLE_LABEL}" -n "$namespace" -o=jsonpath="${JSONPATH_SEARCH}" 2>/dev/null
+    )
+    SYSDIG_DS_NAME=$(echo -e "${DS_LIST}" | grep . | sort | uniq)
+    log_activity "DaemonSet found: $SYSDIG_DS_NAME"
+    (( DS_COUNTER_RETRY++ ))
+  done
+
+  while [[ -z $SYSDIG_DEPLOY_NAME ]] && [[ $DP_COUNTER_RETRY -le $DP_FIND_ATTEMPT_RETRY ]]; do
+    DEPLOY_LIST=$(
+      $k8sCmd get deploy -l "${SYSDIG_SHIELD_IMMUTABLE_LABEL}" -n "$namespace" -o=jsonpath="${JSONPATH_SEARCH}" 2>/dev/null
+      $k8sCmd get deploy -l "${SYSDIG_KSPM_COLLECTOR_IMMUTABLE_LABEL}" -n "$namespace" -o=jsonpath="${JSONPATH_SEARCH}" 2>/dev/null
+    )
+    SYSDIG_DEPLOY_NAME=$(echo -e "${DEPLOY_LIST}" | grep . | sort | uniq)
+    log_activity "Deployment found: $SYSDIG_DEPLOY_NAME"
+    (( DP_COUNTER_RETRY++ ))
+  done
+
+  if [[ -z $SYSDIG_DS_NAME ]] && [[ -z $SYSDIG_DEPLOY_NAME ]]; then
+    printf -- "  -----------------------------------------------------------------------\n"
+    printf "  ${_C_WARN}WARNING: No Sysdig components found in namespace: '%s'${_C_RESET}\n" "$namespace"
+    printf -- "  -----------------------------------------------------------------------\n"
+    printf "  Possible reasons:\n"
+    printf "   1. The namespace provided is incorrect.\n"
+    printf "   2. The components (DaemonSet/Deployment) are not yet deployed.\n"
+    printf "   3. The components are installed in a DIFFERENT namespace.\n"
+    printf -- "  -----------------------------------------------------------------------\n"
+    log_activity "No Sysdig components found in namespace: $namespace"
+    return 1
+  fi
+
+  # _instance_set: comma-joined distinct app.kubernetes.io/instance values
+  # captured from matched workloads. Used downstream by
+  # _kubectl_get_sysdig_filtered to scope cm/ds/deploy listings.
+  local _instance_set="" INSTANCE_LABEL
+
+  # Per-workload _sysdig_matched flag gates the INSTANCE_LABEL accumulation.
+  # Without it, ANY workload picked up by the broad app.kubernetes.io/instance
+  # discovery query (which catches every Helm-installed chart in the namespace)
+  # would leak its instance value into SYSDIG_INSTANCE_LABELS — polluting
+  # downstream manifest collection with non-Sysdig workloads (customer apps
+  # or Sysdig backend components sharing the namespace).
+  local _sysdig_matched
+  while IFS=$'\t' read -r APP_NAME IMAGE_NAME INSTANCE_LABEL SHIELD_COMP; do
+    _sysdig_matched=0
+    if [[ "$IMAGE_NAME" =~ $SYSDIG_AGENT_IMAGE_NAME ]]; then
+      SYSDIG_AGENT_APP_NAME=$APP_NAME
+      _sysdig_matched=1
+      # The new cluster-shield product ships a host-side DaemonSet running the
+      # agent-slim image. Distinguish it from a legacy standalone agent via the
+      # sysdig/component label (present on shield workloads, absent on legacy).
+      # When set, the agent bucket is renamed "shield" downstream and logs land
+      # under logs/shield/{pod}/ instead of logs/agent/{pod}/.
+      if [[ -n "$SHIELD_COMP" ]]; then
+        SYSDIG_AGENT_IS_SHIELD_HOST=1
+        log_activity "Shield host app: $APP_NAME (sysdig/component=$SHIELD_COMP, image=$IMAGE_NAME)"
+      else
+        log_activity "Agent app: $APP_NAME"
+      fi
+    fi
+    [[ "$IMAGE_NAME" =~ $SYSDIG_NA_IMAGE_NAME ]]    && SYSDIG_NA_APP_NAME=$APP_NAME    && _sysdig_matched=1 && log_activity "NodeAnalyzer app: $APP_NAME"
+    [[ "$IMAGE_NAME" =~ $SYSDIG_RR_IMAGE_NAME ]]    && SYSDIG_RR_APP_NAME=$APP_NAME    && _sysdig_matched=1 && log_activity "RapidResponse app: $APP_NAME"
+    if (( _sysdig_matched )) && [[ -n "$INSTANCE_LABEL" ]]; then
+      case ",${_instance_set}," in
+        *,${INSTANCE_LABEL},*) ;;
+        *) [[ -z "$_instance_set" ]] && _instance_set="$INSTANCE_LABEL" || _instance_set="${_instance_set},${INSTANCE_LABEL}" ;;
+      esac
+    fi
+  done <<< "${SYSDIG_DS_NAME}"
+
+  while IFS=$'\t' read -r APP_NAME IMAGE_NAME INSTANCE_LABEL SHIELD_COMP; do
+    _sysdig_matched=0
+    [[ "$IMAGE_NAME" =~ $SYSDIG_CS_IMAGE_NAME ]]             && SYSDIG_CS_APP_NAME=$APP_NAME             && _sysdig_matched=1 && log_activity "ClusterShield app: $APP_NAME"
+    [[ "$IMAGE_NAME" =~ $SYSDIG_KSPM_COLLECTOR_IMAGE_NAME ]] && SYSDIG_KSPM_COLLECTOR_APP_NAME=$APP_NAME && _sysdig_matched=1 && log_activity "KSPMCollector app: $APP_NAME"
+    [[ "$IMAGE_NAME" =~ $SYSDIG_AC_IMAGE_NAME ]]             && SYSDIG_AC_APP_NAME=$APP_NAME             && _sysdig_matched=1 && log_activity "AdmissionController app: $APP_NAME"
+    [[ "$IMAGE_NAME" =~ $SYSDIG_CSCAN_IMAGE_NAME ]]          && SYSDIG_CSCAN_APP_NAME=$APP_NAME          && _sysdig_matched=1 && log_activity "ClusterScanner app: $APP_NAME"
+    if (( _sysdig_matched )) && [[ -n "$INSTANCE_LABEL" ]]; then
+      case ",${_instance_set}," in
+        *,${INSTANCE_LABEL},*) ;;
+        *) [[ -z "$_instance_set" ]] && _instance_set="$INSTANCE_LABEL" || _instance_set="${_instance_set},${INSTANCE_LABEL}" ;;
+      esac
+    fi
+  done <<< "${SYSDIG_DEPLOY_NAME}"
+
+  export SYSDIG_INSTANCE_LABELS="$_instance_set"
+  log_activity "Sysdig instance labels (app.kubernetes.io/instance): ${SYSDIG_INSTANCE_LABELS:-<none>}"
+
+  [[ -n "${SYSDIG_AGENT_APP_NAME//[[:space:]]/}" ]]            && export SYSDIG_AGENT_PREFIX="^${SYSDIG_AGENT_APP_NAME}-[a-zA-Z0-9]{5}$"
+  [[ -n "${SYSDIG_CS_APP_NAME//[[:space:]]/}" ]]               && export SYSDIG_CS_PREFIX="^${SYSDIG_CS_APP_NAME}-[a-zA-Z0-9]"
+  [[ -n "${SYSDIG_NA_APP_NAME//[[:space:]]/}" ]]               && export SYSDIG_NA_PREFIX="^${SYSDIG_NA_APP_NAME}-[a-zA-Z0-9]"
+  [[ -n "${SYSDIG_KSPM_COLLECTOR_APP_NAME//[[:space:]]/}" ]]   && export SYSDIG_KSPMC_PREFIX="^${SYSDIG_KSPM_COLLECTOR_APP_NAME}-[a-zA-Z0-9]"
+  [[ -n "${SYSDIG_AC_APP_NAME//[[:space:]]/}" ]]               && export SYSDIG_AC_PREFIX="^${SYSDIG_AC_APP_NAME}-[a-zA-Z0-9]"
+  [[ -n "${SYSDIG_CSCAN_APP_NAME//[[:space:]]/}" ]]            && export SYSDIG_CSCAN_PREFIX="^${SYSDIG_CSCAN_APP_NAME}-[a-zA-Z0-9]"
+  [[ -n "${SYSDIG_RR_APP_NAME//[[:space:]]/}" ]]               && export SYSDIG_RR_PREFIX="^${SYSDIG_RR_APP_NAME}-[a-zA-Z0-9]"
+
+  printf "  ${_C_OK}Initialization complete.${_C_RESET}\n"
+  log_activity "Component discovery complete for namespace '$namespace'."
+}
+
+# True if any Sysdig component prefix is populated for the current namespace.
+function has_sysdig_components() {
+  [[ -n "$SYSDIG_AGENT_PREFIX" || -n "$SYSDIG_CS_PREFIX" || -n "$SYSDIG_NA_PREFIX" || -n "$SYSDIG_KSPMC_PREFIX" \
+     || -n "$SYSDIG_AC_PREFIX" || -n "$SYSDIG_CSCAN_PREFIX" || -n "$SYSDIG_RR_PREFIX" ]]
+}
+
+# True if the current namespace looks like the Sysdig on-prem platform.
+# Signal: presence of the canonical `sysdigcloud-api` Deployment, which is
+# unique to the platform installation.
+function has_sysdig_platform() {
+  $k8sCmd get deployment sysdigcloud-api -n "$namespace" --no-headers >/dev/null 2>&1
+}
+
+# Prompt for a namespace and verify it hosts the Sysdig on-prem platform.
+# Returns 1 if user cancels OR declines to retry after no platform found.
+# (Note: kubectl context is selected once at startup and via the
+# "Change Cluster Context" menu option — not re-prompted here.)
+function prepare_platform_context() {
+  while true; do
+    namespace=""
+    podNames=()
+    select_namespace || return 1
+    printf "  Checking for Sysdig on-prem platform in namespace '%s'...\n" "$namespace"
+    if has_sysdig_platform; then
+      log_activity "Sysdig on-prem platform detected in namespace: $namespace"
+      printf "  ${_C_OK}Platform detected.${_C_RESET}\n"
+      return 0
+    fi
+    printf "\n  ${_C_WARN}No Sysdig on-prem platform found in namespace '%s'.${_C_RESET}\n" "$namespace"
+    printf "  This option targets the Sysdig backend (sysdigcloud-api, Cassandra,\n"
+    printf "  Elasticsearch, etc.). For agent log collection, use options 1, 2, or 3.\n"
+    log_activity "No Sysdig platform detected in '$namespace'."
+    if ! prompt_yn $'\n  Try a different namespace?'; then
+      log_activity "User declined to retry; returning to main menu."
+      return 1
+    fi
+  done
+}
+
+# Prompt for a namespace, run discovery, and verify Sysdig components were
+# found. On success, $namespace and prefix vars are populated.
+# If no components are detected, offers the user the chance to pick a
+# different namespace instead of bouncing straight back to the main menu.
+# Returns 1 only if the user cancels OR declines to retry.
+# (Note: kubectl context is selected once at startup and via the
+# "Change Cluster Context" menu option — not re-prompted here.)
+function prepare_namespace_context() {
+  while true; do
+    resetDiscoveryVars
+    namespace=""
+    podNames=()
+    select_namespace || return 1
+    discoverComponents
+    if has_sysdig_components; then
+      return 0
+    fi
+    printf "\n  ${_C_WARN}Nothing to collect in namespace '%s'.${_C_RESET}\n" "$namespace"
+    printf "  This script only handles Helm-installed Sysdig deployments\n"
+    printf "  (sysdig-deploy, shield, or the agent subchart).\n"
+    log_activity "No Sysdig components detected in '$namespace'."
+    if ! prompt_yn $'\n  Try a different namespace?'; then
+      log_activity "User declined to retry; returning to main menu."
+      return 1
+    fi
+  done
+}
+
+# ─────────────────────────────────────────────
+#  trackPodError
+# ─────────────────────────────────────────────
+
+function trackPodError() {
+  FAILED_PODS+=("$1")
+}
+
+# Map a pod name to a Phase-1 component bucket using the SYSDIG_*_PREFIX
+# regexes discovered by discoverComponents. Returns the lowerCamelCase
+# bucket name, or empty if the pod is not a known Sysdig component.
+# Used by select_pods_by_component (bucketing), the "by specific pod"
+# picker filter, getLogs (log destination), and the describe collection
+# loops — single source of truth for the regex chain.
+function _component_for_pod() {
+  local _p="$1"
+  if   [[ -n "$SYSDIG_AGENT_PREFIX" && "$_p" =~ $SYSDIG_AGENT_PREFIX ]]; then
+    (( SYSDIG_AGENT_IS_SHIELD_HOST )) && echo "shield" || echo "agent"
+  elif [[ -n "$SYSDIG_CS_PREFIX"    && "$_p" =~ $SYSDIG_CS_PREFIX    ]]; then echo "cluster-shield"
+  elif [[ -n "$SYSDIG_NA_PREFIX"    && "$_p" =~ $SYSDIG_NA_PREFIX    ]]; then echo "node-analyzer"
+  elif [[ -n "$SYSDIG_KSPMC_PREFIX" && "$_p" =~ $SYSDIG_KSPMC_PREFIX ]]; then echo "kspm-collector"
+  elif [[ -n "$SYSDIG_AC_PREFIX"    && "$_p" =~ $SYSDIG_AC_PREFIX    ]]; then echo "admission-controller"
+  elif [[ -n "$SYSDIG_CSCAN_PREFIX" && "$_p" =~ $SYSDIG_CSCAN_PREFIX ]]; then echo "cluster-scanner"
+  elif [[ -n "$SYSDIG_RR_PREFIX"    && "$_p" =~ $SYSDIG_RR_PREFIX    ]]; then echo "rapid-response"
+  else echo ""
+  fi
+}
+
+# Run a `kubectl get <obj> -n $namespace ...` scoped to Sysdig-related items via
+# the app.kubernetes.io/instance label values captured by discoverComponents.
+# Falls back to an un-filtered listing when SYSDIG_INSTANCE_LABELS is empty
+# (rare — would mean discovery found Sysdig workloads but couldn't read any
+# instance label). Any extra args after $1 are passed through to kubectl.
+function _kubectl_get_sysdig_filtered() {
+  local _obj="$1"; shift
+  if [[ -n "$SYSDIG_INSTANCE_LABELS" ]]; then
+    $k8sCmd get "$_obj" -l "app.kubernetes.io/instance in (${SYSDIG_INSTANCE_LABELS})" -n "$namespace" "$@"
+  else
+    $k8sCmd get "$_obj" -n "$namespace" "$@"
+  fi
+}
+
+# Loop over every item of a namespaced resource and write one YAML file
+# per item to <base>/<obj>/<name>-<suffix>.yaml. Phase 1 only.
+#
+# Filters items to those tagged with one of the discovered
+# app.kubernetes.io/instance label values (see discoverComponents). When the
+# instance-scoped query returns nothing, we accept that result rather than
+# falling back to an unfiltered listing — the previous fallback over-collected
+# non-Sysdig workloads (customer apps or Sysdig-backend components sharing the
+# namespace). Customers applying raw YAML with inconsistent instance labels
+# should fix their labels for SLC to capture those configs.
+function _collect_resource_per_item_yaml() {
+  local obj="$1" suffix="$2" base="$3"
+  local items item _err _rc
+  items=$(_kubectl_get_sysdig_filtered "$obj" -o jsonpath="{.items[*]['metadata.name']}" 2>/dev/null)
+  [[ -z "$items" ]] && return 0
+  mkdir -p "$base/$obj"
+  for item in $items; do
+    # Skip k8s-managed ConfigMaps that aren't Sysdig-relevant. kube-root-ca.crt
+    # is auto-injected into every namespace and only contains the cluster CA.
+    if [[ "$obj" == "configmap" && "$item" == "kube-root-ca.crt" ]]; then
+      continue
+    fi
+    _err=$($k8sCmd get "$obj" "$item" -n "$namespace" -o yaml 2>&1 1>"$base/$obj/${item}-${suffix}.yaml")
+    _rc=$?
+    if [[ $_rc -ne 0 ]]; then
+      log_activity "ERROR: Failed to collect $obj/$item. Reason: ${_err:-unknown}"
+    fi
+  done
+}
+
+# Run a kubectl/oc command, redirect its stdout to a file, and capture stderr
+# to activity.log on failure (and as a warning on success). The `2>&1 1>FILE`
+# order matters: stderr is first dup'd to the command-substitution pipe, then
+# stdout is redirected to the file. Result: large stdout (yaml/json) goes to
+# disk; small stderr (error messages) gets logged.
+# Args: outfile label cmd...
+function _kubectl_to_file_logged() {
+  local _outfile="$1" _label="$2"
+  shift 2
+  local _err _rc
+  _err=$("$@" 2>&1 1>"$_outfile")
+  _rc=$?
+  if [[ $_rc -eq 0 ]]; then
+    [[ -n "$_err" ]] && log_activity "Collected $_label (with warnings): $_err"
+  else
+    log_activity "ERROR: Failed to collect $_label. Reason: ${_err:-unknown} (rc=$_rc)"
+  fi
+}
+
+# ─────────────────────────────────────────────
+#  collectArtifacts
+# ─────────────────────────────────────────────
+
+# Collect Helm release info for the current namespace into helm.txt. If the
+# helm CLI isn't on PATH (common when the Agent is deployed via raw manifests
+# instead of a Helm chart), write a clear placeholder so support engineers
+# don't see an empty / missing file and wonder why.
+function collectHelmInfo() {
+  local _outfile="$DEST_DIR/$SYSDIG_SUPPORT_DIR/helm.txt"
+  if ! command -v helm >/dev/null 2>&1; then
+    {
+      printf "Helm CLI not found in PATH.\n"
+      printf "The Sysdig Agent in namespace '%s' may not be deployed via Helm,\n" "$namespace"
+      printf "or the helm binary is not installed on this machine.\n"
+    } > "$_outfile"
+    log_activity "Helm CLI not found in PATH; helm.txt notes the Agent may not be deployed via Helm."
+    return 0
+  fi
+  local _err _rc
+  _err=$(helm ls -n "$namespace" 2>&1 1>"$_outfile")
+  _rc=$?
+  if [[ $_rc -ne 0 ]]; then
+    log_activity "ERROR: helm ls failed for namespace '$namespace': ${_err:-unknown}"
+  else
+    log_activity "Helm release list for namespace '$namespace' collected successfully."
+  fi
+}
+
+# Write `top pod` resource usage to <outfile>. On OpenShift, try `oc adm top`
+# first and fall back to plain `top pod`; warns (non-fatal) if no metrics server.
+function _collect_top_pods() {
+  local _outfile="$1"
+  if [[ "$BASE_K8S_CMD" == "oc" ]]; then
+    $k8sCmd adm top pod -n "$namespace" > "$_outfile" 2>/dev/null \
+      || $k8sCmd top pod -n "$namespace" > "$_outfile" 2>/dev/null \
+      || printf "${_C_WARN}Metrics server not available, moving forward.${_C_RESET}\n"
+  else
+    $k8sCmd top pod -n "$namespace" > "$_outfile" 2>/dev/null || printf "${_C_WARN}Metrics server not available, moving forward.${_C_RESET}\n"
+  fi
+}
+
+# Per-pod `describe` grouped by component bucket under describe/<comp>/<pod>.txt,
+# plus a describe/describe_pods.txt overview. Reads pod names from
+# <dst>/running_pods.txt. Args: dst dir.
+function _collect_pod_describes_by_component() {
+  local _dst="$1" _p _comp
+  mkdir -p "$_dst/describe"
+  for _p in $(awk '{print $1}' < "$_dst/running_pods.txt" 2>/dev/null); do
+    _comp=$(_component_for_pod "$_p")
+    [[ -z "$_comp" ]] && continue
+    mkdir -p "$_dst/describe/$_comp"
+    $k8sCmd describe pod "$_p" -n "$namespace" > "$_dst/describe/$_comp/$_p.txt" 2>/dev/null \
+      || log_activity "ERROR: describe failed for pod $_p"
+  done
+  _kubectl_to_file_logged "$_dst/describe/describe_pods.txt" "describe overview" $k8sCmd describe po -n "$namespace"
+}
+
+# Collect per-item YAML for the Sysdig configmaps, daemonsets, and deployments.
+# Args: dst dir.
+function _collect_sysdig_manifests() {
+  local _dst="$1"
+  _collect_resource_per_item_yaml configmap cm "$_dst"
+  _collect_resource_per_item_yaml daemonset ds "$_dst"
+  _collect_resource_per_item_yaml deployment deploy "$_dst"
+}
+
+# Per-node `describe` (.txt) under nodes/, plus a nodes/nodes.txt overview.
+# Args: dst dir.
+function _collect_nodes() {
+  local _dst="$1" _node
+  mkdir -p "$_dst/nodes"
+  for _node in $($k8sCmd get nodes -o name 2>/dev/null | sed 's|^node/||'); do
+    $k8sCmd describe node "$_node" > "$_dst/nodes/$_node.txt" 2>/dev/null \
+      || log_activity "ERROR: describe failed for node $_node"
+  done
+  _kubectl_to_file_logged "$_dst/nodes/nodes.txt" "nodes" $k8sCmd describe nodes
+}
+
+# Set the global CS_POD_IP from the cluster-shield pod's IP (column 6 of
+# running_pods.txt) when a cluster-shield app is present. No-op otherwise.
+function _extract_cs_pod_ip() {
+  [[ -z "$SYSDIG_CS_APP_NAME" ]] && return 0
+  CS_POD_IP=$(grep -E "$SYSDIG_CS_PREFIX" "$DEST_DIR/$SYSDIG_SUPPORT_DIR/running_pods.txt" | head -1 | awk '{print $6}')
+  return 0
+}
+
+function collectArtifacts() {
+  log_activity "Starting configuration collection (namespace: '${namespace}', pod: ${podName:-all pods})."
+  local _dst="$DEST_DIR/$SYSDIG_SUPPORT_DIR"
+  if [[ -z $podName ]]; then
+    printf "Collecting configuration for all Sysdig pods, this may take a while...\n"
+    log_activity "Collecting cluster info."
+    _kubectl_to_file_logged "$_dst/cluster_info.json"  "cluster_info"  $k8sCmd version -o json
+    _kubectl_to_file_logged "$_dst/running_pods.txt"   "running_pods"  $k8sCmd get po --sort-by='.status.containerStatuses[0].restartCount' --no-headers -n "$namespace" -o wide
+    _collect_top_pods "$_dst/top_pods.txt"
+    _collect_pod_describes_by_component "$_dst"
+    _collect_sysdig_manifests "$_dst"
+    _collect_nodes "$_dst"
+    log_activity "Configuration for all Sysdig pods collected successfully."
+  else
+    printf "Collecting configuration for pod %s...\n" "$podName"
+    _kubectl_to_file_logged "$_dst/cluster_info.json"             "cluster_info"           $k8sCmd version -o json
+    _kubectl_to_file_logged "$_dst/running_pods.txt"              "running_pods"           $k8sCmd get po --sort-by='.status.containerStatuses[0].restartCount' --no-headers -n "$namespace" -o wide
+    _collect_top_pods "$_dst/top_pods.txt"
+    local _comp
+    _comp=$(_component_for_pod "$podName")
+    if [[ -n "$_comp" ]]; then
+      mkdir -p "$_dst/describe/$_comp"
+      _kubectl_to_file_logged "$_dst/describe/$_comp/$podName.txt" "describe pod $podName" $k8sCmd describe pod "$podName" -n "$namespace"
+    fi
+    _collect_sysdig_manifests "$_dst"
+    _collect_nodes "$_dst"
+    log_activity "Configuration for pod $podName collected successfully."
+  fi
+
+  printf "Collecting cluster object counts...\n"
+  local deployments replicasets namespaces configmaps pods
+  deployments=$($k8sCmd get deployments --all-namespaces --no-headers 2>/dev/null | wc -l)
+  replicasets=$($k8sCmd get replicasets --all-namespaces --no-headers 2>/dev/null | wc -l)
+  namespaces=$($k8sCmd get namespaces --no-headers 2>/dev/null | wc -l)
+  configmaps=$($k8sCmd get configmaps --all-namespaces --no-headers 2>/dev/null | wc -l)
+  pods=$($k8sCmd get pods --all-namespaces --no-headers 2>/dev/null | wc -l)
+  {
+    printf "Cluster Object Counts:\n"
+    printf -- "-----------------------\n"
+    printf "Deployments : %s\n" "$deployments"
+    printf "ReplicaSets : %s\n" "$replicasets"
+    printf "Namespaces  : %s\n" "$namespaces"
+    printf "ConfigMaps  : %s\n" "$configmaps"
+    printf "Pods        : %s\n" "$pods"
+  } > "$DEST_DIR/$SYSDIG_SUPPORT_DIR/cluster_object_counts.txt"
+  log_activity "Cluster object counts collected successfully."
+
+  printf "Collecting Helm release info...\n"
+  collectHelmInfo
+
+  _extract_cs_pod_ip
+
+  # Success message printed AFTER the cluster object counts so the user sees
+  # "complete" only when every piece of the configuration collection is done.
+  if [[ -z $podName ]]; then
+    printf "${_C_OK}Configuration for all Sysdig pods collected successfully.${_C_RESET}\n"
+  else
+    printf "${_C_OK}Configuration for pod %s collected successfully.${_C_RESET}\n" "$podName"
+  fi
+  log_activity "Configuration collection complete."
+}
+
+# ─────────────────────────────────────────────
+#  getLogs
+# ─────────────────────────────────────────────
+
+# Collect the pod-specific describe file under describe/<component>/.
+# Cluster-wide artifacts (running_pods.txt with NODE column + nodes/ describes)
+# must already have been gathered via collectArtifacts.
+function collectPodArtifacts() {
+  local _comp
+  _comp=$(_component_for_pod "$podName")
+  if [[ -n "$_comp" ]]; then
+    mkdir -p "$DEST_DIR/$SYSDIG_SUPPORT_DIR/describe/$_comp"
+    $k8sCmd describe po "$podName" -n "$namespace" > "$DEST_DIR/$SYSDIG_SUPPORT_DIR/describe/$_comp/$podName.txt"
+  fi
+}
+
+# Decide the cause of a refused Tier 0 exec from kubectl/oc's OWN stderr. Scoped
+# to the exec-refusal cases that actually apply (the Sysdig images ship tar, and
+# collection can't start unauthenticated): RBAC, admission control, or a pod
+# that isn't running. The raw stderr is still logged as Detail — this label is
+# the decision, that line is the ground truth. Unrecognised / empty stderr falls
+# back to the enumerated form rather than guessing one cause.
+function _tier0_exec_cause() {
+  case "$1" in
+    *[Ff]orbidden*|*pods/exec*)                                printf "RBAC — missing 'create' on pods/exec" ;;
+    *"admission webhook"*[Dd]enied*)                           printf 'blocked by an admission controller' ;;
+    *"completed pod"*|*"not running"*|*"container not found"*) printf 'pod is not running' ;;
+    *)                                                         printf "exec refused — missing 'create' on pods/exec, or an admission controller" ;;
+  esac
+}
+
+# Phase 1 per-pod worker — invoked by run_bg from getLogs's all-pods branch.
+# Mirrors the original serial loop body, with two differences:
+#  - trackPodError is replaced by a marker file under $fail_dir, because the
+#    FAILED_PODS array does not propagate from a subshell back to the parent.
+#  - The once-only dragent.yaml and csFeaturesStatus.json collections are
+#    hoisted out into the parent (see getLogs); they're per-cluster artifacts.
+# All other per-component logic, output paths, log_activity wording, and
+# printf wording are unchanged from the original serial implementation.
+function _phase1_collect_one_pod_logs() {
+  local pod="$1" fail_dir="$2"
+  local cpError cpRc
+  local _partial=0
+  # Skip pods that aren't Sysdig components. getLogs's all-pods branch iterates
+  # every entry in running_pods.txt (the full `kubectl get po -n NS` list), so
+  # non-Sysdig workloads sharing the namespace would otherwise get stdout
+  # collected. _component_for_pod returns empty for any pod that doesn't match
+  # a discovered SYSDIG_*_PREFIX regex.
+  if [[ -z "$(_component_for_pod "$pod")" ]]; then
+    log_activity "Skipping non-Sysdig pod $pod (not matched by any SYSDIG_*_PREFIX)."
+    return 0
+  fi
+  printf "Collecting logs for pod %s...\n" "$pod"
+  log_activity "Collecting logs for pod $pod"
+  if [[ -n "$SYSDIG_AGENT_PREFIX" ]] && [[ $pod =~ $SYSDIG_AGENT_PREFIX ]]; then
+    local _agent_log_subdir="agent"
+    (( SYSDIG_AGENT_IS_SHIELD_HOST )) && _agent_log_subdir="shield"
+    local _pod_log_dir="$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/$_agent_log_subdir/$pod"
+    mkdir -p "$_pod_log_dir"
+    # Three-tier flow. Tier 0 = probe tar in the pod. Tier 1 = compress-in-pod
+    # + cp .tgz + integrity check + retry. Tier 2 = direct kubectl cp of
+    # /opt/draios/logs/ (legacy fallback). Tier 3 = kubectl logs --all-containers
+    # (stdout-only). /opt/draios/logs/ is ~100+ MB so streaming via direct cp
+    # is fragile under apiserver exec-stream timeouts — compress-in-pod shrinks
+    # it to ~5-15 MB so the cp completes inside the timeout window. Tiers 1
+    # and 2 both require tar in the pod (kubectl cp uses tar internally); when
+    # absent we short-circuit to Tier 3. tar exits 1 on benign "file changed as
+    # we read it"; trust file size, not exit code. Compress is NOT repeated on
+    # cp-retry — the in-pod .tgz is unchanged.
+    local _in_pod_tgz_candidates=("/tmp/draios-logs.tgz" "/opt/draios/draios-logs.tgz")
+    local _in_pod_tgz="" _local_tgz=""
+    local _compressErr _attempt=1 _cp_ok=0 _have_tgz=0 _have_tar=0
+    # Tier 0: probe tar once. One extra exec round-trip up front, saves 3-4
+    # wasted attempts. The Sysdig agent/shield images ship tar, so a failed
+    # probe means the exec itself was refused (Tiers 1+2 both need exec).
+    # _tier0_exec_cause decides the cause from the stderr; the raw stderr is
+    # logged as confirming Detail. Fall through to Tier 3 (stdout).
+    local _tier0_err _tier0_cause
+    _tier0_err=$($k8sCmd exec "$pod" -n "$namespace" -- sh -c 'command -v tar' 2>&1 1>/dev/null)
+    if [[ $? -eq 0 ]]; then
+      _have_tar=1
+    else
+      _tier0_cause=$(_tier0_exec_cause "$_tier0_err")
+      log_activity "Tier 0: cannot exec into $pod for file-based collection — ${_tier0_cause}; falling through to Tier 3 (stdout).${_tier0_err:+ Detail: ${_tier0_err//$'\n'/ | }}"
+    fi
+    # Tier 1a+b (coalesced): compress in pod + size check + in-pod integrity
+    # check, all in ONE kubectl exec via sh -c. The && chain short-circuits on
+    # first failure, so any of (no write access, disk full, partial write) at
+    # a candidate path cascades cleanly to the next candidate. Doing this in
+    # one exec instead of three saves 2 round-trips per candidate per pod —
+    # meaningful under MAX_JOBS=4 concurrent workers on flaky networks.
+    # /opt/draios/ is the agent's own writable volume (the agent writes
+    # draios.log inside /opt/draios/logs/, so write perms are guaranteed); the
+    # .tgz is placed in /opt/draios/ rather than /opt/draios/logs/ to avoid a
+    # tar self-reference. Loop short-circuits when Tier 0 found no tar.
+    for _candidate in "${_in_pod_tgz_candidates[@]}"; do
+      (( _have_tar )) || break
+      # tar exits 1 on benign "file changed as we read it" (the agent is actively
+      # writing draios.log) — trust the post-archive validation, not tar's exit
+      # code. Use `;` after tar czf to ignore its exit; rely on test -s +
+      # tar tzf as the real signal.
+      if _compressErr=$($k8sCmd exec "$pod" -n "$namespace" -- sh -c \
+           "tar czf \"$_candidate\" -C /opt/draios/logs . ; test -s \"$_candidate\" && tar tzf \"$_candidate\" >/dev/null" 2>&1); then
+        _in_pod_tgz="$_candidate"
+        _local_tgz="$_pod_log_dir/draios-logs.tgz"
+        _have_tgz=1
+        break
+      fi
+      log_activity "Tier 1 at $_candidate failed for $pod (write / size / integrity); trying next path. Reason: ${_compressErr//$'\n'/ | }"
+      $k8sCmd exec "$pod" -n "$namespace" -- rm -f "$_candidate" 2>/dev/null
+    done
+    # Tier 1: cp the .tgz with post-cp integrity check; retry the cp on
+    # integrity failure (compress NOT repeated).
+    if (( _have_tgz )); then
+      while (( _attempt <= AGENT_CP_RETRY )); do
+        rm -f "$_local_tgz"
+        cpError=$($k8sCmd -n "$namespace" cp "$pod:$_in_pod_tgz" "$_local_tgz" --retries=$AGENT_CP_RETRY 2>&1)
+        if [[ -s "$_local_tgz" ]] && tar tzf "$_local_tgz" >/dev/null 2>&1; then
+          _cp_ok=1
+          break
+        fi
+        if (( _attempt < AGENT_CP_RETRY )); then
+          printf "${_C_WARN}Retrying %s cp .tgz (attempt %d/%d): integrity check failed.${_C_RESET}\n" "$pod" "$_attempt" "$AGENT_CP_RETRY"
+          log_activity "Retrying $pod cp .tgz (attempt $_attempt/$AGENT_CP_RETRY): integrity check failed. ${cpError//$'\n'/ | }"
+          sleep 2
+        fi
+        ((_attempt++))
+      done
+    fi
+    # Tier 1: extract on success.
+    if (( _cp_ok )); then
+      tar xzf "$_local_tgz" -C "$_pod_log_dir" 2>/dev/null
+      rm -f "$_local_tgz"
+      # Clean Tier 1 success is the happy path — left unlogged to keep
+      # activity.log quiet on success and loud on degradation. The per-pod
+      # start marker ("Collecting logs for pod $pod") above still records it;
+      # the noisier Tier 2/3 and ERROR lines below all signal something failed.
+    else
+      rm -f "$_local_tgz"
+    fi
+    # Tier 1 cleanup: remove the in-pod .tgz if it exists.
+    [[ -n "$_in_pod_tgz" ]] && $k8sCmd exec "$pod" -n "$namespace" -- rm -f "$_in_pod_tgz" 2>/dev/null
+    # Tier 2: direct kubectl cp of /opt/draios/logs/ (legacy fallback).
+    # Survives Tier 1 failures that don't disable cp itself: no candidate
+    # path produced a valid archive, in-pod tarball corrupt at every path,
+    # mysterious tar hang.
+    if (( ! _cp_ok && _have_tar )); then
+      log_activity "Tier 1 (compress-in-pod) failed for $pod; trying Tier 2 (direct kubectl cp)."
+      cpError=$($k8sCmd -n "$namespace" cp "$pod:opt/draios/logs/." "$_pod_log_dir" --retries=$AGENT_CP_RETRY 2>&1)
+      cpRc=$?
+      if [[ -n "$(ls -A "$_pod_log_dir" 2>/dev/null)" ]]; then
+        _cp_ok=1
+        # Tier 2 partial-detection: kubectl cp may produce files but with a
+        # truncated tail when the apiserver stream drops mid-transfer. The
+        # cpError patterns below were the legacy single-pod branch's signal
+        # for that case. When detected, mark the bundle as partial so support
+        # knows draios.log's tail may be incomplete.
+        if [[ $cpRc -ne 0 ]] && \
+           { [[ "$cpError" == *"invalid tar header"* ]] || \
+             [[ "$cpError" == *"i/o timeout"* ]] || \
+             [[ "$cpError" == *"unexpected EOF"* ]]; }; then
+          printf "${_C_WARN}Logs for pod %s partially collected via direct kubectl cp (Tier 2); see activity.log.${_C_RESET}\n" "$pod"
+          log_activity "Agent logs for $pod collected via direct kubectl cp (Tier 2, PARTIAL — cp errored mid-stream; draios.log tail may be truncated). cp output: ${cpError//$'\n'/ | }"
+          _partial=1
+        else
+          log_activity "Agent logs for $pod collected via direct kubectl cp (Tier 2).${cpError:+ cp output: ${cpError//$'\n'/ | }}"
+        fi
+      fi
+    fi
+    # Tier 3: kubectl logs --all-containers (stdout-only).
+    if (( ! _cp_ok )); then
+      # Why the FILE-BASED tiers produced nothing — shown when we still salvage a
+      # stdout fallback ("fell back because <this>"). A Tier 0 miss means exec was
+      # refused (missing pods/exec); otherwise a Tier 1/2 cp error routed us here.
+      local _fb_reason
+      if (( ! _have_tar )); then
+        _fb_reason="$_tier0_cause"
+      else
+        _fb_reason="${cpError:-${_compressErr:-file-based copy failed}}"
+        _fb_reason="${_fb_reason//$'\n'/ | }"
+      fi
+      # Capture Tier 3's OWN stderr. When the stdout fallback itself errors or
+      # comes back empty, THAT — not the file-based cause — is why no logs were
+      # collected. 2>&1 1>file: stdout → file, stderr → captured.
+      local _t3_err
+      _t3_err=$($k8sCmd -n "$namespace" logs "$pod" --all-containers=true --prefix=true 2>&1 1>"$_pod_log_dir/$pod.log")
+      if [[ ! -s "$_pod_log_dir/$pod.log" ]]; then
+        _t3_err=$($k8sCmd -n "$namespace" logs "$pod" 2>&1 1>"$_pod_log_dir/$pod.log")
+      fi
+      if [[ -s "$_pod_log_dir/$pod.log" ]]; then
+        printf "${_C_WARN}%s: file-based logs unavailable (%s), fell back to kubectl logs — stdout logs only for this pod.${_C_RESET}\n" "$pod" "$_fb_reason"
+        log_activity "Collected stdout logs for $pod (Tier 3 — file-based collection failed). Reason: ${_fb_reason}"
+        _partial=1
+      else
+        rm -f "$_pod_log_dir/$pod.log"
+        rmdir "$_pod_log_dir" 2>/dev/null
+        # The stdout fallback also yielded nothing: report Tier 3's real error
+        # (e.g. missing 'get' on pods/log), or — when it exited clean but empty —
+        # the only two things we can actually stand behind: the pod isn't
+        # running, or its containers have written nothing to stdout.
+        local _t3_fail="${_t3_err:-no stdout to collect (pod not running, or its containers have written nothing to stdout)}"
+        _t3_fail="${_t3_fail//$'\n'/ | }"
+        printf "${_C_ERR}Error: no logs collected for %s (all 3 tiers failed — %s).${_C_RESET}\n" "$pod" "$_t3_fail"
+        log_activity "ERROR: No logs found for $pod (all 3 tiers failed). Reason: ${_t3_fail}"
+        touch "$fail_dir/$pod"
+      fi
+    fi
+  elif [[ -n "$SYSDIG_CS_PREFIX" ]] && [[ $pod =~ $SYSDIG_CS_PREFIX ]]; then
+    mkdir -p "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/cluster-shield/$pod"
+    $k8sCmd -n "$namespace" logs "$pod" > "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/cluster-shield/$pod/$pod.log" 2>/dev/null
+    [[ $? -eq 0 ]] && log_activity "Collected CS log for $pod." || log_activity "ERROR: CS log failed for $pod."
+  elif [[ -n "$SYSDIG_NA_PREFIX" ]] && [[ $pod =~ $SYSDIG_NA_PREFIX ]]; then
+    mkdir -p "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/node-analyzer/$pod"
+    local _na_c
+    for _na_c in "$SYSDIG_KSPMA_CONTAINER_NAME" "$SYSDIG_HS_CONTAINER_NAME" "$SYSDIG_RS_CONTAINER_NAME" \
+                 "$SYSDIG_HA_CONTAINER_NAME" "$SYSDIG_IA_CONTAINER_NAME" "$SYSDIG_BR_CONTAINER_NAME" "$SYSDIG_EC_CONTAINER_NAME"; do
+      $k8sCmd -n "$namespace" logs "$pod" -c "$_na_c" > /dev/null 2>&1 && \
+        $k8sCmd -n "$namespace" logs "$pod" -c "$_na_c" > "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/node-analyzer/$pod/${pod}_${_na_c}.log" && \
+        log_activity "Collected $_na_c log for $pod" || log_activity "$_na_c not on $pod"
+    done
+  elif [[ -n "$SYSDIG_KSPMC_PREFIX" ]] && [[ $pod =~ $SYSDIG_KSPMC_PREFIX ]]; then
+    mkdir -p "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/kspm-collector/$pod"
+    $k8sCmd -n "$namespace" logs "$pod" > "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/kspm-collector/$pod/$pod.log" 2>/dev/null
+    [[ $? -eq 0 ]] && log_activity "Collected kspmcollector log for $pod." || log_activity "ERROR: kspmcollector log failed for $pod."
+  elif [[ -n "$SYSDIG_AC_PREFIX" ]] && [[ $pod =~ $SYSDIG_AC_PREFIX ]]; then
+    mkdir -p "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/admission-controller/$pod"
+    local _ac_c _ac_collected=false
+    for _ac_c in "${SYSDIG_AC_CONTAINER_NAMES[@]}"; do
+      $k8sCmd -n "$namespace" logs "$pod" -c "$_ac_c" > /dev/null 2>&1 && \
+        $k8sCmd -n "$namespace" logs "$pod" -c "$_ac_c" > "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/admission-controller/$pod/${pod}_${_ac_c}.log" && \
+        { _ac_collected=true; log_activity "Collected $_ac_c log for $pod"; } || log_activity "$_ac_c not on $pod"
+    done
+    if [[ "$_ac_collected" == "false" ]]; then
+      $k8sCmd -n "$namespace" logs "$pod" --all-containers=true --prefix=true > "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/admission-controller/$pod/$pod.log" 2>/dev/null
+      [[ -s "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/admission-controller/$pod/$pod.log" ]] && log_activity "Collected admission-controller fallback log for $pod" || log_activity "ERROR: AC log failed for $pod."
+    fi
+  elif [[ -n "$SYSDIG_CSCAN_PREFIX" ]] && [[ $pod =~ $SYSDIG_CSCAN_PREFIX ]]; then
+    mkdir -p "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/cluster-scanner/$pod"
+    local _cscan_c _cscan_collected=false
+    for _cscan_c in "${SYSDIG_CSCAN_CONTAINER_NAMES[@]}"; do
+      $k8sCmd -n "$namespace" logs "$pod" -c "$_cscan_c" > /dev/null 2>&1 && \
+        $k8sCmd -n "$namespace" logs "$pod" -c "$_cscan_c" > "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/cluster-scanner/$pod/${pod}_${_cscan_c}.log" && \
+        { _cscan_collected=true; log_activity "Collected $_cscan_c log for $pod"; } || log_activity "$_cscan_c not on $pod"
+    done
+    if [[ "$_cscan_collected" == "false" ]]; then
+      $k8sCmd -n "$namespace" logs "$pod" --all-containers=true --prefix=true > "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/cluster-scanner/$pod/$pod.log" 2>/dev/null
+      [[ -s "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/cluster-scanner/$pod/$pod.log" ]] && log_activity "Collected cluster-scanner fallback log for $pod" || log_activity "ERROR: cluster-scanner log failed for $pod."
+    fi
+  elif [[ -n "$SYSDIG_RR_PREFIX" ]] && [[ $pod =~ $SYSDIG_RR_PREFIX ]]; then
+    mkdir -p "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/rapid-response/$pod"
+    $k8sCmd -n "$namespace" logs "$pod" > "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/rapid-response/$pod/$pod.log" 2>/dev/null
+    [[ -s "$DEST_DIR/$SYSDIG_SUPPORT_DIR/logs/rapid-response/$pod/$pod.log" ]] && log_activity "Collected rapid-response log for $pod." || log_activity "ERROR: rapid-response log failed for $pod."
+  fi
+  # Matches the per-pod completion marker emitted by the single-pod branch
+  # below, so options 1, 2, and 3 produce the same activity.log shape.
+  if (( _partial )); then
+    log_activity "Logs for pod $pod partially collected."
+    printf "${_C_WARN}Logs for pod %s partially collected (see activity.log for details).${_C_RESET}\n" "$pod"
+  else
+    log_activity "Logs for pod $pod collected successfully."
+    printf "${_C_OK}Logs for pod %s collected successfully.${_C_RESET}\n" "$pod"
+  fi
+}
+
+# Find the first agent pod (matching SYSDIG_AGENT_PREFIX) among the given pods
+# and hoist its one-shot, per-cluster artifacts — dragent.yaml and
+# csFeaturesStatus.json — into the current $DEST_DIR/$SYSDIG_SUPPORT_DIR. These
+# files are per-cluster, not per-pod, so collecting them once (here, before the
+# parallel workers) avoids a race on whichever agent ends up "first". No-op when
+# no agent pod is in the list. Pods passed as args.
+function _hoist_agent_oneshot_artifacts() {
+  local _first_agent="" _p
+  for _p in "$@"; do
+    if [[ -n "$SYSDIG_AGENT_PREFIX" && "$_p" =~ $SYSDIG_AGENT_PREFIX ]]; then
+      _first_agent="$_p"; break
+    fi
+  done
+  [[ -z "$_first_agent" ]] && return 0
+
+  local _cpDrAgentError
+  _cpDrAgentError=$($k8sCmd -n "$namespace" cp "$_first_agent:$AGENT_DRAGENT_DIR/dragent.yaml" "$DEST_DIR/$SYSDIG_SUPPORT_DIR/dragent.yaml" 2>&1)
+  if [[ $? -eq 0 || $? -eq 1 ]]; then
+    log_activity "Copied dragent.yaml from $_first_agent. ${_cpDrAgentError:-}"
+  else
+    log_activity "ERROR: Failed to copy dragent.yaml from $_first_agent. Reason: ${_cpDrAgentError:-unknown}"
+  fi
+  if [[ -n "$CS_POD_IP" ]]; then
+    $k8sCmd exec "$_first_agent" -n "$namespace" -- curl "http://${CS_POD_IP}:${SYSDIG_CS_MONITORING_PORT}/${SYSDIG_CS_ENDPOINT}" > "$DEST_DIR/$SYSDIG_SUPPORT_DIR/csFeaturesStatus.json" 2>/dev/null \
+      || log_activity "Unable to call CS health endpoint."
+  fi
+}
+
+# Dispatch parallel per-pod Phase-1 log collection (MAX_JOBS bounded) into the
+# current $DEST_DIR/$SYSDIG_SUPPORT_DIR, wait for completion, then drain worker
+# failure markers into FAILED_PODS via trackPodError. Pods passed as args; the
+# caller is expected to print its own "Dispatching ..." progress line first.
+function _dispatch_pod_log_collection() {
+  local _fail_dir="$DEST_DIR/$SYSDIG_SUPPORT_DIR/.failed_pods"
+  rm -rf "$_fail_dir"; mkdir -p "$_fail_dir"
+  # Scratch dir for captured stderr from each worker (.err files).
+  local _bg_dir="$DEST_DIR/$SYSDIG_SUPPORT_DIR/.bg"
+  mkdir -p "$_bg_dir"; rm -f "$_bg_dir"/logs-*.err
+
+  local _p
+  for _p in "$@"; do
+    run_bg_inline "logs-$_p" _phase1_collect_one_pod_logs "$_p" "$_fail_dir"
+    throttle
+  done
+  wait_all
+
+  # Surface any failed pods recorded by workers via marker files.
+  local _f
+  for _f in "$_fail_dir"/*; do
+    [[ -f "$_f" ]] && trackPodError "$(basename "$_f")"
+  done
+  rm -rf "$_fail_dir" "$_bg_dir"
+}
+
+function getLogs() {
+  log_activity "Starting log collection (namespace: '$namespace', pod: ${podName:-all pods})."
+  if [[ -z $podName ]]; then
+    printf "Collecting logs for all Sysdig pods, this may take a while...\n"
+
+    # Hoist one-shot per-cluster agent artifacts (dragent.yaml +
+    # csFeaturesStatus.json) before dispatching the parallel workers.
+    _hoist_agent_oneshot_artifacts $(awk '{print $1}' < "$DEST_DIR/$SYSDIG_SUPPORT_DIR/running_pods.txt")
+
+    printf "Dispatching log collection for %d pods (%d parallel collector workers)...\n" "$(awk 'END{print NR}' < "$DEST_DIR/$SYSDIG_SUPPORT_DIR/running_pods.txt")" "$MAX_JOBS"
+    _dispatch_pod_log_collection $(awk '{print $1}' < "$DEST_DIR/$SYSDIG_SUPPORT_DIR/running_pods.txt")
+
+    log_activity "Logs for all Sysdig pods collected successfully."
+  fi
+  log_activity "Log collection complete."
+}
+
+function collectArtifactsNamespaceOnly() {
+  log_activity "Starting namespace configuration collection (namespace: '${namespace}', pod: ${podName:-all pods})."
+  local _dst="$DEST_DIR/$SYSDIG_SUPPORT_DIR"
+  if [[ -z $podName ]]; then
+    printf "Collecting configuration for namespace %s...\n" "$namespace"
+    _kubectl_to_file_logged "$_dst/running_pods.txt"   "running_pods"  $k8sCmd get po --sort-by='.status.containerStatuses[0].restartCount' --no-headers -n "$namespace" -o wide
+    _collect_top_pods "$_dst/top_pods.txt"
+    _collect_pod_describes_by_component "$_dst"
+    _collect_sysdig_manifests "$_dst"
+    log_activity "Configuration for namespace $namespace collected successfully."
+    printf "${_C_OK}Configuration for namespace %s collected successfully.${_C_RESET}\n" "$namespace"
+  else
+    printf "Collecting configuration for pod %s...\n" "$podName"
+    _kubectl_to_file_logged "$_dst/running_pods.txt"              "running_pods"           $k8sCmd get po --sort-by='.status.containerStatuses[0].restartCount' --no-headers -n "$namespace" -o wide
+    _collect_top_pods "$_dst/top_pods.txt"
+    local _comp
+    _comp=$(_component_for_pod "$podName")
+    if [[ -n "$_comp" ]]; then
+      mkdir -p "$_dst/describe/$_comp"
+      _kubectl_to_file_logged "$_dst/describe/$_comp/$podName.txt" "describe pod $podName" $k8sCmd describe pod "$podName" -n "$namespace"
+    fi
+    _collect_sysdig_manifests "$_dst"
+    log_activity "Configuration for pod $podName collected successfully."
+    printf "${_C_OK}Configuration for pod %s collected successfully.${_C_RESET}\n" "$podName"
+  fi
+
+  printf "Collecting Helm release info...\n"
+  collectHelmInfo
+
+  _extract_cs_pod_ip
+  log_activity "Namespace configuration collection complete."
+}
+
+# ─────────────────────────────────────────────
+#  createArchive
+# ─────────────────────────────────────────────
+
+# Upload the named archive (relative to the current dir) to S3 when
+# UPLOAD_TO_S3=true. On HTTP 200, removes the local copy unless KEEP_LOCAL=true;
+# on failure, keeps it. No-op when UPLOAD_TO_S3 != true. Args: archive, work_dir.
+function _upload_archive_to_s3() {
+  local _archive="$1" _work_dir="$2"
+  [[ "$UPLOAD_TO_S3" == "true" ]] || return 0
+  printf "Uploading archive to S3, please wait...\n"
+  log_activity "Uploading $_archive to S3."
+  local _http
+  _http=$(curl -s -S -o /dev/null -w "%{http_code}" -X PUT --url "${SYSDIG_UPLOAD_URL}" \
+    -H "Content-Disposition: attachment; filename=${_archive}" -T "${_archive}")
+  if [[ $_http -eq 200 ]]; then
+    printf "${_C_OK}Archive uploaded successfully.${_C_RESET}\n"
+    log_activity "Archive uploaded successfully."
+    if [[ "$KEEP_LOCAL" == "true" ]]; then
+      log_activity "KEEP_LOCAL=true; retaining local archive copy."
+    else
+      rm -f "$_archive"
+    fi
+  else
+    printf "${_C_ERR}Upload failed (HTTP %s).${_C_RESET} Archive kept locally at: %s\n" "$_http" "$_work_dir/$_archive"
+    log_activity "S3 upload failed: HTTP $_http. Archive retained locally."
+  fi
+}
+
+# ── Secret redaction ──────────────────────────────────────────────────────
+# Sysdig components occasionally log credentials: customer access keys in API
+# request paths, datastore passwords in startup config dumps, and creds embedded
+# in connection URLs. These land verbatim in collected logs/configs, which then
+# ship to Support / upload to S3. _redact_file masks them in place just before
+# the archive is built. Patterns are deliberately scoped so real secret VALUES
+# are masked while the bundle stays readable: placeholders ([hidden], ****,
+# empty ""), ${ENV}/$(...) references, and diagnostic text (e.g. the path in
+# "/etc/pam.d/common-password: No such file") are left intact. The leading
+# [^-"…] boundary on the key keeps hyphenated filenames like 'common-password'
+# from being treated as a 'password' field.
+function _redact_file() {
+  local f="$1"
+  [[ -f "$f" && -w "$f" ]] || return 0
+  # Only rewrite text files; skip binaries (captures, images, archives).
+  grep -Iq . "$f" 2>/dev/null || return 0
+  local sedi
+  if [[ "$OSTYPE" == "darwin"* ]]; then sedi=(-i ''); else sedi=(-i); fi
+  sed -E "${sedi[@]}" \
+    -e 's#(/accessKey/)[0-9a-fA-F-]{8,}#\1<redacted>#g' \
+    -e 's#(Bearer )[A-Za-z0-9._~+/=-]{8,}#\1<redacted>#g' \
+    -e 's#(accessKey=)[^&" ]+#\1<redacted>#g' \
+    -e 's#("[A-Za-z0-9_]*[Pp]assword"[[:space:]]*:[[:space:]]*")[^"$[*][^"]*#\1<redacted>#g' \
+    -e 's#((^|[^-"A-Za-z0-9_])[A-Za-z0-9_]*[Pp]assword[[:space:]]*[:=][[:space:]]*)[^][:space:]"$<*{][^][:space:]",}]*#\1<redacted>#g' \
+    -e 's#(://[^/:@[:space:]]+:)[^@/[:space:]]+(@)#\1<redacted>\2#g' \
+    "$f" 2>/dev/null
+}
+
+# Redact every text file referenced by the tar target list (files redacted
+# directly, directories walked). Best-effort: never aborts the run. Call with
+# the same paths passed to tar, from inside the work dir.
+function _redact_targets() {
+  [[ $# -gt 0 ]] || return 0
+  printf "Redacting sensitive data from collected files...\n"
+  log_activity "Redacting sensitive data before archiving."
+  local t _f _n=0
+  for t in "$@"; do
+    if [[ -d "$t" ]]; then
+      while IFS= read -r -d '' _f; do
+        _redact_file "$_f"; _n=$(( _n + 1 ))
+      done < <(find "$t" -type f -print0 2>/dev/null)
+    elif [[ -f "$t" ]]; then
+      _redact_file "$t"; _n=$(( _n + 1 ))
+    fi
+  done
+  printf "Redaction complete (%s files scanned).\n" "$_n"
+  log_activity "Redaction complete ($_n files scanned)."
+}
+
+# Print the post-archive summary: an optional FAILED_PODS warning (whose manual
+# collection hint shows <ns_token> as the namespace), then the Saved/Archive/
+# Retained block plus the matching cleanup log line. Args: archive, work_dir,
+# ns_token.
+function _print_archive_summary() {
+  local _archive="$1" _work_dir="$2" _ns_token="$3"
+  if [[ ${#FAILED_PODS[@]} -gt 0 ]]; then
+    printf "\n${_C_WARN}--- WARNING: LOGS MAY NOT HAVE BEEN COLLECTED FOR SOME PODS ---${_C_RESET}\n"
+    printf "  Pod list:\n"
+    printf "    - %s\n" "${FAILED_PODS[@]}"
+    printf "  Collect manually: %s -n %s cp <pod>:opt/draios/logs/. <localPath>\n" "$k8sCmd" "$_ns_token"
+    printf -- "----------------------------------------------------------------\n"
+    FAILED_PODS=()
+  fi
+
+  printf "\nSaved to : %s\n" "$_work_dir"
+  printf "Archive  : %s\n" "$_archive"
+  printf "Retained : activity.log"
+  [[ -f "$_archive" ]] && printf " + %s" "$_archive"
+  printf "\n"
+  if [[ -f "$_archive" ]]; then
+    log_activity "Cleanup complete. Retained: $_archive and activity.log."
+  else
+    log_activity "Cleanup complete. Retained: activity.log (archive uploaded and removed)."
+  fi
+}
+
+function createArchive() {
+  local orig_dir
+  orig_dir=$(pwd)
+  local work_dir="$DEST_DIR/$SYSDIG_SUPPORT_DIR"
+
+  ARCHIVE_NAME="support-util-$(date '+%Y-%m-%d_%H%M%S').tar.gz"
+
+  cd "$work_dir" || { printf "${_C_ERR}Cannot access output directory.${_C_RESET}\n"; return 1; }
+
+  # Build explicit list of files generated by this script
+  local candidates=(
+    "cluster_info.json"
+    "running_pods.txt"
+    "top_pods.txt"
+    "cluster_object_counts.txt"
+    "helm.txt"
+    "dragent.yaml"
+    "csFeaturesStatus.json"
+  )
+
+  local files_to_archive=()
+  for f in "${candidates[@]}"; do
+    [[ -f "$f" ]] && files_to_archive+=("$f")
+  done
+
+  if [[ ${#files_to_archive[@]} -eq 0 && ! -d "logs" ]]; then
+    printf "No collected files found to archive.\n"
+    log_activity "Archive skipped: no files found."
+    cd "$orig_dir"
+    return 1
+  fi
+
+  # tar gets files + logs dir + activity.log; cleanup uses files_to_archive only
+  # (logs is removed separately with rm -rf to avoid "is a directory" errors)
+  local tar_targets=("${files_to_archive[@]}")
+  [[ -d "logs" ]] && tar_targets+=("logs")
+  local _d
+  for _d in configmap daemonset deployment describe nodes; do
+    [[ -d "$_d" ]] && tar_targets+=("$_d")
+  done
+  [[ -f "activity.log" ]] && tar_targets+=("activity.log")
+
+  _redact_targets "${tar_targets[@]}"
+
+  printf "Creating archive %s...\n" "$ARCHIVE_NAME"
+  log_activity "Creating archive: $ARCHIVE_NAME"
+
+  local errorMessage rc
+  errorMessage=$(tar czf "$ARCHIVE_NAME" "${tar_targets[@]}" 2>&1)
+  rc=$?
+  if [[ $rc -ge 2 ]]; then
+    printf "${_C_ERR}Error creating archive: %s${_C_RESET}\n" "$errorMessage"
+    log_activity "Archive creation failed: $errorMessage"
+    cd "$orig_dir"
+    return 1
+  fi
+  [[ $rc -eq 1 ]] && log_activity "Archive created with warnings: $errorMessage"
+
+  log_activity "Archive $ARCHIVE_NAME created successfully."
+  printf "${_C_OK}Archive created:${_C_RESET} %s\n" "$ARCHIVE_NAME"
+
+  # Remove all raw collected files — keep only archive and activity.log
+  rm -f "${files_to_archive[@]}"
+  rm -rf logs configmap daemonset deployment describe nodes .bg
+
+  _upload_archive_to_s3 "$ARCHIVE_NAME" "$work_dir"
+  _print_archive_summary "$ARCHIVE_NAME" "$work_dir" "$namespace"
+
+  cd "$orig_dir"
+}
+
+function createArchiveAll() {
+  local orig_dir
+  orig_dir=$(pwd)
+  local work_dir="$DEST_DIR/$SYSDIG_SUPPORT_DIR"
+  local archive_name="support-util-$(date '+%Y-%m-%d_%H%M%S').tar.gz"
+
+  cd "$work_dir" || { printf "${_C_ERR}Cannot access output directory.${_C_RESET}\n"; return 1; }
+
+  local ns_dirs=()
+  for d in */; do
+    [[ -d "$d" ]] && ns_dirs+=("$d")
+  done
+
+  if [[ ${#ns_dirs[@]} -eq 0 ]]; then
+    printf "No collected namespace directories found to archive.\n"
+    log_activity "Archive skipped: no namespace directories found."
+    cd "$orig_dir"
+    return 1
+  fi
+
+  # Include activity.log in the archive but keep it on disk after cleanup
+  local tar_targets=("${ns_dirs[@]}")
+  [[ -f "activity.log" ]] && tar_targets+=("activity.log")
+
+  _redact_targets "${tar_targets[@]}"
+
+  printf "Creating archive %s...\n" "$archive_name"
+  log_activity "Creating cross-namespace archive: $archive_name"
+
+  local errorMessage rc
+  errorMessage=$(tar czf "$archive_name" "${tar_targets[@]}" 2>&1)
+  rc=$?
+  if [[ $rc -ge 2 ]]; then
+    printf "${_C_ERR}Error creating archive: %s${_C_RESET}\n" "$errorMessage"
+    log_activity "Archive creation failed: $errorMessage"
+    cd "$orig_dir"
+    return 1
+  fi
+  [[ $rc -eq 1 ]] && log_activity "Archive created with warnings: $errorMessage"
+
+  log_activity "Archive $archive_name created successfully."
+  printf "${_C_OK}Archive created:${_C_RESET} %s\n" "$archive_name"
+
+  rm -rf "${ns_dirs[@]}"
+
+  _upload_archive_to_s3 "$archive_name" "$work_dir"
+  _print_archive_summary "$archive_name" "$work_dir" "<namespace>"
+
+  cd "$orig_dir"
+}
+
+# ─────────────────────────────────────────────
+#  Main Menu
+# ─────────────────────────────────────────────
+
+# Interactive directory picker. Pure bash, no external deps. Navigates the
+# local filesystem, supports inline mkdir, jump-to-absolute-path, and a
+# home shortcut. On success writes the chosen absolute path to PICKED_DIR.
+# Returns 0 on selection, 1 on back/cancel.
+function _pick_directory_interactive() {
+  local cwd="${1:-$(pwd)}"
+  cwd=$(cd "$cwd" 2>/dev/null && pwd) || cwd="$(pwd)"
+
+  PICKED_DIR=""
+  local input
+  # Persisted across redraws: each loop starts with `clear`, so a message
+  # printed right before read would be wiped before the user sees it. We stash
+  # it here and render it just above the prompt on the next redraw instead.
+  local _msg=""
+
+  while true; do
+    clear
+    local -a dirs=()
+    local entry
+    while IFS= read -r entry; do
+      [[ -z "$entry" ]] && continue
+      [[ -d "$cwd/$entry" ]] && dirs+=("$entry")
+    done < <(ls -1 "$cwd" 2>/dev/null | sort)
+
+    printf "\n  ── Choose a folder to save into ──\n"
+    printf "  Current folder: %s\n\n" "$cwd"
+    if [[ ${#dirs[@]} -eq 0 ]]; then
+      printf "    (no subfolders here)\n"
+    else
+      local i
+      for ((i = 0; i < ${#dirs[@]}; i++)); do
+        printf "    %3d) %s/\n" $((i + 1)) "${dirs[$i]}"
+      done
+    fi
+    printf "\n   ${_C_KEY}%-6s${_C_RESET}  %-18s  ${_C_KEY}%-6s${_C_RESET}  %s\n" "number" "open that folder" "s" "use this folder"
+    printf "   ${_C_KEY}%-6s${_C_RESET}  %-18s  ${_C_KEY}%-6s${_C_RESET}  %s\n" "u" "up one level" "m" "make a new folder"
+    printf "   ${_C_KEY}%-6s${_C_RESET}  %-18s  ${_C_KEY}%-6s${_C_RESET}  %s\n" "h" "go to home" "t" "type a full path"
+    printf "   ${_C_KEY}%-6s${_C_RESET}  %-18s  ${_C_KEY}%-6s${_C_RESET}  %s\n" "" "" "b" "cancel"
+    [[ -n "$_msg" ]] && printf "\n  %s\n" "$_msg"
+    _msg=""
+    printf "  > "
+    read -r input
+    input="${input#"${input%%[![:space:]]*}"}"
+    input="${input%"${input##*[![:space:]]}"}"
+
+    case "$input" in
+      b|B) return 1 ;;
+      u|U|"..") cwd=$(cd "$cwd/.." 2>/dev/null && pwd) ;;
+      h|H) cwd="$HOME" ;;
+      s|S)
+        if [[ -w "$cwd" ]]; then
+          PICKED_DIR="$cwd"
+          return 0
+        else
+          _msg="${_C_ERR}Can't save to this folder${_C_RESET} (permission denied). Try another, or 'm' to make one."
+        fi
+        ;;
+      m|M)
+        printf "  Name for the new folder (e.g. cases/2026/c-12345): "
+        local _new
+        read -r _new
+        # Strip surrounding whitespace and trim leading/trailing slashes so the
+        # path is appended cleanly to $cwd. Reject absolute paths and parent
+        # traversal — the picker's 't' (type a path) option is the right tool
+        # for jumping to an arbitrary location.
+        _new="${_new#"${_new%%[![:space:]]*}"}"
+        _new="${_new%"${_new##*[![:space:]]}"}"
+        _new="${_new#/}"
+        _new="${_new%/}"
+        if [[ -z "$_new" || "$_new" == "." || "$_new" == ".." || "$_new" == *..* ]]; then
+          _msg="${_C_WARN}Invalid folder name${_C_RESET} (no absolute paths, no '.' or '..')."
+          continue
+        fi
+        # mkdir -p creates the full nested path; idempotent if some segments exist.
+        if mkdir -p "$cwd/$_new" 2>/dev/null; then
+          cwd=$(cd "$cwd/$_new" && pwd)
+          _msg="${_C_OK}Created and opened:${_C_RESET} $cwd"
+        else
+          _msg="${_C_ERR}Couldn't create that folder${_C_RESET} (permission denied or invalid name)."
+        fi
+        ;;
+      t|T)
+        printf "  Type a folder path (absolute or starting with ~): "
+        local _typed
+        read -r _typed
+        [[ -z "$_typed" ]] && continue
+        _typed="${_typed/#\~/$HOME}"
+        if [[ -d "$_typed" ]]; then
+          cwd=$(cd "$_typed" && pwd)
+        else
+          _msg="${_C_WARN}Not a folder:${_C_RESET} $_typed"
+        fi
+        ;;
+      "") ;;
+      *)
+        if [[ "$input" =~ ^[0-9]+$ ]] && (( input >= 1 && input <= ${#dirs[@]} )); then
+          cwd=$(cd "$cwd/${dirs[$(( input - 1 ))]}" && pwd)
+        else
+          _msg="${_C_WARN}Didn't recognize that.${_C_RESET} Enter a number from the list, or a key shown below it."
+        fi
+        ;;
+    esac
+  done
+}
+
+# Interactive file picker — mirrors _pick_directory_interactive but lists files
+# alongside subdirectories and returns a path to a chosen file in PICKED_FILE.
+# Selecting a directory number navigates into it; selecting a file number
+# returns that file. The listing is filtered to the archive extensions that
+# upload_existing_file accepts (.tar.gz, .tgz, .tar.bz2, .tbz, .tbz2, .tar.xz,
+# .txz, .tar, .zip, .7z). Returns 0 on success, 1 on [b]ack.
+function _pick_file_interactive() {
+  local cwd="${1:-$(pwd)}"
+  cwd=$(cd "$cwd" 2>/dev/null && pwd) || cwd="$(pwd)"
+
+  PICKED_FILE=""
+  local input
+  # Persisted across redraws — see the note in _pick_directory_interactive.
+  local _msg=""
+
+  while true; do
+    clear
+    local -a dirs=() files=()
+    local entry
+    while IFS= read -r entry; do
+      [[ -z "$entry" ]] && continue
+      if [[ -d "$cwd/$entry" ]]; then
+        dirs+=("$entry")
+      elif [[ -f "$cwd/$entry" ]] && [[ "$(printf '%s' "$entry" | tr '[:upper:]' '[:lower:]')" =~ \.(tar\.gz|tgz|tar\.bz2|tbz2?|tar\.xz|txz|tar|zip|7z)$ ]]; then
+        files+=("$entry")
+      fi
+    done < <(ls -1 "$cwd" 2>/dev/null | sort)
+
+    printf "\n  ── Choose an archive to upload ──\n"
+    printf "  Current folder: %s\n\n" "$cwd"
+    if [[ ${#dirs[@]} -eq 0 && ${#files[@]} -eq 0 ]]; then
+      printf "    (no subfolders or supported archives here)\n"
+    else
+      local i
+      for ((i = 0; i < ${#dirs[@]}; i++)); do
+        printf "    %3d) %s/\n" $((i + 1)) "${dirs[$i]}"
+      done
+      for ((i = 0; i < ${#files[@]}; i++)); do
+        printf "    %3d) %s\n" $((i + 1 + ${#dirs[@]})) "${files[$i]}"
+      done
+    fi
+    printf "\n   ${_C_KEY}%-6s${_C_RESET}  %-18s  ${_C_KEY}%-6s${_C_RESET}  %s\n" "number" "open a folder" "number" "upload an archive"
+    printf "   ${_C_KEY}%-6s${_C_RESET}  %-18s  ${_C_KEY}%-6s${_C_RESET}  %s\n" "u" "up one level" "t" "type a path"
+    printf "   ${_C_KEY}%-6s${_C_RESET}  %-18s  ${_C_KEY}%-6s${_C_RESET}  %s\n" "h" "go to home" "b" "cancel"
+    printf "  (only folders and supported archives are shown)\n"
+    [[ -n "$_msg" ]] && printf "\n  %s\n" "$_msg"
+    _msg=""
+    printf "  > "
+    read -r input
+    input="${input#"${input%%[![:space:]]*}"}"
+    input="${input%"${input##*[![:space:]]}"}"
+
+    case "$input" in
+      b|B) return 1 ;;
+      u|U|"..") cwd=$(cd "$cwd/.." 2>/dev/null && pwd) ;;
+      h|H) cwd="$HOME" ;;
+      t|T)
+        printf "  Type a file or folder path (absolute or starting with ~): "
+        local _typed
+        read -r _typed
+        [[ -z "$_typed" ]] && continue
+        _typed="${_typed/#\~/$HOME}"
+        if [[ -d "$_typed" ]]; then
+          cwd=$(cd "$_typed" && pwd)
+        elif [[ -f "$_typed" ]]; then
+          PICKED_FILE="$_typed"
+          return 0
+        else
+          _msg="${_C_WARN}Not a file or folder:${_C_RESET} $_typed"
+        fi
+        ;;
+      "") ;;
+      *)
+        if [[ "$input" =~ ^[0-9]+$ ]]; then
+          local _total=$(( ${#dirs[@]} + ${#files[@]} ))
+          if (( input >= 1 && input <= ${#dirs[@]} )); then
+            cwd=$(cd "$cwd/${dirs[$(( input - 1 ))]}" && pwd)
+          elif (( input > ${#dirs[@]} && input <= _total )); then
+            PICKED_FILE="$cwd/${files[$(( input - 1 - ${#dirs[@]} ))]}"
+            return 0
+          else
+            _msg="${_C_WARN}That number isn't in the list.${_C_RESET} Pick one shown above."
+          fi
+        else
+          _msg="${_C_WARN}Didn't recognize that.${_C_RESET} Enter a number from the list, or a key shown below it."
+        fi
+        ;;
+    esac
+  done
+}
+
+function prompt_output_path() {
+  local default_path custom_path
+  default_path="$(pwd)/sysdig-support"
+  while true; do
+    printf "  Where should the support bundle be saved? Type a folder path, or:\n"
+    printf "    ${_C_KEY}Enter${_C_RESET} use default (%s) · ${_C_KEY}?${_C_RESET} browse folders · ${_C_KEY}0${_C_RESET} cancel\n" "$default_path"
+    printf "  > "
+    read -r custom_path
+    [[ "$custom_path" == "0" ]] && return 1
+    if [[ "$custom_path" == "?" ]]; then
+      # Back in picker → re-prompt at this output-path step, not bubble up.
+      if _pick_directory_interactive; then
+        PICKED_DIR="${PICKED_DIR%/}"
+        DEST_DIR="$(dirname "$PICKED_DIR")"
+        SYSDIG_SUPPORT_DIR="$(basename "$PICKED_DIR")"
+        break
+      fi
+    elif [[ -n "$custom_path" ]]; then
+      # Strip trailing slash, then split into dirname/basename so that the
+      # $DEST_DIR/$SYSDIG_SUPPORT_DIR concatenation used 76 places downstream
+      # always forms a clean path. With an empty SYSDIG_SUPPORT_DIR the
+      # pattern '${DEST_DIR}/${SYSDIG_SUPPORT_DIR}/...' yields 'A//...' which
+      # propagates into PLATFORM_LOG_DIR, log lines, and the Working Directory
+      # banner.
+      custom_path="${custom_path%/}"
+      DEST_DIR="$(dirname "$custom_path")"
+      SYSDIG_SUPPORT_DIR="$(basename "$custom_path")"
+      break
+    else
+      DEST_DIR="$(pwd)"
+      SYSDIG_SUPPORT_DIR="sysdig-support"
+      break
+    fi
+  done
+  mkdir -p "$DEST_DIR/$SYSDIG_SUPPORT_DIR"
+  local _new_log="$DEST_DIR/$SYSDIG_SUPPORT_DIR/activity.log"
+  # Preserve any pre-existing activity.log at this destination (e.g. from a
+  # prior CLI session) so we never silently overwrite history.
+  if [[ -f "$_new_log" ]]; then
+    mv "$_new_log" "${_new_log}.previous-$(date +%s)"
+  fi
+  # Build the new run's activity.log: fresh header, then replay the session
+  # bootstrap buffer + this run's pre-output-path buffer. Each bundle gets its
+  # own complete log (session setup + this run's events only) with no
+  # cross-contamination from other runs in the same session and no stripping
+  # of activity.log from prior bundle dirs.
+  echo "Sysdig Log Collector v$SLC_VERSION - $(date)" > "$_new_log"
+  local _line
+  for _line in "${SESSION_BOOTSTRAP_LINES[@]}"; do
+    echo "$_line" >> "$_new_log"
+  done
+  for _line in "${RUN_BUFFER_LINES[@]}"; do
+    echo "$_line" >> "$_new_log"
+  done
+  ACTIVITY_LOG="$_new_log"
+  LOG_PHASE="run-active"
+  printf "  Saving output to: %s\n" "$DEST_DIR/$SYSDIG_SUPPORT_DIR"
+  log_activity "Output path set to $DEST_DIR/$SYSDIG_SUPPORT_DIR"
+}
+
+# Interactive read-loop for a Sysdig presigned S3 URL. Reads from the terminal,
+# trims whitespace and a balanced surrounding quote pair, validates shape via
+# _validate_s3_url, and checks the expiry window. On success assigns the URL to
+# the variable named by $1 and returns 0; returns 1 if the user enters 0 (cancel).
+# The caller is responsible for printing any intro/instructions first.
+function _read_s3_url_loop() {
+  local _out_var="$1" _val=""
+  while true; do
+    printf "  S3 URL: "
+    read -r _val
+    [[ "$_val" == "0" ]] && return 1
+    _val="${_val//[[:space:]]/}"
+    # Trim a balanced pair of surrounding quotes that users sometimes copy
+    # along with the URL from the `--url='...'` CLI form.
+    if   [[ "$_val" =~ ^\'(.*)\'$ ]]; then _val="${BASH_REMATCH[1]}"
+    elif [[ "$_val" =~ ^\"(.*)\"$ ]]; then _val="${BASH_REMATCH[1]}"
+    fi
+    _validate_s3_url "$_val"
+    case $? in
+      0) if _check_s3_url_expiry "$_val" "URL" "  "; then
+           printf -v "$_out_var" '%s' "$_val"
+           return 0
+         else
+           printf "  Enter 0 to cancel if you need to request a fresh URL.\n"
+         fi
+         ;;
+      1) printf "  ${_C_WARN}URL cannot be empty.${_C_RESET}\n" ;;
+      2) printf "  ${_C_WARN}Invalid URL.${_C_RESET} It must start with https:// and end with id=PutObject.\n" ;;
+    esac
+  done
+}
+
+# Prompt for the Sysdig-provided S3 upload URL and validate its shape.
+# Sets SYSDIG_UPLOAD_URL on success. Returns 1 if user enters 0 (cancel).
+function _prompt_s3_url() {
+  SYSDIG_UPLOAD_URL=""
+  printf "  From the curl command provided by Sysdig Support,\n"
+  printf "  paste only the URL value (the part after --url, with or without surrounding quotes).\n"
+  printf "  The URL must:\n"
+  printf "    - Start with https://\n"
+  printf "    - End with id=PutObject\n"
+  printf "  (or enter 0 to return to main menu)\n"
+  _read_s3_url_loop SYSDIG_UPLOAD_URL || { SYSDIG_UPLOAD_URL=""; return 1; }
+  log_activity "S3 upload URL provided by user."
+  return 0
+}
+
+# Prompt the user to set the number of parallel collection workers used by
+# Phase 1 log collection (controls run_bg / throttle concurrency). Empty input
+# keeps the current value. Range is enforced — accepts only integers in
+# [MAX_JOBS_MIN, MAX_JOBS_MAX]; anything else re-prompts.
+function prompt_max_jobs() {
+  local _input _confirm
+  while true; do
+    printf "\n  Parallel collector workers [%d-%d, default %d]: " \
+      "$MAX_JOBS_MIN" "$MAX_JOBS_MAX" "$MAX_JOBS"
+    read -r _input
+    if [[ -z "$_input" ]]; then
+      log_activity "Parallel collection workers: $MAX_JOBS (default kept)."
+      return 0
+    fi
+    if ! [[ "$_input" =~ ^[0-9]+$ ]] || (( _input < MAX_JOBS_MIN )) || (( _input > MAX_JOBS_MAX )); then
+      printf "  ${_C_ERR}Invalid input.${_C_RESET} Please enter a number between %d and %d.\n" \
+        "$MAX_JOBS_MIN" "$MAX_JOBS_MAX"
+      continue
+    fi
+    # Above the safe baseline (MAX_JOBS_DEFAULT): surface the apiserver-stress
+    # warning and require explicit confirmation. At or below: accept silently.
+    if (( _input > MAX_JOBS_DEFAULT )); then
+      printf "\n  ${_C_WARN}Higher values on small or constrained clusters can overload the apiserver and lead to partial log collection.${_C_RESET}\n"
+      printf "  ${_C_WARN}Proceed with %d workers?${_C_RESET}\n" "$_input"
+      printf "    1) No  - choose a different value\n"
+      printf "    2) Yes - continue\n"
+      while true; do
+        printf "  Choice [1-2]: "
+        read -r _confirm
+        case "$_confirm" in
+          1) break 1 ;;       # leave inner loop → outer loop re-prompts for value
+          2) MAX_JOBS="$_input"
+             log_activity "Parallel collection workers set to $MAX_JOBS (user-confirmed above default of $MAX_JOBS_DEFAULT)."
+             return 0 ;;
+          *) printf "    ${_C_ERR}Please enter 1 or 2.${_C_RESET}\n" ;;
+        esac
+      done
+      continue
+    fi
+    MAX_JOBS="$_input"
+    log_activity "Parallel collection workers set to $MAX_JOBS (user-selected)."
+    return 0
+  done
+}
+
+function prompt_delivery() {
+  # Flags (positional, in any order):
+  #   allow_modify  → show "4) Modify selection", return 2 if chosen
+  #   allow_back    → show "b) Back",             return 3 if chosen
+  # Return codes:
+  #   0 = selection complete, 1 = return to main menu,
+  #   2 = modify, 3 = back one step
+  local allow_modify=false allow_back=false _arg
+  for _arg in "$@"; do
+    case "$_arg" in
+      allow_modify) allow_modify=true ;;
+      allow_back)   allow_back=true   ;;
+    esac
+  done
+
+  UPLOAD_TO_S3=false
+  KEEP_LOCAL=false
+  SYSDIG_UPLOAD_URL=""
+
+  printf "\n  ${_C_BOLD}How would you like to save the output?${_C_RESET}\n"
+  printf "    ${_C_KEY}[1]${_C_RESET} Save locally\n"
+  printf "    ${_C_KEY}[2]${_C_RESET} Upload to S3\n"
+  printf "    ${_C_KEY}[3]${_C_RESET} Both (save locally and upload to S3)\n"
+  [[ "$allow_modify" == "true" ]] && printf "    ${_C_KEY}[4]${_C_RESET} Modify selection\n"
+  [[ "$allow_back"   == "true" ]] && printf "    ${_C_KEY}[b]${_C_RESET} Back\n"
+  printf "    ${_C_KEY}[0]${_C_RESET} Return to main menu\n"
+  while true; do
+    printf "\n  >> Select: "
+    read -r delivery_choice
+    case "$delivery_choice" in
+      0) return 1 ;;
+      1)
+        UPLOAD_TO_S3=false
+        KEEP_LOCAL=true
+        prompt_output_path || return 1
+        break
+        ;;
+      2)
+        UPLOAD_TO_S3=true
+        KEEP_LOCAL=false
+        prompt_output_path || return 1
+        _prompt_s3_url     || return 1
+        break
+        ;;
+      3)
+        UPLOAD_TO_S3=true
+        KEEP_LOCAL=true
+        prompt_output_path || return 1
+        _prompt_s3_url     || return 1
+        break
+        ;;
+      4)
+        if [[ "$allow_modify" == "true" ]]; then
+          return 2
+        fi
+        printf "  Please select a valid option.\n"
+        ;;
+      b|B)
+        if [[ "$allow_back" == "true" ]]; then
+          return 3
+        fi
+        printf "  Please select a valid option.\n"
+        ;;
+      *) printf "  Please select a valid option.\n" ;;
+    esac
+  done
+}
+
+# Scalable pod selector with substring filter + pagination.
+# Args: pod names to display (one per arg). Populates global podNames on success.
+# Returns 0 on selection, 1 on cancel.
+function select_pods_paginated() {
+  podNames=()
+  _PICKED_ITEMS=()
+  if _select_items_paginated "pod" "Pods" "$@"; then
+    podNames=("${_PICKED_ITEMS[@]+"${_PICKED_ITEMS[@]}"}")
+    log_activity "User selected pods: ${podNames[*]}"
+    return 0
+  fi
+  return 1
+}
+
+# Component-based pod selector. Buckets pods by the Sysdig prefix vars built
+# by discoverComponents and lets the user pick one or more components.
+# Populates global podNames. Returns 0 on success, 1 on cancel / no components.
+function select_pods_by_component() {
+  podNames=()
+
+  local all_pods=()
+  local line
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && all_pods+=("$line")
+  done < <($k8sCmd get pods -n "$namespace" --no-headers 2>/dev/null | awk '{print $1}')
+
+  if [[ ${#all_pods[@]} -eq 0 ]]; then
+    printf "  No pods found in namespace '%s'.\n" "$namespace"
+    return 1
+  fi
+
+  local agent_pods=() shield_pods=() cs_pods=() na_pods=() kspmc_pods=() ac_pods=() cscan_pods=() rr_pods=()
+  local p
+  for p in "${all_pods[@]}"; do
+    case "$(_component_for_pod "$p")" in
+      agent)               agent_pods+=("$p") ;;
+      shield)              shield_pods+=("$p") ;;
+      cluster-shield)       cs_pods+=("$p") ;;
+      node-analyzer)        na_pods+=("$p") ;;
+      kspm-collector)       kspmc_pods+=("$p") ;;
+      admission-controller) ac_pods+=("$p") ;;
+      cluster-scanner)      cscan_pods+=("$p") ;;
+      rapid-response)       rr_pods+=("$p") ;;
+    esac
+  done
+
+  # Parallel arrays: label + space-joined pod list (pod names are DNS-1123, no spaces)
+  local comp_labels=()
+  local comp_pod_strings=()
+  [[ ${#agent_pods[@]}  -gt 0 ]] && comp_labels+=("agent")                && comp_pod_strings+=("${agent_pods[*]}")
+  [[ ${#shield_pods[@]} -gt 0 ]] && comp_labels+=("shield")               && comp_pod_strings+=("${shield_pods[*]}")
+  [[ ${#cs_pods[@]}     -gt 0 ]] && comp_labels+=("cluster-shield")       && comp_pod_strings+=("${cs_pods[*]}")
+  [[ ${#na_pods[@]}     -gt 0 ]] && comp_labels+=("node-analyzer")        && comp_pod_strings+=("${na_pods[*]}")
+  [[ ${#kspmc_pods[@]}  -gt 0 ]] && comp_labels+=("kspm-collector")       && comp_pod_strings+=("${kspmc_pods[*]}")
+  [[ ${#ac_pods[@]}     -gt 0 ]] && comp_labels+=("admission-controller") && comp_pod_strings+=("${ac_pods[*]}")
+  [[ ${#cscan_pods[@]}  -gt 0 ]] && comp_labels+=("cluster-scanner")      && comp_pod_strings+=("${cscan_pods[*]}")
+  [[ ${#rr_pods[@]}     -gt 0 ]] && comp_labels+=("rapid-response")       && comp_pod_strings+=("${rr_pods[*]}")
+
+  if [[ ${#comp_labels[@]} -eq 0 ]]; then
+    printf "\n  ${_C_WARN}No Sysdig components detected in namespace '%s'.${_C_RESET}\n" "$namespace"
+    printf "  This usually means the namespace has no Sysdig workloads, or\n"
+    printf "  they were deployed without Helm labels (airgapped/manual install).\n"
+    return 1
+  fi
+
+  printf "\n  Components in namespace '%s':\n" "$namespace"
+  local i
+  for i in "${!comp_labels[@]}"; do
+    local pod_arr=()
+    read -ra pod_arr <<< "${comp_pod_strings[$i]}"
+    local n=${#pod_arr[@]}
+    local suffix="s"
+    [[ $n -eq 1 ]] && suffix=""
+    printf "    %3d) %-22s (%d pod%s)\n" $(( i + 1 )) "${comp_labels[$i]}" "$n" "$suffix"
+  done
+  printf "\n  Select components by number (space-separated, e.g. '1 3 5'), or use:\n\n"
+  _print_cmd_columns "── Options ──" $'a|all components\nb|back (prev. menu)'
+
+  while true; do
+    printf "\n  >> Enter selection or command: "
+    read -r selection
+    selection="${selection#"${selection%%[![:space:]]*}"}"
+    selection="${selection%"${selection##*[![:space:]]}"}"
+
+    # b = back one step (to the pod-selection menu). Matches the pod picker,
+    # which has no jump-to-main-menu shortcut.
+    [[ "$selection" == "b" || "$selection" == "B" ]] && return 1
+
+    if [[ "$selection" == "a" || "$selection" == "A" ]]; then
+      podNames=()
+      for i in "${!comp_pod_strings[@]}"; do
+        local pods_arr=()
+        read -ra pods_arr <<< "${comp_pod_strings[$i]}"
+        podNames+=("${pods_arr[@]}")
+      done
+      log_activity "User selected all components: ${comp_labels[*]} (${#podNames[@]} pods)"
+      return 0
+    fi
+
+    local valid=true
+    local seen=" "
+    local selections=()
+    local picked_labels=()
+    podNames=()
+    read -ra selections <<< "$selection"
+
+    if [[ ${#selections[@]} -eq 0 ]]; then
+      printf "  ${_C_WARN}Please enter at least one number,${_C_RESET} or 'a' or 'b'.\n"
+      continue
+    fi
+
+    local sel
+    for sel in "${selections[@]}"; do
+      if [[ ! "$sel" =~ ^[0-9]+$ ]] || (( sel < 1 || sel > ${#comp_labels[@]} )); then
+        printf "  ${_C_WARN}'%s' isn't a valid choice.${_C_RESET} Enter numbers 1-%d, or a command key listed above.\n" "$sel" "${#comp_labels[@]}"
+        valid=false
+        break
+      fi
+      if [[ "$seen" != *" $sel "* ]]; then
+        seen+="$sel "
+        local idx=$(( sel - 1 ))
+        picked_labels+=("${comp_labels[$idx]}")
+        local pods_arr=()
+        read -ra pods_arr <<< "${comp_pod_strings[$idx]}"
+        podNames+=("${pods_arr[@]}")
+      fi
+    done
+
+    if [[ "$valid" == "true" && ${#podNames[@]} -gt 0 ]]; then
+      log_activity "User selected components: ${picked_labels[*]} (${#podNames[@]} pods)"
+      return 0
+    fi
+
+    podNames=()
+  done
+}
+
+# Top-level pod selector: prompts user to pick by component or by specific pod,
+# then routes to the appropriate selector. Populates global podNames on success.
+# Returns 0 on selection, 1 on cancel.
+function select_pod_dispatcher() {
+  while true; do
+    printf "\n  ${_C_BOLD}How would you like to select pods?${_C_RESET}\n"
+    printf "    ${_C_KEY}[1]${_C_RESET} By component   ${_C_DIM}(recommended for large clusters)${_C_RESET}\n"
+    printf "    ${_C_KEY}[2]${_C_RESET} By specific pod(s)\n"
+    printf "    ${_C_KEY}[0]${_C_RESET} Return to main menu\n"
+    printf "\n  >> Select [0-2]: "
+    read -r choice
+    case "$choice" in
+      0) return 1 ;;
+      1)
+        select_pods_by_component && return 0
+        ;;
+      2)
+        local all_pods=() _line
+        while IFS= read -r _line; do
+          [[ -z "$_line" ]] && continue
+          [[ -n "$(_component_for_pod "$_line")" ]] && all_pods+=("$_line")
+        done < <($k8sCmd get pods -n "$namespace" --no-headers 2>/dev/null | awk '{print $1}')
+        if [[ ${#all_pods[@]} -eq 0 ]]; then
+          printf "  ${_C_WARN}No Sysdig component pods found in namespace '%s'.${_C_RESET}\n" "$namespace"
+          continue
+        fi
+        select_pods_paginated "${all_pods[@]}" && return 0
+        ;;
+      *) printf "  ${_C_WARN}Please select 0, 1, or 2.${_C_RESET}\n" ;;
+    esac
+  done
+}
+
+# Print a component-bucketed summary of pod counts.
+# Args: pod names. Uses discovery prefix vars to classify.
+function display_component_summary() {
+  local pods=("$@")
+  local agent=0 shield=0 cs=0 na=0 kspmc=0 ac=0 cscan=0 rr=0 other=0
+  local p
+  for p in "${pods[@]}"; do
+    case "$(_component_for_pod "$p")" in
+      agent)               (( agent++ )) ;;
+      shield)              (( shield++ )) ;;
+      cluster-shield)       (( cs++ )) ;;
+      node-analyzer)        (( na++ )) ;;
+      kspm-collector)       (( kspmc++ )) ;;
+      admission-controller) (( ac++ )) ;;
+      cluster-scanner)      (( cscan++ )) ;;
+      rapid-response)       (( rr++ )) ;;
+      *)                   (( other++ )) ;;
+    esac
+  done
+
+  printf "\n  Components in namespace '%s':\n" "$namespace"
+  local _suf
+  if [[ $agent  -gt 0 ]]; then _suf="s"; [[ $agent  -eq 1 ]] && _suf=""; printf "    - %-22s %d pod%s\n" "agent" "$agent" "$_suf"; fi
+  if [[ $shield -gt 0 ]]; then _suf="s"; [[ $shield -eq 1 ]] && _suf=""; printf "    - %-22s %d pod%s\n" "shield" "$shield" "$_suf"; fi
+  if [[ $cs     -gt 0 ]]; then _suf="s"; [[ $cs     -eq 1 ]] && _suf=""; printf "    - %-22s %d pod%s\n" "cluster-shield" "$cs" "$_suf"; fi
+  if [[ $na     -gt 0 ]]; then _suf="s"; [[ $na     -eq 1 ]] && _suf=""; printf "    - %-22s %d pod%s\n" "node-analyzer" "$na" "$_suf"; fi
+  if [[ $kspmc  -gt 0 ]]; then _suf="s"; [[ $kspmc  -eq 1 ]] && _suf=""; printf "    - %-22s %d pod%s\n" "kspm-collector" "$kspmc" "$_suf"; fi
+  if [[ $ac     -gt 0 ]]; then _suf="s"; [[ $ac     -eq 1 ]] && _suf=""; printf "    - %-22s %d pod%s\n" "admission-controller" "$ac" "$_suf"; fi
+  if [[ $cscan  -gt 0 ]]; then _suf="s"; [[ $cscan  -eq 1 ]] && _suf=""; printf "    - %-22s %d pod%s\n" "cluster-scanner" "$cscan" "$_suf"; fi
+  if [[ $rr     -gt 0 ]]; then _suf="s"; [[ $rr     -eq 1 ]] && _suf=""; printf "    - %-22s %d pod%s\n" "rapid-response" "$rr" "$_suf"; fi
+  printf "    ---------------------------------\n"
+  printf "    Total Sysdig pods: %d\n" "$(( agent + shield + cs + na + kspmc + ac + cscan + rr ))"
+  [[ $other -gt 0 ]] && printf "    (Non-Sysdig pods in namespace: %d — not collected)\n" "$other"
+}
+
+# Read-only paginated browser. Same UI as select_pods_paginated but no selection.
+# Args: pod names. Returns when the user presses 0 or empty input.
+function browse_pods_paginated() {
+  local source_pods=("$@")
+  local filter=""
+  local filtered=()
+  local page=0
+  local page_size=20
+  # Persisted across redraws — see the note in _select_items_paginated.
+  local _msg=""
+
+  if [[ ${#source_pods[@]} -eq 0 ]]; then
+    printf "  No pods to display.\n"
+    return
+  fi
+
+  while true; do
+    clear
+    filtered=()
+    local p
+    for p in "${source_pods[@]}"; do
+      if [[ -z "$filter" || "$p" == *"$filter"* ]]; then
+        filtered+=("$p")
+      fi
+    done
+
+    local total=${#filtered[@]}
+    local pages=1
+    [[ $total -gt 0 ]] && pages=$(( (total + page_size - 1) / page_size ))
+    [[ $page -ge $pages ]] && page=0
+
+    local start=$(( page * page_size ))
+    local end=$(( start + page_size ))
+    [[ $end -gt $total ]] && end=$total
+
+    printf "\n  Pods — %d total" "$total"
+    [[ -n "$filter" ]] && printf " · filter: '%s'" "$filter"
+    [[ $pages -gt 1 ]] && printf " · page %d/%d" $((page + 1)) "$pages"
+    printf "\n"
+
+    if [[ $total -eq 0 ]]; then
+      printf "    (no pods match filter)\n"
+    else
+      local i
+      for ((i = start; i < end; i++)); do
+        printf "    - %s\n" "${filtered[$i]}"
+      done
+    fi
+
+    printf "\n"
+    # Two columns when paged (Navigation + Other); a single "Options" column
+    # when everything fits on one page (no navigation keys to show).
+    local _nav _oth _oth_hdr
+    _nav=""
+    _oth=$'f|filter\nc|clear filter\nb|back (prev. menu)'
+    if [[ $pages -gt 1 ]]; then
+      _nav=$'n|next page\np|previous page\ng|go to page'
+      _oth_hdr="── Other ──"
+    else
+      _oth_hdr="── Options ──"
+    fi
+    _print_cmd_columns "── Navigation ──" "$_nav" "$_oth_hdr" "$_oth"
+    [[ -n "$_msg" ]] && printf "\n  %s\n" "$_msg"
+    _msg=""
+    printf "\n  >> Enter command: "
+    local input
+    read -r input
+
+    case "$input" in
+      b|B|"") return ;;
+      n|N) if [[ $pages -gt 1 ]]; then page=$(( (page + 1) % pages )); else _msg="Already on the only page."; fi ;;
+      p|P) if [[ $pages -gt 1 ]]; then page=$(( (page - 1 + pages) % pages )); else _msg="Already on the only page."; fi ;;
+      g|G)
+        if [[ $pages -gt 1 ]]; then
+          printf "  Go to page [1-%d]: " "$pages"
+          local np
+          read -r np
+          if [[ "$np" =~ ^[0-9]+$ ]] && (( np >= 1 && np <= pages )); then
+            page=$(( np - 1 ))
+          else
+            _msg="${_C_WARN}Invalid page number.${_C_RESET}"
+          fi
+        else
+          _msg="Already on the only page."
+        fi
+        ;;
+      f|F)
+        printf "  Filter (substring, empty to clear): "
+        read -r filter
+        page=0
+        ;;
+      c|C) filter=""; page=0 ;;
+      *) _msg="${_C_WARN}Unknown command.${_C_RESET} Enter one of the command keys listed above." ;;
+    esac
+  done
+}
+
+# ───── Upload helpers (shared by interactive `upload_existing_file` and CLI `cli_upload`) ─────
+
+# Validate that $1 is a usable archive path. Pure check; no prompts, no printing.
+# Returns:
+#   0 — path is a regular file with a supported extension
+#   1 — path is empty
+#   2 — path doesn't exist (or isn't a regular file)
+#   3 — extension not in the accepted set
+function _validate_archive_path() {
+  local _path="$1"
+  [[ -z "$_path" ]] && return 1
+  [[ ! -f "$_path" ]] && return 2
+  if [[ ! "$(printf '%s' "$_path" | tr '[:upper:]' '[:lower:]')" =~ \.(tar\.gz|tgz|tar\.bz2|tbz2?|tar\.xz|txz|tar|zip|7z)$ ]]; then
+    return 3
+  fi
+  return 0
+}
+
+# Validate $1 as a Sysdig-issued presigned S3 PUT URL. Pure check.
+# Returns:
+#   0 — URL matches the expected presigned PutObject shape
+#   1 — URL is empty
+#   2 — URL is malformed
+function _validate_s3_url() {
+  local _url="$1"
+  [[ -z "$_url" ]] && return 1
+  if [[ ! "$_url" =~ ^https://[^[:space:]]+\.amazonaws\.com/.+X-Amz-Signature=[a-f0-9]+.+x-id=PutObject$ ]]; then
+    return 2
+  fi
+  return 0
+}
+
+# Compute the epoch second at which an S3 presigned URL expires by parsing the
+# X-Amz-Date (basic ISO 8601: YYYYMMDDTHHMMSSZ) and X-Amz-Expires (seconds) query
+# params. Echoes the epoch on success and returns 0; returns 1 if either field is
+# missing or can't be parsed by the local `date` (BSD/macOS or GNU/Linux).
+function _s3_url_expiry_epoch() {
+  local _url="$1"
+  local _date_raw _expires_raw
+  _date_raw=$(printf '%s' "$_url"    | grep -oE 'X-Amz-Date=[0-9]{8}T[0-9]{6}Z' | head -1 | sed 's/X-Amz-Date=//')
+  _expires_raw=$(printf '%s' "$_url" | grep -oE 'X-Amz-Expires=[0-9]+'          | head -1 | sed 's/X-Amz-Expires=//')
+  [[ -z "$_date_raw" || -z "$_expires_raw" ]] && return 1
+
+  # YYYYMMDDTHHMMSSZ → YYYY-MM-DDTHH:MM:SSZ (the extended form GNU date accepts).
+  local _iso="${_date_raw:0:4}-${_date_raw:4:2}-${_date_raw:6:2}T${_date_raw:9:2}:${_date_raw:11:2}:${_date_raw:13:2}Z"
+  local _signed_epoch
+  _signed_epoch=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$_iso" +%s 2>/dev/null) || \
+    _signed_epoch=$(date -u -d "$_iso" +%s 2>/dev/null)
+  [[ -z "$_signed_epoch" ]] && return 1
+
+  printf '%d' "$((_signed_epoch + _expires_raw))"
+}
+
+# Human-friendly duration (always positive).
+function _format_duration() {
+  local _secs=$1
+  (( _secs < 0 )) && _secs=$((-_secs))
+  if   (( _secs < 60    )); then printf '%ds' "$_secs"
+  elif (( _secs < 3600  )); then printf '%dm %ds' $((_secs/60)) $((_secs%60))
+  elif (( _secs < 86400 )); then printf '%dh %dm' $((_secs/3600)) $(((_secs%3600)/60))
+  else                           printf '%dd %dh' $((_secs/86400)) $(((_secs%86400)/3600))
+  fi
+}
+
+# Format an epoch second as "YYYY-MM-DD HH:MM:SS UTC". Portable across BSD/GNU date.
+function _format_utc_from_epoch() {
+  local _epoch=$1
+  date -u -r "$_epoch" +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null || \
+    date -u -d "@$_epoch" +"%Y-%m-%d %H:%M:%S UTC" 2>/dev/null
+}
+
+# Verify a presigned URL's X-Amz-Date + X-Amz-Expires window hasn't passed.
+# Prints "Error: presigned <label> expired N ago (at T). Request a fresh URL."
+# to stderr and returns 1 if expired. Returns 0 if not expired, or if the
+# expiry fields are missing/unparseable (silent skip).
+# When verbose=1, additionally prints an OK line on success — used by
+# `upload --dry-run` to surface remaining URL lifetime up-front.
+#
+# Args: <url> [label="URL"] [indent=""] [verbose=0]
+function _check_s3_url_expiry() {
+  local _url="$1" _label="${2:-URL}" _indent="${3:-}" _verbose="${4:-0}"
+  local _exp _now _diff
+  _exp=$(_s3_url_expiry_epoch "$_url") || return 0
+  _now=$(date -u +%s)
+  _diff=$((_exp - _now))
+  if (( _diff <= 0 )); then
+    printf "%s${_C_ERR}Error: presigned %s expired %s ago (at %s). Request a fresh URL.${_C_RESET}\n" \
+      "$_indent" "$_label" "$(_format_duration "$_diff")" "$(_format_utc_from_epoch "$_exp")" >&2
+    return 1
+  fi
+  (( _verbose )) && printf "${_C_OK}OK:${_C_RESET} URL not expired (valid for %s, until %s).\n" \
+    "$(_format_duration "$_diff")" "$(_format_utc_from_epoch "$_exp")"
+  return 0
+}
+
+# CLI fallback used when -u / --url / --url= / -u= are provided without a
+# value. On a TTY, prompts the user for the URL (same validate + quote-strip
+# + expiry-check chain as the interactive prompts). On a non-TTY (CI, piped
+# stdin, cron), prints the legacy strict error and returns 1 so scripts still
+# fail loudly. On success, writes the validated URL into the global variable
+# whose name is passed as $1.
+#
+# Args: <output_var_name> [label="--url"]
+function _prompt_s3_url_cli() {
+  local _out_var="$1" _label="${2:---url}"
+  if [[ ! -t 0 ]]; then
+    printf "${_C_ERR}Error: %s requires a value.${_C_RESET}\n" "$_label" >&2
+    return 1
+  fi
+  printf "\n  %s was provided without a value.\n" "$_label"
+  printf "  Paste the Sysdig presigned S3 URL (or enter 0 to cancel).\n"
+  _read_s3_url_loop "$_out_var"
+}
+
+# Execute the actual S3 PUT. Args: file_path upload_url.
+# Prints colored success/fail to stdout; appends activity.log lines.
+# Returns 0 on HTTP 200, 1 otherwise.
+function _perform_upload() {
+  local _file="$1" _url="$2"
+  local _filename
+  _filename=$(basename "$_file")
+  printf "\nUploading %s, please wait...\n" "$_filename"
+  log_activity "Uploading $_file to S3."
+  local _http
+  _http=$(curl -s -S -o /dev/null -w "%{http_code}" -X PUT --url "$_url" \
+    -H "Content-Disposition: attachment; filename=${_filename}" -T "$_file")
+  if [[ $_http -eq 200 ]]; then
+    printf "${_C_OK}Archive uploaded successfully.${_C_RESET}\n"
+    log_activity "File $_filename uploaded successfully."
+    return 0
+  fi
+  printf "${_C_ERR}Upload failed (HTTP %s).${_C_RESET}\n" "$_http"
+  log_activity "S3 upload failed: HTTP $_http."
+  return 1
+}
+
+function upload_existing_file() {
+  local file_path=""
+  printf "\n  Which archive do you want to upload? (produced by this script)\n"
+  printf "  Accepted formats: .tar.gz, .tgz, .tar.bz2, .tbz, .tbz2, .tar.xz, .txz,\n"
+  printf "  .tar, .zip, .7z.\n"
+  while true; do
+    printf "  Type the archive's path, or: ${_C_KEY}?${_C_RESET} browse files · ${_C_KEY}0${_C_RESET} back to main menu\n"
+    printf "  > "
+    read -r file_path
+    [[ "$file_path" == "0" ]] && return 1
+    if [[ "$file_path" == "?" ]]; then
+      if _pick_file_interactive; then
+        file_path="$PICKED_FILE"
+      else
+        continue
+      fi
+    else
+      file_path="${file_path//[[:space:]]/}"
+    fi
+    _validate_archive_path "$file_path"
+    case $? in
+      0) break ;;
+      1) printf "  ${_C_WARN}Path cannot be empty.${_C_RESET}\n" ;;
+      2) printf "  ${_C_ERR}File not found:${_C_RESET} %s\n" "$file_path" ;;
+      3) printf "  ${_C_WARN}Unsupported file type.${_C_RESET} Accepted: .tar.gz, .tgz, .tar.bz2, .tbz,\n"
+         printf "  .tbz2, .tar.xz, .txz, .tar, .zip, .7z.\n" ;;
+    esac
+  done
+
+  local upload_url=""
+  printf "\n  From the curl command provided by Sysdig Support,\n"
+  printf "  paste only the URL value (the part after --url, with or without surrounding quotes).\n"
+  printf "  The URL must:\n"
+  printf "    - Start with https://\n"
+  printf "    - End with id=PutObject\n"
+  printf "  (or enter 0 to return to main menu)\n"
+  _read_s3_url_loop upload_url || return 1
+
+  _perform_upload "$file_path" "$upload_url"
+}
+
+function collect_cross_namespace() {
+  prepare_namespace_context || return 1
+  local original_ns="$namespace"
+  local sel_namespaces=() sel_pods=() primary_ns="$namespace"
+  local run_phase0=true modify_mode=false
+
+  while true; do
+
+    if [[ "$run_phase0" == "true" ]]; then
+      sel_namespaces=()
+      sel_pods=()
+      namespace="$original_ns"
+      primary_ns="$original_ns"
+
+      # Phase 0: pod selection for primary namespace (NS A)
+      podNames=()
+      namespace="$primary_ns"
+      printf "\n  Primary namespace: \033[1;37m%s\033[0m\n" "$primary_ns"
+      select_pod_dispatcher || return 1
+
+      for pod in "${podNames[@]}"; do
+        sel_namespaces+=("$primary_ns")
+        sel_pods+=("$pod")
+      done
+      podNames=()
+
+      run_phase0=false
+    fi
+
+    # Phase 1: additional namespaces
+    local selected_ns=" $primary_ns "
+    local add_more
+    if [[ "$modify_mode" == "true" ]]; then
+      # Strip all non-primary namespace pods and jump straight into the list
+      local keep_ns=() keep_pods=()
+      for idx in "${!sel_pods[@]}"; do
+        if [[ "${sel_namespaces[$idx]}" == "$primary_ns" ]]; then
+          keep_ns+=("${sel_namespaces[$idx]}")
+          keep_pods+=("${sel_pods[$idx]}")
+        fi
+      done
+      sel_namespaces=("${keep_ns[@]}")
+      sel_pods=("${keep_pods[@]}")
+      modify_mode=false
+      add_more="y"
+    else
+      # Rebuild selected_ns from current state
+      for ns in "${sel_namespaces[@]}"; do
+        [[ "$selected_ns" != *" $ns "* ]] && selected_ns+="$ns "
+      done
+      add_more="n"
+      prompt_yn $'\n  Add another namespace?' && add_more="y"
+    fi
+
+    while [[ "$add_more" == "y" || "$add_more" == "Y" ]]; do
+      local ns_list=()
+      printf "\n  Fetching available namespaces...\n"
+      while IFS= read -r line; do
+        [[ -n "$line" ]] && ns_list+=("$line")
+      done < <($k8sCmd get namespaces --no-headers 2>/dev/null | awk '{print $1}')
+
+      if [[ ${#ns_list[@]} -eq 0 ]]; then
+        printf "  No namespaces found.\n"
+        break
+      fi
+
+      printf "\n  ${_C_BOLD}Available namespaces:${_C_RESET}\n"
+      local i
+      for i in "${!ns_list[@]}"; do
+        local ns_entry="${ns_list[$i]}"
+        local pod_count=0
+        for idx in "${!sel_pods[@]}"; do
+          [[ "${sel_namespaces[$idx]}" == "$ns_entry" ]] && (( pod_count++ ))
+        done
+        if (( pod_count > 0 )); then
+          printf "    ${_C_KEY}[%d]${_C_RESET} %s ${_C_OK}(%d pod(s) selected)${_C_RESET}\n" $(( i + 1 )) "$ns_entry" "$pod_count"
+        else
+          printf "    ${_C_KEY}[%d]${_C_RESET} %s\n" $(( i + 1 )) "$ns_entry"
+        fi
+      done
+      printf "    ${_C_KEY}[0]${_C_RESET} Done\n"
+
+      local ns_sel chosen_ns pods_updated=false
+      while true; do
+        printf "\n  >> Select namespace [0-%d]: " "${#ns_list[@]}"
+        read -r ns_sel
+        if [[ "$ns_sel" == "0" ]]; then
+          break 2
+        elif [[ "$ns_sel" =~ ^[0-9]+$ ]] && (( ns_sel >= 1 && ns_sel <= ${#ns_list[@]} )); then
+          chosen_ns="${ns_list[$(( ns_sel - 1 ))]}"
+          if [[ "$selected_ns" == *" $chosen_ns "* ]]; then
+            printf "  Namespace '%s' already selected. Current pods:\n" "$chosen_ns"
+            for idx in "${!sel_pods[@]}"; do
+              [[ "${sel_namespaces[$idx]}" == "$chosen_ns" ]] && printf "    - %s\n" "${sel_pods[$idx]}"
+            done
+            if prompt_yn "  Update pod selection for '$chosen_ns'?"; then
+              namespace="$chosen_ns"
+              resetDiscoveryVars
+              discoverComponents
+              if ! has_sysdig_components; then
+                printf "\n  ${_C_WARN}Nothing to collect in namespace '%s'. Skipping.${_C_RESET}\n" "$namespace"
+                log_activity "Rejected namespace '$namespace' on update: no Sysdig components."
+                pods_updated=true
+                break
+              fi
+              if select_pod_dispatcher; then
+                local new_ns=() new_pods=()
+                for idx in "${!sel_pods[@]}"; do
+                  if [[ "${sel_namespaces[$idx]}" != "$chosen_ns" ]]; then
+                    new_ns+=("${sel_namespaces[$idx]}")
+                    new_pods+=("${sel_pods[$idx]}")
+                  fi
+                done
+                sel_namespaces=("${new_ns[@]}")
+                sel_pods=("${new_pods[@]}")
+                for pod in "${podNames[@]}"; do
+                  sel_namespaces+=("$chosen_ns")
+                  sel_pods+=("$pod")
+                done
+                podNames=()
+              fi
+              pods_updated=true
+              break
+            fi
+          else
+            # New namespace candidate — verify Sysdig is present before committing
+            namespace="$chosen_ns"
+            resetDiscoveryVars
+            discoverComponents
+            if ! has_sysdig_components; then
+              printf "\n  ${_C_WARN}Nothing to collect in namespace '%s'. Skipping.${_C_RESET}\n" "$namespace"
+              log_activity "Rejected namespace '$namespace': no Sysdig components."
+              continue
+            fi
+            selected_ns+="$chosen_ns "
+            log_activity "Selected namespace: $namespace"
+            break
+          fi
+        else
+          printf "  Please enter a number between 0 and %d.\n" "${#ns_list[@]}"
+        fi
+      done
+
+      if [[ "$pods_updated" == "false" ]]; then
+        # Discovery already done in the new-namespace branch above (guard enforced).
+        if select_pod_dispatcher; then
+          for pod in "${podNames[@]}"; do
+            sel_namespaces+=("$namespace")
+            sel_pods+=("$pod")
+          done
+          podNames=()
+        fi
+      fi
+
+      add_more="n"
+      prompt_yn $'\n  Add another namespace?' && add_more="y"
+    done
+
+    if [[ ${#sel_pods[@]} -eq 0 ]]; then
+      printf "  No pods selected.\n"
+      log_activity "Cross-namespace collection cancelled: no pods selected."
+      return 1
+    fi
+
+    # Summary
+    printf "\n  Collection summary:\n"
+    local summary_ns=" "
+    for idx in "${!sel_pods[@]}"; do
+      local sns="${sel_namespaces[$idx]}"
+      if [[ "$summary_ns" != *" $sns "* ]]; then
+        printf "\n  ── Namespace: %s ──\n" "$sns"
+        summary_ns+="$sns "
+      fi
+      printf "    - %s\n" "${sel_pods[$idx]}"
+    done
+    printf "\n"
+
+    local confirm
+    while true; do
+      printf "    ${_C_KEY}[1]${_C_RESET} Proceed\n"
+      printf "    ${_C_KEY}[2]${_C_RESET} Re-select secondary namespace(s)\n"
+      printf "    ${_C_KEY}[3]${_C_RESET} Start over\n"
+      printf "    ${_C_KEY}[0]${_C_RESET} Cancel\n"
+      printf "\n  >> Select [0-3]: "
+      read -r confirm
+      case "$confirm" in
+        1)
+          prompt_max_jobs
+          prompt_delivery allow_modify
+          local pd_rc=$?
+          if [[ $pd_rc -eq 0 ]]; then
+            break 2
+          elif [[ $pd_rc -eq 1 ]]; then
+            return 1
+          fi
+          # pd_rc == 2 → user chose "Modify selection"; re-show this menu
+          ;;
+        2) modify_mode=true; break ;;
+        3) run_phase0=true; break ;;
+        0) log_activity "Cross-namespace collection cancelled by user."; return 1 ;;
+        *) printf "  ${_C_WARN}Please select 0, 1, 2, or 3.${_C_RESET}\n" ;;
+      esac
+    done
+  done
+
+  local base_support_dir="$SYSDIG_SUPPORT_DIR"
+
+  # Phase 3: per-namespace parallel collection.
+  #
+  # Pods can be added in non-grouped order by the picker (e.g., primary →
+  # secondary → re-update primary), so first re-group sel_pods by namespace
+  # of first appearance. Then for each namespace: switch context, run the
+  # namespace setup serially (resetDiscoveryVars + discoverComponents +
+  # collectArtifacts/NamespaceOnly), hoist one-shot agent artifacts, and
+  # dispatch the namespace's pods in parallel via run_bg/throttle. wait_all
+  # between namespaces — the next namespace's discoverComponents would
+  # overwrite the SYSDIG_*_PREFIX vars that workers from the previous
+  # namespace are still reading. parallel arrays for bash 3.2 portability.
+  local _unique_ns=() _ns_pod_strings=()
+  local _i _ns _seen _k
+  for _i in "${!sel_pods[@]}"; do
+    _ns="${sel_namespaces[$_i]}"
+    _seen=-1
+    for _k in "${!_unique_ns[@]}"; do
+      [[ "${_unique_ns[$_k]}" == "$_ns" ]] && { _seen=$_k; break; }
+    done
+    if [[ $_seen -eq -1 ]]; then
+      _unique_ns+=("$_ns")
+      _ns_pod_strings+=("${sel_pods[$_i]}")
+    else
+      _ns_pod_strings[$_seen]+=" ${sel_pods[$_i]}"
+    fi
+  done
+
+  local _ns_idx _ns_pods
+  for _ns_idx in "${!_unique_ns[@]}"; do
+    _ns="${_unique_ns[$_ns_idx]}"
+    read -ra _ns_pods <<< "${_ns_pod_strings[$_ns_idx]}"
+
+    printf "\n  ── Namespace: %s ──\n" "$_ns"
+    log_activity "Collecting for namespace: $_ns"
+    namespace="$_ns"
+    SYSDIG_SUPPORT_DIR="$base_support_dir/$_ns"
+    mkdir -p "$DEST_DIR/$SYSDIG_SUPPORT_DIR"
+
+    # Always rediscover — the picker may have overwritten prefix vars while
+    # the user was adding namespaces. Shared helper resets all 20 discovery
+    # vars (incl. AC, CSCAN, RR) — see resetDiscoveryVars at line ~2748.
+    resetDiscoveryVars
+
+    if [[ "$_ns" == "$primary_ns" ]]; then
+      discoverComponents
+      podName=""
+      collectArtifacts
+    else
+      if ! discoverComponents; then
+        # No Sysdig components found in this secondary namespace — skip.
+        continue
+      fi
+      podName=""
+      collectArtifactsNamespaceOnly
+    fi
+
+    # Hoist one-shot per-cluster agent artifacts before dispatching workers.
+    _hoist_agent_oneshot_artifacts "${_ns_pods[@]}"
+
+    printf "Dispatching log collection for %d pods in namespace '%s' (%d parallel collector workers)...\n" "${#_ns_pods[@]}" "$_ns" "$MAX_JOBS"
+    _dispatch_pod_log_collection "${_ns_pods[@]}"
+  done
+
+  podName=""
+  SYSDIG_SUPPORT_DIR="$base_support_dir"
+  createArchiveAll
+}
+
+function main_menu() {
+  while true; do
+    # Reset per-iteration log state so the previous option's run-active /
+    # run-prep doesn't leak into the next menu choice. After a collection run
+    # completes, ACTIVITY_LOG still points at that run's destination file;
+    # zeroing it here ensures the next iteration's log_activity buffers into
+    # SESSION_BOOTSTRAP_LINES (for change-settings options) or RUN_BUFFER_LINES
+    # (when a collection option flips LOG_PHASE to run-prep below) until the
+    # next prompt_output_path establishes a fresh destination.
+    LOG_PHASE="bootstrap"
+    ACTIVITY_LOG=""
+    RUN_BUFFER_LINES=()
+    local _mode_display="SaaS"
+    [[ "$DEPLOYMENT_TYPE" == "onprem" ]] && _mode_display="On-premises"
+    local _product_display=""
+    if [[ "$DEPLOYMENT_TYPE" == "onprem" && -n "$SYSDIG_PRODUCT" ]]; then
+      case "$SYSDIG_PRODUCT" in
+        monitor)  _product_display="Monitor" ;;
+        secure)   _product_display="Secure" ;;
+        platform) _product_display="Platform" ;;
+      esac
+    fi
+
+    # Line 1: Mode (+ Product in parens, if set) | CLI
+    # Status-line labels are dimmed so the values stand out and the line
+    # doesn't compete with the bold-cyan action keys below.
+    local _line1="${_C_BOLD}Mode:${_C_RESET} $_mode_display"
+    [[ -n "$_product_display" ]] && _line1="${_line1} (${_product_display})"
+    # Ctx folds inline, in front of CLI, so the whole status stays on one line.
+    # Truncated to a fixed max (25) so the line length stays bounded.
+    if [[ -n "$K8S_CONTEXT" ]]; then
+      local _ctx_short="$K8S_CONTEXT"
+      # Keep the status line within the 68-col rule: cap a long context at 15
+      # chars (head…tail) so Mode + Ctx + CLI fit on one row.
+      (( ${#K8S_CONTEXT} > 15 )) && _ctx_short="${K8S_CONTEXT:0:7}…${K8S_CONTEXT: -7}"
+      _line1="${_line1} | ${_C_BOLD}Ctx:${_C_RESET} $_ctx_short"
+    fi
+    _line1="${_line1} | ${_C_BOLD}CLI:${_C_RESET} ${BASE_K8S_CMD:-$k8sCmd}"
+
+    # Second status line no longer used — Ctx is folded into line 1 above.
+    local _line2=""
+
+    # Borderless grouped menu. UTF-8 box-drawing rules + tree branches; group
+    # headers and the [n] keys are bold-cyan on a TTY (plain otherwise). Exit is [0].
+    local _W=68
+    local _rule _trule _title="Sysdig Log Collector"
+    _rule=$(printf '%*s' "$_W" '' | tr ' ' '─')
+    local _tdash=$(( _W - ${#_title} - 1 )); (( _tdash < 0 )) && _tdash=0
+    _trule=$(printf '%*s' "$_tdash" '' | tr ' ' '─')
+
+    printf "\n"
+    printf "  ${_C_KEY}%s${_C_RESET} %s\n" "$_title" "$_trule"
+    printf "  %s\n" "$_line1"
+    [[ -n "$_line2" ]] && printf "  %s\n" "$_line2"
+    printf "  %s\n\n" "$_rule"
+
+    printf "   ${_C_KEY}Collect Agent logs${_C_RESET}\n"
+    printf "   ├── ${_C_KEY}[1]${_C_RESET} Automated\n"
+    printf "   ├── ${_C_KEY}[2]${_C_RESET} Manual\n"
+    printf "   └── ${_C_KEY}[3]${_C_RESET} Multi-namespace\n\n"
+    if [[ "$DEPLOYMENT_TYPE" == "onprem" ]]; then
+      printf "   ${_C_KEY}Collect On-prem Platform logs${_C_RESET}\n"
+      printf "   ├── ${_C_KEY}[4]${_C_RESET} Automated\n"
+      printf "   └── ${_C_KEY}[5]${_C_RESET} Manual\n\n"
+      printf "   ${_C_KEY}Other operations${_C_RESET}\n"
+      printf "   ├── ${_C_KEY}[6]${_C_RESET} Send archive to Sysdig\n"
+      printf "   ├── ${_C_KEY}[7]${_C_RESET} Change Platform mode\n"
+      printf "   ├── ${_C_KEY}[8]${_C_RESET} Change Orchestration CLI\n"
+      printf "   ├── ${_C_KEY}[9]${_C_RESET} Change Cluster Context\n"
+      printf "   └── ${_C_KEY}[0]${_C_RESET} Exit\n\n"
+    else
+      printf "   ${_C_KEY}Other operations${_C_RESET}\n"
+      printf "   ├── ${_C_KEY}[4]${_C_RESET} Send archive to Sysdig\n"
+      printf "   ├── ${_C_KEY}[5]${_C_RESET} Change Platform mode\n"
+      printf "   ├── ${_C_KEY}[6]${_C_RESET} Change Orchestration CLI\n"
+      printf "   ├── ${_C_KEY}[7]${_C_RESET} Change Cluster Context\n"
+      printf "   └── ${_C_KEY}[0]${_C_RESET} Exit\n\n"
+    fi
+    printf "  %s\n" "$_rule"
+    printf "  >> Enter choice: "
+    read -r choice
+    case "$choice" in
+      1)
+        LOG_PHASE="run-prep"
+        prepare_namespace_context || continue
+        podName=""
+
+        local all_pods=()
+        while IFS= read -r line; do
+          [[ -n "$line" ]] && all_pods+=("$line")
+        done < <($k8sCmd get pods -n "$namespace" --no-headers 2>/dev/null | awk '{print $1}')
+
+        if [[ ${#all_pods[@]} -eq 0 ]]; then
+          printf "\n  No pods found in namespace '%s'.\n" "$namespace"
+          continue
+        fi
+
+        local opt1_proceed=false
+        while true; do
+          display_component_summary "${all_pods[@]}"
+          printf "\n    ${_C_KEY}[1]${_C_RESET} Proceed with collection\n"
+          printf "    ${_C_KEY}[2]${_C_RESET} Browse pods\n"
+          printf "    ${_C_KEY}[3]${_C_RESET} Change namespace\n"
+          printf "    ${_C_KEY}[0]${_C_RESET} Return to main menu\n"
+          printf "\n  >> Select [0-3]: "
+          local opt1_action
+          read -r opt1_action
+          case "$opt1_action" in
+            0) break ;;
+            1) opt1_proceed=true; break ;;
+            2) browse_pods_paginated "${all_pods[@]}" ;;
+            3)
+              if prepare_namespace_context; then
+                all_pods=()
+                while IFS= read -r line; do
+                  [[ -n "$line" ]] && all_pods+=("$line")
+                done < <($k8sCmd get pods -n "$namespace" --no-headers 2>/dev/null | awk '{print $1}')
+                if [[ ${#all_pods[@]} -eq 0 ]]; then
+                  printf "\n  No pods found in namespace '%s'.\n" "$namespace"
+                  break
+                fi
+              else
+                break
+              fi
+              ;;
+            *) printf "  Please select 0, 1, 2, or 3.\n" ;;
+          esac
+        done
+        [[ "$opt1_proceed" != "true" ]] && continue
+
+        prompt_max_jobs
+        prompt_delivery || continue
+        collectArtifacts
+        getLogs
+        createArchive
+        ;;
+      2)
+        LOG_PHASE="run-prep"
+        prepare_namespace_context || continue
+        while true; do
+          select_pod_dispatcher || { podNames=(); break; }
+          printf "\n  Selected pods in namespace '%s':\n" "$namespace"
+          for podName in "${podNames[@]}"; do
+            printf "    - %s\n" "$podName"
+          done
+          printf "\n"
+          prompt_max_jobs
+          prompt_delivery allow_modify
+          local pd_rc=$?
+          if [[ $pd_rc -eq 1 ]]; then
+            podNames=()
+            break
+          elif [[ $pd_rc -eq 2 ]]; then
+            podNames=()
+            continue
+          fi
+          # Cluster-wide artifacts once, then per-pod work in parallel.
+          local _selected_pods=("${podNames[@]}")
+          podName=""
+          collectArtifacts
+
+          # Hoist one-shot per-cluster agent artifacts before dispatching workers.
+          _hoist_agent_oneshot_artifacts "${_selected_pods[@]}"
+
+          # Per-pod yaml files (collectPodArtifacts) stay serial — they're
+          # only two cheap kubectl calls per pod. Parallelize getLogs only.
+          for podName in "${_selected_pods[@]}"; do
+            collectPodArtifacts
+          done
+
+          printf "Dispatching log collection for %d selected pods (%d parallel collector workers)...\n" "${#_selected_pods[@]}" "$MAX_JOBS"
+          _dispatch_pod_log_collection "${_selected_pods[@]}"
+
+          podName=""
+          podNames=("${_selected_pods[@]}")
+          createArchive
+          podNames=()
+          break
+        done
+        ;;
+      3) LOG_PHASE="run-prep"; collect_cross_namespace || continue ;;
+      4)
+        if [[ "$DEPLOYMENT_TYPE" == "onprem" ]]; then
+          LOG_PHASE="run-prep"
+          automatic_platform_collector || continue
+        else
+          upload_existing_file || continue
+        fi
+        ;;
+      5)
+        if [[ "$DEPLOYMENT_TYPE" == "onprem" ]]; then
+          LOG_PHASE="run-prep"
+          manual_platform_collector || continue
+        else
+          select_deployment_type
+          [[ "$DEPLOYMENT_TYPE" == "onprem" ]] && select_sysdig_product
+        fi
+        ;;
+      6)
+        if [[ "$DEPLOYMENT_TYPE" == "onprem" ]]; then
+          upload_existing_file || continue
+        else
+          select_orchestration_cli
+        fi
+        ;;
+      7)
+        if [[ "$DEPLOYMENT_TYPE" == "onprem" ]]; then
+          select_deployment_type
+          [[ "$DEPLOYMENT_TYPE" == "onprem" ]] && select_sysdig_product
+        else
+          select_kube_context || true
+        fi
+        ;;
+      8)
+        if [[ "$DEPLOYMENT_TYPE" == "onprem" ]]; then
+          select_orchestration_cli
+        else
+          printf "  ${_C_WARN}Invalid option.${_C_RESET} Please choose 0-7.\n"
+        fi
+        ;;
+      9)
+        if [[ "$DEPLOYMENT_TYPE" == "onprem" ]]; then
+          select_kube_context || true
+        else
+          printf "  ${_C_WARN}Invalid option.${_C_RESET} Please choose 0-7.\n"
+        fi
+        ;;
+      0)
+        printf "${_C_OK}Exiting. Goodbye!${_C_RESET}\n"; log_activity "User exited."; exit 0
+        ;;
+      *)
+        if [[ "$DEPLOYMENT_TYPE" == "onprem" ]]; then
+          printf "  ${_C_WARN}Invalid option.${_C_RESET} Please choose 0-9.\n"
+        else
+          printf "  ${_C_WARN}Invalid option.${_C_RESET} Please choose 0-7.\n"
+        fi
+        ;;
+    esac
+  done
+}
+
+# ─────────────────────────────────────────────
+#  CLI dispatch
+# ─────────────────────────────────────────────
+
+# Root help text. Shown when invoked with no arguments, -h, or --help.
+# Each new CLI command appended to the Available commands section gets its
+# own print_help_<command> function and a case branch below.
+function print_help_root() {
+  cat <<'EOF'
+Sysdig Log Collector (SLC) — collects support bundles for Sysdig deployments.
+
+  Agent / Shield collection works for ANY cluster running the Sysdig agent
+  for both SaaS customers and on-prem customers. It covers all installation
+  forms:
+    - Shield chart
+    - sysdig-deploy chart
+    - Standalone agent sub-chart
+
+  On-Prem Platform collection produces a Full Bundle (default) or a faster
+  Healthcheck variant (--healthcheck) from a self-hosted Sysdig backend.
+  SaaS customers don't need it.
+
+Usage:
+  sysdig-log-collector [command]
+  sysdig-log-collector [flags]
+
+Available commands:
+  interactive      Run the interactive menu-driven mode.
+  collect          Collect a Sysdig support archive (agent | platform).
+  list             Discover component / pod names for use with --from-file.
+  upload           Upload an archive to a Sysdig-provided S3 location.
+  autocomplete     Enable or disable shell tab-completion (bash / zsh auto-detected).
+  version          Print the Sysdig Log Collector (SLC) version and exit.
+
+Flags:
+  -i, --interactive    Alias for the 'interactive' command.
+  -h, --help           Show help and exit.
+
+Examples:
+  sysdig-log-collector --help
+  sysdig-log-collector -i
+  sysdig-log-collector collect agent --help
+  sysdig-log-collector collect platform --help
+  sysdig-log-collector list agent pods --help
+  sysdig-log-collector list platform components --help
+  sysdig-log-collector upload --help
+
+Safety:
+  - No Kubernetes resources are created, modified, or deleted.
+  - kubectl/oc access is read-only (get, describe, logs, cp, exec). One
+    exception: agent log collection uses exec + tar to write a temporary
+    archive inside the agent pod's own writable volume, copies it out, then
+    removes it with rm -f — an ephemeral file inside the pod, never a
+    Kubernetes resource.
+  - Sysdig API calls are GET-only against the platform's own endpoints.
+  - API keys are entered with hidden input, validated up-front, wiped from
+    memory after the run, and never written to the archive.
+  - Before archiving the bundle, all sensitive data (access keys, datastore
+    passwords, bearer tokens, and embedded credentials in connection URLs) are
+    masked in place as <redacted>. This is a best-effort safeguard, not a
+    guarantee; kindly review the archive before sharing externally.
+  - All activity is logged to the bundle's activity.log for transparency.
+
+Use "sysdig-log-collector <command> --help" for more information about a given command.
+EOF
+}
+
+# Per-command help for: upload.
+function print_help_upload() {
+  cat <<'EOF'
+Upload an existing support-bundle archive to a Sysdig-provided presigned S3 location.
+
+Usage:
+  sysdig-log-collector upload -f <path>      --url <url>
+  sysdig-log-collector upload --file=<path>  --url=<url>
+  sysdig-log-collector upload -f <path>      --url <url> --dry-run
+
+Flags:
+  -f, --file <path>    Path to the archive file (required).
+                       Accepted: .tar.gz, .tgz, .tar.bz2, .tbz, .tbz2,
+                                 .tar.xz, .txz, .tar, .zip, .7z
+  --url <url>          Sysdig-provided presigned S3 PUT URL (required).
+                       Must start with https://, contain .amazonaws.com,
+                       include X-Amz-Signature=, and end with x-id=PutObject.
+                       Wrap the URL in single quotes (e.g., --url='https://...').
+      --dry-run        Validate the file and URL, then exit without uploading.
+                       Useful for verifying a presigned URL before its expiry.
+  -h, --help           Show help and exit.
+
+Examples:
+  sysdig-log-collector upload -f bundle.tgz --url "https://...amazonaws.com/...x-id=PutObject"
+  sysdig-log-collector upload --file=./bundle.tgz --url="https://...PutObject"
+  sysdig-log-collector upload -f bundle.tgz --url "https://...PutObject" --dry-run
+EOF
+}
+
+# Detect whether $1 looks like a CLI flag rather than a value. Used by every
+# parser case where a flag REQUIRES a value, so that something like
+# `--namespace --components ...` doesn't silently consume `--components` as
+# the namespace value and then fail downstream with a confusing message.
+# Matches `-x` and `--x` (single letter prefix). Negative numbers like `-5`
+# don't match — they get through and validation catches them later.
+function _looks_like_flag() {
+  [[ "$1" =~ ^-{1,2}[a-zA-Z] ]]
+}
+
+# Guard for flags that require a value. Prints the standard error and returns 1
+# when the value is missing or looks like another flag; returns 0 otherwise.
+# Usage inside an arg-parse case arm:  _require_value "$1" "${2:-}" || return 1
+function _require_value() {
+  local _flag="$1" _val="${2:-}"
+  if [[ -z "$_val" ]] || _looks_like_flag "$_val"; then
+    printf "${_C_ERR}Error: %s requires a value (got '%s').${_C_RESET}\n" "$_flag" "${_val:-<missing>}" >&2
+    return 1
+  fi
+  return 0
+}
+
+# Heuristic: returns 0 when $1 looks pod-like (contains at least one digit).
+# Sysdig component names (agent, cluster-shield, node-analyzer, …) are
+# pure-alpha-dash; pod names always carry a random-hash suffix with digits.
+# Used to power "did you mean --pods?" hints when --components validation fails.
+function _looks_like_pod_name() {
+  [[ "$1" == *[0-9]* ]]
+}
+
+# Returns 0 if $1 matches exactly one of the known Sysdig Phase-1 component
+# bucket names. Used by "did you mean --components?" hints when --pods
+# validation fails.
+function _is_known_component_name() {
+  case "$1" in
+    agent|shield|cluster-shield|node-analyzer|kspm-collector|admission-controller|cluster-scanner|rapid-response)
+      return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# CLI entry point for the `upload` command. Parses flags, validates inputs via
+# the shared _validate_archive_path / _validate_s3_url helpers, and either
+# invokes _perform_upload or (with --dry-run) prints OK lines and exits 0.
+function cli_upload() {
+  local file_path="" upload_url="" dry_run=0
+  while (( $# > 0 )); do
+    case "$1" in
+      -h|--help)
+        print_help_upload
+        return 0
+        ;;
+      -f|--file)
+        _require_value "$1" "${2:-}" || return 1
+        file_path="$2"; shift 2
+        ;;
+      --file=*)
+        file_path="${1#--file=}"; shift
+        ;;
+      -f=*)
+        file_path="${1#-f=}"; shift
+        ;;
+      --url)
+        if [[ -z "${2:-}" ]] || _looks_like_flag "$2"; then
+          _prompt_s3_url_cli upload_url "--url" || return 1
+          shift
+        else
+          upload_url="$2"; shift 2
+        fi
+        ;;
+      --url=*)
+        upload_url="${1#--url=}"
+        [[ -z "$upload_url" ]] && { _prompt_s3_url_cli upload_url "--url" || return 1; }
+        shift
+        ;;
+      --dry-run)
+        dry_run=1; shift
+        ;;
+      *)
+        printf "${_C_ERR}Error: unknown flag for upload: %s${_C_RESET}\n" "$1" >&2
+        printf "  Run 'sysdig-log-collector upload --help' for usage.\n" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  if [[ -z "$file_path" ]]; then
+    printf "${_C_ERR}Error: -f/--file is required.${_C_RESET}\n" >&2
+    printf "  Run 'sysdig-log-collector upload --help' for usage.\n" >&2
+    return 1
+  fi
+  if [[ -z "$upload_url" ]]; then
+    printf "${_C_ERR}Error: --url is required.${_C_RESET}\n" >&2
+    printf "  Run 'sysdig-log-collector upload --help' for usage.\n" >&2
+    return 1
+  fi
+
+  _validate_archive_path "$file_path"
+  case $? in
+    0) (( dry_run )) && printf "${_C_OK}OK:${_C_RESET} file is valid (%s).\n" "$file_path" ;;
+    1) printf "${_C_ERR}Error: file path cannot be empty.${_C_RESET}\n" >&2; return 1 ;;
+    2) printf "${_C_ERR}Error: file not found: %s${_C_RESET}\n" "$file_path" >&2; return 1 ;;
+    3) printf "${_C_ERR}Error: unsupported file type. Accepted: .tar.gz, .tgz, .tar.bz2, .tbz, .tbz2, .tar.xz, .txz, .tar, .zip, .7z${_C_RESET}\n" >&2; return 1 ;;
+  esac
+
+  _validate_s3_url "$upload_url"
+  case $? in
+    0) (( dry_run )) && printf "${_C_OK}OK:${_C_RESET} URL is valid.\n" ;;
+    1) printf "${_C_ERR}Error: URL cannot be empty.${_C_RESET}\n" >&2; return 1 ;;
+    2) printf "${_C_ERR}Error: invalid URL. Must start with https://, contain .amazonaws.com, include X-Amz-Signature=, and end with x-id=PutObject.${_C_RESET}\n" >&2; return 1 ;;
+  esac
+
+  # Expiry check: a presigned URL with a valid format is still useless once
+  # X-Amz-Date + X-Amz-Expires is in the past — S3 would return HTTP 403.
+  _check_s3_url_expiry "$upload_url" "URL" "" "$dry_run" || return 1
+
+  (( dry_run )) && return 0
+
+  _perform_upload "$file_path" "$upload_url"
+}
+
+function print_help_autocomplete() {
+  cat <<'EOF'
+Enable or disable shell tab-completion for sysdig-log-collector.
+
+Run from your terminal:
+  sysdig-log-collector autocomplete enable     Install: appends an eval line
+                                               to your rc file (~/.bashrc or
+                                               ~/.zshrc) and confirms.
+  sysdig-log-collector autocomplete disable    Uninstall: removes that line.
+
+The same command also works as the rc-file payload (eval context): when
+stdout isn't a terminal, it emits the registration script that the rc
+file's eval applies into the current shell. You don't need to invoke
+that mode by hand — it runs automatically each time your shell starts.
+
+Shell detection: the user's interactive shell is inferred from the parent
+process (the shell that ran this command). Re-run from each shell you use
+if you switch between bash and zsh.
+
+Flags:
+  -h, --help    Show help and exit.
+EOF
+}
+
+# Detect the user's actual interactive shell. Prefers the parent process
+# name (the shell that invoked us) over $SHELL, since on macOS $SHELL is
+# the LOGIN shell — a user running this command from a bash subshell on
+# top of a zsh login would still see $SHELL=/bin/zsh.
+function _detect_user_shell() {
+  local _parent
+  _parent=$(ps -p "$PPID" -o comm= 2>/dev/null | sed 's|^-||' | awk -F/ '{print $NF}')
+  case "$_parent" in
+    bash) echo "bash"; return 0 ;;
+    zsh)  echo "zsh";  return 0 ;;
+  esac
+  case "${SHELL:-}" in
+    */bash) echo "bash"; return 0 ;;
+    */zsh)  echo "zsh";  return 0 ;;
+  esac
+  return 1
+}
+
+# Map detected shell to the conventional rc-file path. Echoes the absolute
+# path on stdout. Used by both install and uninstall.
+function _detect_user_rc_file() {
+  local _shell
+  _shell=$(_detect_user_shell) || return 1
+  case "$_shell" in
+    bash) echo "$HOME/.bashrc" ;;
+    zsh)  echo "$HOME/.zshrc" ;;
+  esac
+}
+
+# Resolve $0 to an absolute path so the rc-file eval line keeps working
+# after the user `cd`'s elsewhere.
+function _autocomplete_self_path() {
+  local _p="$0"
+  [[ "$_p" != /* ]] && _p="$(pwd)/$_p"
+  printf '%s\n' "$(cd "$(dirname "$_p")" && pwd)/$(basename "$_p")"
+}
+
+# Marker constants. Used as the block boundaries when appending to / removing
+# from the user's rc file.
+_AUTOCOMPLETE_MARKER_START='# >>> sysdig-log-collector autocomplete >>>'
+_AUTOCOMPLETE_MARKER_END='# <<< sysdig-log-collector autocomplete <<<'
+
+# Install path — runs when the user invokes `autocomplete enable` from a terminal.
+# Appends a guarded eval block to the user's shell rc file. Idempotent: if the
+# block is already present we report "already enabled" and exit 0.
+function _cli_autocomplete_install() {
+  local _shell _rc _self
+  _shell=$(_detect_user_shell) || {
+    printf "${_C_ERR}Error: could not detect your interactive shell (\$SHELL='%s').${_C_RESET}\n" "${SHELL:-<unset>}" >&2
+    printf "  Supported: bash, zsh.\n" >&2
+    return 1
+  }
+  _rc=$(_detect_user_rc_file) || return 1
+  _self=$(_autocomplete_self_path)
+
+  if [[ -f "$_rc" ]] && grep -Fq "$_AUTOCOMPLETE_MARKER_START" "$_rc"; then
+    printf "Tab-completion is already enabled in %s — nothing to do.\n" "$_rc"
+    return 0
+  fi
+
+  # Create rc file if it doesn't exist (zero-config users may not have one).
+  if [[ ! -f "$_rc" ]]; then
+    touch "$_rc" 2>/dev/null || {
+      printf "${_C_ERR}Error: could not create %s.${_C_RESET}\n" "$_rc" >&2
+      return 1
+    }
+  fi
+
+  # Append the eval block. The leading blank line keeps the rc readable when
+  # the file already ends without one. Quoting around %s preserves spaces in
+  # the resolved path.
+  {
+    printf '\n%s\n' "$_AUTOCOMPLETE_MARKER_START"
+    printf 'eval "$("%s" autocomplete enable)" 2>/dev/null\n' "$_self"
+    printf '%s\n' "$_AUTOCOMPLETE_MARKER_END"
+  } >> "$_rc" || {
+    printf "${_C_ERR}Error: could not write to %s.${_C_RESET}\n" "$_rc" >&2
+    return 1
+  }
+
+  printf "${_C_OK}Tab-completion enabled for %s.${_C_RESET}\n" "$_shell"
+  printf "  Added eval block to: %s\n" "$_rc"
+  printf "  To use it now without restarting: source %s\n" "$_rc"
+  printf "  To disable later: %s autocomplete disable\n" "$_self"
+}
+
+# Uninstall path — runs when the user invokes `autocomplete disable` from a
+# terminal. Removes the marker block from the rc file. Idempotent.
+function _cli_autocomplete_uninstall() {
+  local _rc _tmp
+  _rc=$(_detect_user_rc_file) || {
+    printf "${_C_ERR}Error: could not detect your interactive shell.${_C_RESET}\n" >&2
+    return 1
+  }
+
+  if [[ ! -f "$_rc" ]]; then
+    printf "No rc file at %s — nothing to disable.\n" "$_rc"
+    return 0
+  fi
+  if ! grep -Fq "$_AUTOCOMPLETE_MARKER_START" "$_rc"; then
+    printf "Tab-completion is not enabled in %s — nothing to do.\n" "$_rc"
+    return 0
+  fi
+
+  _tmp=$(mktemp) || return 1
+  # awk strips lines between (and including) the start/end markers. Any
+  # preceding blank line is also dropped to avoid leaving a dangling gap.
+  awk -v start="$_AUTOCOMPLETE_MARKER_START" -v end="$_AUTOCOMPLETE_MARKER_END" '
+    BEGIN { in_block=0; pending_blank=0 }
+    $0 == start { in_block=1; pending_blank=0; next }
+    $0 == end   { in_block=0; next }
+    in_block    { next }
+    /^$/        { pending_blank=1; next }
+                { if (pending_blank) { print ""; pending_blank=0 } print }
+    END         { if (pending_blank) print "" }
+  ' "$_rc" > "$_tmp" && mv "$_tmp" "$_rc"
+
+  printf "${_C_OK}Tab-completion disabled.${_C_RESET}\n"
+  printf "  Removed eval block from: %s\n" "$_rc"
+  printf "  Current shell still has the function loaded; it'll be gone on next shell start.\n"
+}
+
+# Emit a universal tab-completion script that auto-adapts to bash or zsh at
+# the time the script is sourced. The zsh-specific prelude (compinit +
+# bashcompinit shim) is guarded by [[ -n "$ZSH_VERSION" ]] so bash silently
+# skips it. The bash `complete -F` registration works directly in bash and
+# in zsh (post-bashcompinit). Static flag-level completion only; dynamic
+# value completion (e.g. listing kubectl namespaces under `-n <TAB>`) is
+# intentionally deferred.
+function _emit_completion_script() {
+  cat <<'EOF'
+# zsh needs bashcompinit before `complete -F` works. Bash ignores this block.
+if [[ -n "${ZSH_VERSION:-}" ]]; then
+  if ! whence -w compinit >/dev/null 2>&1; then
+    autoload -U compinit && compinit
+  fi
+  autoload -U bashcompinit && bashcompinit
+fi
+EOF
+  cat <<'EOF'
+# Walk COMP_WORDS for an already-typed -c/--context value (in either
+# `-c foo`, `--context foo`, `-c=foo`, or `--context=foo` shapes) so that
+# namespace completion can query the same cluster the user intends to act on.
+# `=` is a default COMP_WORDBREAKS char, so `--context=foo` arrives as the
+# 3-word sequence (--context, =, foo) — both shapes are handled below.
+_sysdig_log_collector_context_from_words() {
+  local i _w _next _val
+  for ((i=1; i<COMP_CWORD; i++)); do
+    _w="${COMP_WORDS[i]}"
+    if [[ "$_w" == "-c" || "$_w" == "--context" ]]; then
+      _next="${COMP_WORDS[i+1]:-}"
+      if [[ "$_next" == "=" ]]; then
+        _val="${COMP_WORDS[i+2]:-}"
+      else
+        _val="$_next"
+      fi
+      if [[ -n "$_val" && "$_val" != -* && "$_val" != "=" ]]; then
+        printf '%s' "$_val"
+        return
+      fi
+    fi
+  done
+}
+
+# Fetch live namespace names. Prefers kubectl, falls back to oc. Honors an
+# optional context arg ($1). Bounded by kubectl's --request-timeout so a
+# stalled cluster doesn't hang the prompt.
+_sysdig_log_collector_namespaces() {
+  local _cmd _ctx_args=()
+  [[ -n "${1:-}" ]] && _ctx_args=(--context="$1")
+  for _cmd in kubectl oc; do
+    if command -v "$_cmd" >/dev/null 2>&1; then
+      "$_cmd" "${_ctx_args[@]}" --request-timeout=3s get ns --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null
+      return
+    fi
+  done
+}
+
+_sysdig_log_collector() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+  COMPREPLY=()
+
+  # Path-taking flags → fall through to filesystem completion.
+  case "$prev" in
+    -o|--output-dir)
+      COMPREPLY=( $(compgen -d -- "$cur") ); return ;;
+    -f|--file|--from-file)
+      COMPREPLY=( $(compgen -f -- "$cur") ); return ;;
+  esac
+
+  # URL-taking flags → emit a pre-quoted placeholder so the user can replace
+  # the literal HERE_IN_QUOTES text with the real URL without worrying about
+  # shell escaping of `&`/`?`. Two shapes are handled:
+  #   `--url <TAB>` / `-u <TAB>`  → prev=--url/-u, cur="" — emit standalone.
+  #   `--url=<TAB>` / `-u=<TAB>`  → bash keeps the whole `--url=` as one word
+  #                                  (cur=--url=), so we emit a candidate that
+  #                                  starts with the user's prefix.
+  # The `IN_QUOTES` suffix doubles as a reminder for zsh users — zsh's
+  # bashcompinit shim strips the literal single quotes on insertion, so the
+  # text itself tells them quotes are still required.
+  # `compopt -o nospace` keeps the cursor adjacent to the closing quote so
+  # the user can select-replace the placeholder. Silently no-op on macOS
+  # bash 3.2 (no compopt builtin) — degrades to a trailing space, no break.
+  case "$prev" in
+    -u|--url)
+      COMPREPLY=( "'PASTE_SYSDIG_S3_URL_HERE_IN_QUOTES'" )
+      compopt -o nospace 2>/dev/null
+      return ;;
+  esac
+  case "$cur" in
+    --url=|-u=)
+      # bash 3.2 appends the candidate to cur instead of replacing — emit
+      # just the suffix so the joined result is `--url='PASTE_...'`.
+      COMPREPLY=( "'PASTE_SYSDIG_S3_URL_HERE_IN_QUOTES'" )
+      compopt -o nospace 2>/dev/null
+      return ;;
+  esac
+
+  # Namespace-taking flags → query the live cluster for ns names, honoring
+  # any earlier -c/--context value so completion reflects the cluster the
+  # user is actually targeting.
+  # For --namespaces (CSV), only complete the segment after the last comma
+  # and preserve the rest as a prefix.
+  case "$prev" in
+    -n|--namespace)
+      local _ctx; _ctx=$(_sysdig_log_collector_context_from_words)
+      COMPREPLY=( $(compgen -W "$(_sysdig_log_collector_namespaces "$_ctx")" -- "$cur") )
+      return ;;
+    --namespaces)
+      local _ctx; _ctx=$(_sysdig_log_collector_context_from_words)
+      local _nss; _nss=$(_sysdig_log_collector_namespaces "$_ctx")
+      if [[ "$cur" == *,* ]]; then
+        local _pref="${cur%,*},"
+        local _last="${cur##*,}"
+        COMPREPLY=( $(compgen -P "$_pref" -W "$_nss" -- "$_last") )
+      else
+        COMPREPLY=( $(compgen -W "$_nss" -- "$cur") )
+      fi
+      return ;;
+  esac
+
+  local cmd1="${COMP_WORDS[1]:-}"
+  local cmd2="${COMP_WORDS[2]:-}"
+  local cmd3="${COMP_WORDS[3]:-}"
+
+  # Word lists below intentionally omit short flags (-h, -i, -n, -A, -c, -o,
+  # -j, -u, -f). The short forms still WORK if typed; they're just hidden
+  # from <TAB> listings so the completion UI is dominated by self-documenting
+  # long-form flags (--namespace > -n, --output-dir > -o, …).
+  if [[ $COMP_CWORD -eq 1 ]]; then
+    COMPREPLY=( $(compgen -W "interactive collect list upload autocomplete version --help --interactive" -- "$cur") )
+    return
+  fi
+
+  if [[ $COMP_CWORD -eq 2 ]]; then
+    case "$cmd1" in
+      collect)      COMPREPLY=( $(compgen -W "agent platform --help" -- "$cur") ) ;;
+      list)         COMPREPLY=( $(compgen -W "agent platform --help" -- "$cur") ) ;;
+      autocomplete) COMPREPLY=( $(compgen -W "enable disable --help" -- "$cur") ) ;;
+      upload)       COMPREPLY=( $(compgen -W "--file --url --dry-run --help" -- "$cur") ) ;;
+    esac
+    return
+  fi
+
+  if [[ $COMP_CWORD -eq 3 ]]; then
+    case "$cmd1 $cmd2" in
+      "collect agent")
+        COMPREPLY=( $(compgen -W "--namespace --all --pods --components --namespaces --from-file --context --output-dir --max-jobs --url --no-save --help" -- "$cur") ) ;;
+      "collect platform")
+        COMPREPLY=( $(compgen -W "--namespace --all --pods --components --from-file --context --output-dir --max-jobs --since --debug --healthcheck --url --no-save --api-key --secure-api-key --local-api --help" -- "$cur") ) ;;
+      "list agent")
+        COMPREPLY=( $(compgen -W "components pods --namespace --namespaces --context --no-headers --status --components --help" -- "$cur") ) ;;
+      "list platform")
+        COMPREPLY=( $(compgen -W "components pods --namespace --context --no-headers --status --components --help" -- "$cur") ) ;;
+      "upload "*|"upload")
+        COMPREPLY=( $(compgen -W "--file --url --dry-run --help" -- "$cur") ) ;;
+    esac
+    return
+  fi
+
+  case "$cmd1 $cmd2 $cmd3" in
+    "list agent components"|"list agent pods")
+      COMPREPLY=( $(compgen -W "--namespace --namespaces --context --no-headers --status --components --help" -- "$cur") )
+      ;;
+    "list platform components"|"list platform pods")
+      COMPREPLY=( $(compgen -W "--namespace --context --no-headers --status --components --help" -- "$cur") )
+      ;;
+  esac
+}
+complete -F _sysdig_log_collector sysdig-log-collector
+EOF
+}
+
+# CLI dispatcher for the `autocomplete` command. Behavior switches on whether
+# stdout is a terminal:
+#   - TTY (user typed this in a terminal): install/uninstall to the user's rc
+#     file with a confirmation message. This is the "automatic setup" path.
+#   - non-TTY (the rc file's eval substitution is running this): emit the
+#     completion script for the current shell. This is invisible to the user
+#     and runs every time their shell starts.
+function cli_autocomplete() {
+  case "${1:-}" in
+    ""|-h|--help)
+      print_help_autocomplete
+      return 0
+      ;;
+    enable)
+      if [[ -t 1 ]]; then
+        _cli_autocomplete_install
+      else
+        _emit_completion_script
+      fi
+      ;;
+    disable)
+      if [[ -t 1 ]]; then
+        _cli_autocomplete_uninstall
+      else
+        # Eval-context disable: best-effort unregister inside the current shell.
+        printf "complete -r sysdig-log-collector 2>/dev/null\n"
+        printf "unset -f _sysdig_log_collector 2>/dev/null\n"
+      fi
+      ;;
+    *)
+      printf "${_C_ERR}Error: unknown autocomplete subcommand '%s'. Use 'enable' or 'disable'.${_C_RESET}\n" "$1" >&2
+      printf "  Run 'sysdig-log-collector autocomplete --help' for usage.\n" >&2
+      return 1
+      ;;
+  esac
+}
+
+# ───── Output-path setup for CLI mode (no prompts) ─────
+# Mimics what prompt_output_path does in the interactive flow: creates the
+# destination directory, opens activity.log (preserving any prior one), replays
+# the session bootstrap buffer, and flips LOG_PHASE to run-active so every
+# subsequent log_activity call hits disk.
+function _cli_setup_output_path() {
+  local _dir="$1"
+  # Mirror prompt_output_path's dirname/basename split (commit 85a5335) so the
+  # user-supplied path is taken at face value, not nested under an extra
+  # "sysdig-support/" subdir. With no -o, fall back to $(pwd)/sysdig-support.
+  if [[ -z "$_dir" ]]; then
+    DEST_DIR="$(pwd)"
+    SYSDIG_SUPPORT_DIR="sysdig-support"
+  else
+    _dir="${_dir%/}"   # strip trailing slash so dirname/basename split cleanly
+    local _parent _leaf
+    _parent="$(dirname "$_dir")"
+    _leaf="$(basename "$_dir")"
+    mkdir -p "$_parent/$_leaf" || return 1
+    # Absolutize parent so $DEST_DIR/$SYSDIG_SUPPORT_DIR works regardless of
+    # mid-run cd's (createArchive cd's into the work dir; a relative DEST_DIR
+    # would otherwise break subsequent absolute-needed appends to ACTIVITY_LOG).
+    DEST_DIR=$(cd "$_parent" && pwd) || return 1
+    SYSDIG_SUPPORT_DIR="$_leaf"
+  fi
+  mkdir -p "$DEST_DIR/$SYSDIG_SUPPORT_DIR" || return 1
+  local _new_log="$DEST_DIR/$SYSDIG_SUPPORT_DIR/activity.log"
+  if [[ -f "$_new_log" ]]; then
+    mv "$_new_log" "${_new_log}.previous-$(date +%s)"
+  fi
+  echo "Sysdig Log Collector v$SLC_VERSION - $(date)" > "$_new_log"
+  local _line
+  for _line in "${SESSION_BOOTSTRAP_LINES[@]+"${SESSION_BOOTSTRAP_LINES[@]}"}"; do
+    echo "$_line" >> "$_new_log"
+  done
+  ACTIVITY_LOG="$_new_log"
+  LOG_PHASE="run-active"
+  log_activity "Output path set to $DEST_DIR/$SYSDIG_SUPPORT_DIR"
+}
+
+# ───── API-key setup for CLI mode (mirrors legacy -a / -sa / -la flags) ─────
+# Shared by cli_collect_platform (both default and --healthcheck modes).
+# Reuses every interactive helper as-is (no edits to prompt_api_keys / _ensure_api_url /
+# discover_platform_api_url / start_platform_portforward / _validate_api_key / the
+# two collector functions): we only WIRE the globals they read and then either
+# call _ensure_api_url (default — direct URL, port-forward fallback) or
+# start_platform_portforward (when --local-api is set, mirroring the legacy
+# get_support_bundle.sh:84-86 'API_LOCAL=true' semantics).
+#
+# Args: $1 = api_key_arg, $2 = secure_api_key_arg, $3 = local_api_flag (0/1)
+# Returns: 0 on success (or no-op if no keys), 1 on hard error (invalid key /
+# unreachable API).
+#
+# Side effects on success:
+#   MONITOR_API_KEY, SECURE_API_KEY → populated from args (or env fallback)
+#   SYSDIG_PRODUCT                  → monitor | secure | platform (based on which keys are set)
+#   API_URL                         → either the discovered direct URL or http://127.0.0.1:8080
+#   API_PORTFORWARD_PID             → set when port-forward is used
+function _cli_setup_api_keys() {
+  local _api_key="$1" _secure_key="$2" _local_api="$3"
+
+  # Env-var fallback. Keeps keys out of shell history when the user exports
+  # SYSDIG_API_KEY / SYSDIG_SECURE_API_KEY in their environment.
+  [[ -z "$_api_key"    && -n "${SYSDIG_API_KEY:-}"        ]] && _api_key="$SYSDIG_API_KEY"
+  [[ -z "$_secure_key" && -n "${SYSDIG_SECURE_API_KEY:-}" ]] && _secure_key="$SYSDIG_SECURE_API_KEY"
+
+  # No keys → caller's pipeline takes the "skipped" branch; we don't need to
+  # set up the API URL or run port-forward.
+  if [[ -z "$_api_key" && -z "$_secure_key" ]]; then
+    return 0
+  fi
+
+  MONITOR_API_KEY="$_api_key"
+  SECURE_API_KEY="$_secure_key"
+  if [[ -n "$_api_key" && -n "$_secure_key" ]]; then
+    SYSDIG_PRODUCT="platform"
+  elif [[ -n "$_api_key" ]]; then
+    SYSDIG_PRODUCT="monitor"
+  else
+    SYSDIG_PRODUCT="secure"
+  fi
+  log_activity "CLI: API keys supplied (product=$SYSDIG_PRODUCT)."
+
+  # Establish API_URL. With --local-api we bypass discover_platform_api_url and
+  # go straight to port-forward (matches legacy 'API_LOCAL=true' semantics).
+  # Otherwise _ensure_api_url tries the discovered URL first and only falls
+  # back to port-forward when the direct URL isn't reachable.
+  if [[ "$_local_api" == "1" ]]; then
+    log_activity "CLI: --local-api set; using kubectl port-forward."
+    if ! start_platform_portforward; then
+      printf "${_C_ERR}Error: could not establish kubectl port-forward to sysdigcloud-api.${_C_RESET}\n" >&2
+      MONITOR_API_KEY=""; SECURE_API_KEY=""
+      return 1
+    fi
+  else
+    if ! _ensure_api_url; then
+      printf "${_C_ERR}Error: could not reach the Sysdig API. Retry with --local-api to use kubectl port-forward.${_C_RESET}\n" >&2
+      MONITOR_API_KEY=""; SECURE_API_KEY=""
+      return 1
+    fi
+  fi
+
+  # Validate each provided key against ${API_URL}/api/license. Fast-fail so
+  # the user doesn't wait through the full collection only to find the key
+  # was rejected after the fact.
+  if [[ -n "$_api_key" ]] && ! _validate_api_key "$_api_key"; then
+    printf "${_C_ERR}Error: Monitor API key rejected by %s/api/license.${_C_RESET}\n" "$API_URL" >&2
+    stop_platform_portforward
+    MONITOR_API_KEY=""; SECURE_API_KEY=""
+    return 1
+  fi
+  if [[ -n "$_secure_key" ]] && ! _validate_api_key "$_secure_key"; then
+    printf "${_C_ERR}Error: Secure API key rejected by %s/api/license.${_C_RESET}\n" "$API_URL" >&2
+    stop_platform_portforward
+    MONITOR_API_KEY=""; SECURE_API_KEY=""
+    return 1
+  fi
+  log_activity "CLI: API keys validated against ${API_URL}/api/license."
+  return 0
+}
+
+# Per-command help for: collect agent.
+function print_help_collect_agent() {
+  cat <<'EOF'
+Collect a Sysdig Agent log bundle from one or more namespaces.
+
+Usage:
+  sysdig-log-collector collect agent [flags]
+
+Scope (pick one; default = all Sysdig pods in target namespace):
+  -n, --namespace <ns>     Target namespace.
+  -A, --all                Default - Collect every Sysdig pod in targeted namespace.
+      --pods <list>        Collect specific pods. <list> or --from-file.
+      --components <list>  Collect specific component buckets. <list> or --from-file.
+                           Run `sysdig-log-collector list agent components -n <ns>`
+                           to discover available buckets in your cluster.
+      --namespaces <list>  Multi-namespace mode. Each <entry> selects a namespace
+                           and optionally narrows its scope:
+                             ns1,ns2                                    all Sysdig pods in each ns
+                             ns1:pods=p1+p2,ns2:pods=p3+p4              only those pods in each ns
+                             ns1:components=c1+c2,ns2:components=c3+c4  only those components in each ns
+                             ns1:pods=p1+p2,ns2:components=c1+c2        mix: pods in ns1, components in ns2
+                           Multiple items per namespace are joined with '+'.
+                           Replaces -n. Mutually exclusive with -A/--all, --pods, --components.
+                           Output is one unified bundle with per-namespace subdirectories.
+
+Common:
+  -c, --context <name>     Kubectl context (defaults to current-context).
+  -o, --output-dir <path>  Bundle output directory (default: current directory).
+  -j, --max-jobs <N>       Parallel collector worker count (1-16; default 4).
+      --from-file <path>   File of pod or component names, one per line.
+                           Pairs with --pods or --components.
+  -h, --help               Show help and exit.
+
+Upload:
+  -u, --url <url>          Presigned S3 PUT URL. Archive is uploaded after
+                           collection. Pre-flight expiry check rejects stale URLs.
+                           Wrap the URL in single quotes (e.g., --url='https://...').
+      --no-save            Delete the local archive after a successful upload.
+                           Requires --url.
+
+Examples:
+  sysdig-log-collector collect agent -n sysdig-agent
+  sysdig-log-collector collect agent -n sysdig-agent --components=node-analyzer,kspm-collector
+  sysdig-log-collector collect agent -n sysdig-agent --pods --from-file=pods.txt
+  sysdig-log-collector collect agent --namespaces=sysdig-agent,sysdig-admission-controller
+  sysdig-log-collector collect agent --namespaces='sysdig-agent:pods=agent-abc+agent-def,sysdig-admission-controller:components=admission-controller'
+  sysdig-log-collector collect agent -n sysdig-agent --url='<presigned-url>'
+EOF
+}
+
+# Validate and read a --from-file list, echoing the joined inline-CSV form on
+# stdout. The file must hold one name per line with no blank lines; whitespace
+# per line is trimmed. Enforces that --from-file pairs with a value-less --pods
+# or --components (mutually exclusive with an inline value). On any failure,
+# prints the error to stderr and returns 1. Args: mode, from_file,
+# current_pods_csv, current_components_arg. bash 3.2 has no namerefs, so the
+# caller assigns the echoed CSV to pods_csv/components_arg per mode.
+function _cli_read_from_file_csv() {
+  local _mode="$1" _from_file="$2" _pods_csv="$3" _components_arg="$4"
+  if [[ "$_mode" != "pods" && "$_mode" != "components" ]]; then
+    printf "${_C_ERR}Error: --from-file requires --pods or --components.${_C_RESET}\n" >&2
+    return 1
+  fi
+  if [[ "$_mode" == "pods" && -n "$_pods_csv" ]]; then
+    printf "${_C_ERR}Error: cannot combine --from-file with an inline --pods value.${_C_RESET}\n" >&2
+    return 1
+  fi
+  if [[ "$_mode" == "components" && -n "$_components_arg" ]]; then
+    printf "${_C_ERR}Error: cannot combine --from-file with an inline --components value.${_C_RESET}\n" >&2
+    return 1
+  fi
+  if [[ ! -f "$_from_file" ]]; then
+    printf "${_C_ERR}Error: file not found: %s${_C_RESET}\n" "$_from_file" >&2
+    return 1
+  fi
+  local -a _file_names=()
+  local _ln _lineno=0
+  while IFS= read -r _ln || [[ -n "$_ln" ]]; do
+    _lineno=$(( _lineno + 1 ))
+    _ln="${_ln#"${_ln%%[![:space:]]*}"}"   # ltrim
+    _ln="${_ln%"${_ln##*[![:space:]]}"}"   # rtrim
+    if [[ -z "$_ln" ]]; then
+      printf "${_C_ERR}Error: %s:%d is empty (file must contain no blank lines).${_C_RESET}\n" "$_from_file" "$_lineno" >&2
+      return 1
+    fi
+    _file_names+=("$_ln")
+  done < "$_from_file"
+  if [[ ${#_file_names[@]} -eq 0 ]]; then
+    printf "${_C_ERR}Error: %s is empty.${_C_RESET}\n" "$_from_file" >&2
+    return 1
+  fi
+  # Join into CSV (names are DNS-1123-style, so they never contain commas).
+  local _joined _i
+  for _i in "${!_file_names[@]}"; do
+    if (( _i == 0 )); then
+      _joined="${_file_names[$_i]}"
+    else
+      _joined="${_joined},${_file_names[$_i]}"
+    fi
+  done
+  printf '%s' "$_joined"
+}
+
+# Validate the CLI --url / --no-save delivery options shared by `collect agent`
+# and `collect platform`. --no-save requires --url. When a URL is given, validate
+# its shape (_validate_s3_url) and pre-flight its expiry, then set the upload
+# globals the archive helpers honor: UPLOAD_TO_S3=true, SYSDIG_UPLOAD_URL=<url>,
+# KEEP_LOCAL=true unless --no-save. Args: url_arg, no_save (0/1). Prints errors to
+# stderr and returns 1 on failure.
+function _cli_validate_url_delivery() {
+  local _url="$1" _no_save="$2"
+  if (( _no_save )) && [[ -z "$_url" ]]; then
+    printf "${_C_ERR}Error: --no-save requires --url.${_C_RESET}\n" >&2
+    return 1
+  fi
+  if [[ -n "$_url" ]]; then
+    _validate_s3_url "$_url"
+    case $? in
+      0) ;;
+      1) printf "${_C_ERR}Error: --url cannot be empty.${_C_RESET}\n" >&2; return 1 ;;
+      2) printf "${_C_ERR}Error: invalid --url. Must start with https://, contain .amazonaws.com, include X-Amz-Signature=, and end with x-id=PutObject.${_C_RESET}\n" >&2; return 1 ;;
+    esac
+    # Pre-flight expiry gate — catches stale presigned URLs at parse time so we
+    # don't waste minutes of collection before S3 returns HTTP 403.
+    _check_s3_url_expiry "$_url" "--url" || return 1
+    UPLOAD_TO_S3=true
+    SYSDIG_UPLOAD_URL="$_url"
+    if (( _no_save )); then
+      KEEP_LOCAL=false
+    else
+      KEEP_LOCAL=true
+    fi
+  fi
+}
+
+# CLI entry point for `collect agent`. Mirrors what interactive options 1 and 2
+# do — wires the chosen scope into the existing collectArtifacts / getLogs /
+# _phase1_collect_one_pod_logs / createArchive pipeline. Multi-namespace
+# (interactive option 3) is intentionally NOT implemented here; see follow-up.
+function cli_collect_agent() {
+  local ns_arg="" output_dir_arg="" context_arg=""
+  local max_jobs_arg="$MAX_JOBS_DEFAULT"
+  local mode="all"          # all | pods | components | namespaces
+  local pods_csv="" components_arg="" namespaces_csv=""
+  local from_file=""        # path supplied via --from-file
+  local url_arg="" no_save=0    # delivery: --url enables upload; --no-save deletes local archive after a successful upload
+  # Resolved at validation time (component-CSV → list of buckets), consumed by
+  # the bucketing loop further down.
+  local -a _wanted_components=()
+  # Scope-flag tracking for mutex validation. -A/--all is also tracked here so
+  # we can detect "the user explicitly set -A alongside --pods/--components"
+  # vs. "no scope flag at all, default to -A".
+  local _saw_all=0 _saw_pods=0 _saw_components=0 _saw_namespaces=0
+
+  while (( $# > 0 )); do
+    case "$1" in
+      -h|--help)            print_help_collect_agent; return 0 ;;
+      -n|--namespace)
+        _require_value "$1" "${2:-}" || return 1
+        ns_arg="$2"; shift 2 ;;
+      --namespace=*)        ns_arg="${1#--namespace=}"; shift ;;
+      -n=*)                 ns_arg="${1#-n=}"; shift ;;
+      -A|--all)             mode="all"; _saw_all=1; shift ;;
+      --pods)
+        # Value-less form allowed: when paired with --from-file the next token
+        # will start with '-' (or be missing), so we don't consume it as value.
+        if [[ -z "${2:-}" || "${2:0:1}" == "-" ]]; then
+          mode="pods"; _saw_pods=1; shift
+        else
+          pods_csv="$2"; mode="pods"; _saw_pods=1; shift 2
+        fi
+        ;;
+      --pods=*)             pods_csv="${1#--pods=}"; mode="pods"; _saw_pods=1; shift ;;
+      --components)
+        # Same value-or-from-file split as --pods.
+        if [[ -z "${2:-}" || "${2:0:1}" == "-" ]]; then
+          mode="components"; _saw_components=1; shift
+        else
+          components_arg="$2"; mode="components"; _saw_components=1; shift 2
+        fi
+        ;;
+      --components=*)        components_arg="${1#--components=}"; mode="components"; _saw_components=1; shift ;;
+      --namespaces)
+        # Same value-or-from-file split as --pods / --components.
+        if [[ -z "${2:-}" || "${2:0:1}" == "-" ]]; then
+          mode="namespaces"; _saw_namespaces=1; shift
+        else
+          namespaces_csv="$2"; mode="namespaces"; _saw_namespaces=1; shift 2
+        fi
+        ;;
+      --namespaces=*)       namespaces_csv="${1#--namespaces=}"; mode="namespaces"; _saw_namespaces=1; shift ;;
+      --from-file)
+        _require_value "$1" "${2:-}" || return 1
+        from_file="$2"; shift 2 ;;
+      --from-file=*)        from_file="${1#--from-file=}"; shift ;;
+      -c|--context)
+        _require_value "$1" "${2:-}" || return 1
+        context_arg="$2"; shift 2 ;;
+      --context=*)          context_arg="${1#--context=}"; shift ;;
+      -c=*)                 context_arg="${1#-c=}"; shift ;;
+      -o|--output-dir)
+        _require_value "$1" "${2:-}" || return 1
+        output_dir_arg="$2"; shift 2 ;;
+      --output-dir=*)       output_dir_arg="${1#--output-dir=}"; shift ;;
+      -o=*)                 output_dir_arg="${1#-o=}"; shift ;;
+      -j|--max-jobs)
+        # _looks_like_flag matches `-x`/`--x` (letter prefix) but NOT negative
+        # numbers like `-5`, so an out-of-range numeric value still reaches
+        # _validate_max_jobs where the proper range error is produced.
+        _require_value "$1" "${2:-}" || return 1
+        max_jobs_arg="$2"; shift 2 ;;
+      --max-jobs=*)         max_jobs_arg="${1#--max-jobs=}"; shift ;;
+      -j=*)                 max_jobs_arg="${1#-j=}"; shift ;;
+      -u|--url)
+        if [[ -z "${2:-}" ]] || _looks_like_flag "$2"; then
+          _prompt_s3_url_cli url_arg "$1" || return 1
+          shift
+        else
+          url_arg="$2"; shift 2
+        fi
+        ;;
+      --url=*)
+        url_arg="${1#--url=}"
+        [[ -z "$url_arg" ]] && { _prompt_s3_url_cli url_arg "--url" || return 1; }
+        shift ;;
+      -u=*)
+        url_arg="${1#-u=}"
+        [[ -z "$url_arg" ]] && { _prompt_s3_url_cli url_arg "-u" || return 1; }
+        shift ;;
+      --no-save)            no_save=1; shift ;;
+      *)
+        printf "${_C_ERR}Error: unknown flag for 'collect agent': %s${_C_RESET}\n" "$1" >&2
+        printf "  Run 'sysdig-log-collector collect agent --help' for usage.\n" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  # Validation
+  # Mutual exclusion: -A/--all, --pods, --components, --namespaces are mutually
+  # exclusive. -n/--namespace is independent (required for single-namespace
+  # modes, forbidden in --namespaces multi-namespace mode).
+  local _scope_count=$(( _saw_all + _saw_pods + _saw_components + _saw_namespaces ))
+  if (( _scope_count > 1 )); then
+    printf "${_C_ERR}Error: -A/--all, --pods, --components, and --namespaces are mutually exclusive.${_C_RESET}\n" >&2
+    printf "  Run 'sysdig-log-collector collect agent --help' for usage.\n" >&2
+    return 1
+  fi
+  if [[ "$mode" == "namespaces" ]]; then
+    if [[ -n "$ns_arg" ]]; then
+      printf "${_C_ERR}Error: cannot combine -n/--namespace with --namespaces.${_C_RESET}\n" >&2
+      return 1
+    fi
+  else
+    if [[ -z "$ns_arg" ]]; then
+      printf "${_C_ERR}Error: -n/--namespace is required (or use --namespaces for multi-namespace mode).${_C_RESET}\n" >&2
+      printf "  Run 'sysdig-log-collector collect agent --help' for usage.\n" >&2
+      return 1
+    fi
+  fi
+
+  # --from-file processing — pairs with a value-less --pods or --components.
+  # File format: one name per line, no empty lines anywhere, optional trailing
+  # newline. Whitespace per line is trimmed. The file's contents are joined
+  # into pods_csv / components_arg as if the user had typed the CSV form.
+  if [[ -n "$from_file" ]]; then
+    local _joined
+    _joined=$(_cli_read_from_file_csv "$mode" "$from_file" "$pods_csv" "$components_arg") || return 1
+    case "$mode" in
+      pods)        pods_csv="$_joined" ;;
+      components)  components_arg="$_joined" ;;
+    esac
+  fi
+
+  if [[ "$mode" == "pods" && -z "$pods_csv" ]]; then
+    printf "${_C_ERR}Error: --pods requires a value (inline CSV or --from-file).${_C_RESET}\n" >&2
+    return 1
+  fi
+  if [[ "$mode" == "components" && -z "$components_arg" ]]; then
+    printf "${_C_ERR}Error: --components requires a value (inline CSV or --from-file).${_C_RESET}\n" >&2
+    return 1
+  fi
+
+  # Static component-CSV validation — runs before any kubectl call so the user
+  # sees a precise error instead of a vague "no components found" warning when
+  # they fat-finger a name.
+  if [[ "$mode" == "components" ]]; then
+    local _csv_comps _c _bucket _known
+    IFS=',' read -ra _csv_comps <<< "$components_arg"
+    local _valid="$AGENT_COMPONENT_BUCKETS"
+    for _c in "${_csv_comps[@]}"; do
+      _c="${_c//[[:space:]]/}"
+      [[ -z "$_c" ]] && continue
+      _known=0
+      for _bucket in $_valid; do
+        [[ "$_c" == "$_bucket" ]] && _known=1 && break
+      done
+      if (( ! _known )); then
+        printf "${_C_ERR}Error: unknown component '%s'.${_C_RESET}\n" "$_c" >&2
+        printf "  Accepted: %s.\n" "${_valid// /, }" >&2
+        if _looks_like_pod_name "$_c"; then
+          printf "  Hint: '%s' looks like a pod name. Did you mean --pods instead of --components?\n" "$_c" >&2
+        fi
+        return 1
+      fi
+      _wanted_components+=("$_c")
+    done
+    if [[ ${#_wanted_components[@]} -eq 0 ]]; then
+      printf "${_C_ERR}Error: --components list was empty after parsing.${_C_RESET}\n" >&2
+      return 1
+    fi
+  fi
+
+  # Delivery validation: --no-save requires --url (otherwise it has nothing to
+  # save against). When --url is set, validate its shape via the same helper
+  # the standalone `upload` command uses, and pre-set the globals that
+  # createArchive / createArchiveAll honor to drive the post-archive upload
+  # (UPLOAD_TO_S3=true, SYSDIG_UPLOAD_URL=<url>, KEEP_LOCAL=true unless --no-save).
+  _cli_validate_url_delivery "$url_arg" "$no_save" || return 1
+
+  # Wire kubectl context. _apply_kube_context reads K8S_CONTEXT + BASE_K8S_CMD
+  # and builds $k8sCmd; downstream Phase 1 functions inherit it automatically.
+  BASE_K8S_CMD="${BASE_K8S_CMD:-kubectl}"
+  K8S_CONTEXT="$context_arg"
+  _apply_kube_context
+
+  # MAX_JOBS validation — reuses the existing helper which clamps to the global
+  # MAX_JOBS_MIN..MAX_JOBS_MAX range and falls back to MAX_JOBS_DEFAULT on
+  # invalid input. Prints any complaint to stderr.
+  MAX_JOBS="$max_jobs_arg"
+  _validate_max_jobs
+
+  # Multi-namespace path forks here. Validation + collection happens in a
+  # dedicated helper that mirrors interactive option 3 (collect_cross_namespace)
+  # — per-namespace subdirs under $SYSDIG_SUPPORT_DIR/<ns>/, createArchiveAll
+  # for the unified bundle. The single-namespace path below is unchanged.
+  if [[ "$mode" == "namespaces" ]]; then
+    _cli_collect_agent_multi_ns "$namespaces_csv" "$output_dir_arg"
+    return $?
+  fi
+
+  # Namespace + component discovery (same primitives the interactive
+  # prepare_namespace_context uses, minus the prompt loop).
+  resetDiscoveryVars
+  namespace="$ns_arg"
+  podNames=()
+  discoverComponents
+  if ! has_sysdig_components; then
+    printf "${_C_ERR}Error: no Sysdig components found in namespace '%s'.${_C_RESET}\n" "$namespace" >&2
+    return 1
+  fi
+
+  # Gather all pods in the namespace once; used to validate --pods and to
+  # bucket --components.
+  local all_pods=() _line
+  while IFS= read -r _line; do
+    [[ -n "$_line" ]] && all_pods+=("$_line")
+  done < <($k8sCmd get pods -n "$namespace" --no-headers 2>/dev/null | awk '{print $1}')
+  if [[ ${#all_pods[@]} -eq 0 ]]; then
+    printf "${_C_ERR}Error: no pods found in namespace '%s'.${_C_RESET}\n" "$namespace" >&2
+    return 1
+  fi
+
+  # Resolve scope into podNames (used by Phase 1 dispatch).
+  case "$mode" in
+    all)
+      # podNames stays empty — getLogs branches on -z $podName for the
+      # all-pods code path that reads running_pods.txt.
+      ;;
+    components)
+      # _wanted_components was populated + validated up-front. Bucket pods
+      # whose derived component is in the requested set.
+      local _p _bucket _c _hit
+      for _p in "${all_pods[@]}"; do
+        _bucket=$(_component_for_pod "$_p")
+        [[ -z "$_bucket" ]] && continue
+        _hit=0
+        for _c in "${_wanted_components[@]}"; do
+          [[ "$_bucket" == "$_c" ]] && _hit=1 && break
+        done
+        (( _hit )) && podNames+=("$_p")
+      done
+      if [[ ${#podNames[@]} -eq 0 ]]; then
+        printf "${_C_ERR}Error: no pods matched component(s) '%s' in namespace '%s'.${_C_RESET}\n" "$components_arg" "$namespace" >&2
+        return 1
+      fi
+      ;;
+    pods)
+      local _csv_pods _p _ap _found
+      IFS=',' read -ra _csv_pods <<< "$pods_csv"
+      for _p in "${_csv_pods[@]}"; do
+        _p="${_p//[[:space:]]/}"
+        [[ -z "$_p" ]] && continue
+        _found=0
+        for _ap in "${all_pods[@]}"; do
+          [[ "$_ap" == "$_p" ]] && _found=1 && break
+        done
+        if [[ $_found -eq 0 ]]; then
+          printf "${_C_ERR}Error: pod '%s' not found in namespace '%s'.${_C_RESET}\n" "$_p" "$namespace" >&2
+          if _is_known_component_name "$_p"; then
+            printf "  Hint: '%s' matches a known component bucket. Did you mean --components instead of --pods?\n" "$_p" >&2
+          fi
+          return 1
+        fi
+        if [[ -z "$(_component_for_pod "$_p")" ]]; then
+          printf "${_C_ERR}Error: pod '%s' is not a recognized Sysdig component.${_C_RESET}\n" "$_p" >&2
+          return 1
+        fi
+        podNames+=("$_p")
+      done
+      if [[ ${#podNames[@]} -eq 0 ]]; then
+        printf "${_C_ERR}Error: --pods list was empty after parsing.${_C_RESET}\n" >&2
+        return 1
+      fi
+      ;;
+  esac
+
+  # Output path + activity.log. Must happen AFTER namespace/scope validation so
+  # we don't leave a stale sysdig-support/ dir when the user passes bad args.
+  if ! _cli_setup_output_path "$output_dir_arg"; then
+    printf "${_C_ERR}Error: could not create output directory '%s'.${_C_RESET}\n" "${output_dir_arg:-$(pwd)}" >&2
+    return 1
+  fi
+  log_activity "CLI: collect agent (namespace=$namespace, mode=$mode, max_jobs=$MAX_JOBS)"
+
+  # ── Dispatch ──
+  case "$mode" in
+    all)
+      collectArtifacts
+      getLogs
+      createArchive
+      ;;
+    pods|components)
+      collectArtifacts
+
+      # One-shot per-cluster artifacts (dragent.yaml + csFeaturesStatus.json)
+      # from the first agent pod in scope. Same logic as interactive option 2.
+      _hoist_agent_oneshot_artifacts "${podNames[@]}"
+
+      # Per-pod yaml files (collectPodArtifacts is two cheap kubectl calls).
+      local _selected_pods=("${podNames[@]}")
+      for podName in "${_selected_pods[@]}"; do
+        collectPodArtifacts
+      done
+
+      # Parallel log workers, MAX_JOBS bounded — same as interactive option 2.
+      printf "Dispatching log collection for %d selected pods (%d parallel collector workers)...\n" "${#_selected_pods[@]}" "$MAX_JOBS"
+      _dispatch_pod_log_collection "${_selected_pods[@]}"
+
+      podName=""
+      podNames=("${_selected_pods[@]}")
+      createArchive
+      podNames=()
+      ;;
+  esac
+}
+
+# CLI helper for `collect agent --namespaces` (mirrors interactive option 3 —
+# collect_cross_namespace — without the interactive selection loops).
+#
+# Parses the per-namespace DSL into a plan:
+#   <entry>(,<entry>)*    where each <entry> is one of:
+#     ns                       all Sysdig pods in ns
+#     ns:pods=p1+p2+...        only those specific pods in ns
+#     ns:components=c1+c2+...  only those component buckets in ns
+#
+# Rules:
+#   - Each namespace appears at most once (duplicate → error).
+#   - "pods" and "components" cannot be mixed within one entry.
+#   - Component names must be in the known set; pod names must exist in the ns
+#     and be classified by _component_for_pod as a Sysdig component.
+#   - Output: one unified bundle with per-namespace subdirs, packed by
+#     createArchiveAll.
+#
+# Args: $1 = DSL CSV, $2 = output dir (passed through to setup helper).
+function _cli_collect_agent_multi_ns() {
+  local _csv="$1" _output_dir="$2"
+
+  # ─── Parse the CSV into per-namespace plan ───
+  # Parallel arrays for bash 3.2 portability:
+  #   _plan_ns[i]    = namespace
+  #   _plan_mode[i]  = "all" | "pods" | "components"
+  #   _plan_items[i] = space-separated names (empty when mode=all)
+  local -a _plan_ns=() _plan_mode=() _plan_items=()
+  local _entry _ns _rest _kind _items_str _items_clean
+
+  local -a _entries=()
+  IFS=',' read -ra _entries <<< "$_csv"
+
+  for _entry in "${_entries[@]+"${_entries[@]}"}"; do
+    _entry="${_entry//[[:space:]]/}"
+    [[ -z "$_entry" ]] && continue
+
+    if [[ "$_entry" == *:* ]]; then
+      _ns="${_entry%%:*}"
+      _rest="${_entry#*:}"
+      if [[ "$_rest" != *=* ]]; then
+        printf "${_C_ERR}Error: --namespaces entry '%s' is malformed (expected 'ns:kind=items').${_C_RESET}\n" "$_entry" >&2
+        return 1
+      fi
+      _kind="${_rest%%=*}"
+      _items_str="${_rest#*=}"
+      if [[ -z "$_ns" || -z "$_kind" || -z "$_items_str" ]]; then
+        printf "${_C_ERR}Error: --namespaces entry '%s': namespace, kind, and items must all be non-empty.${_C_RESET}\n" "$_entry" >&2
+        return 1
+      fi
+      if [[ "$_kind" != "pods" && "$_kind" != "components" ]]; then
+        printf "${_C_ERR}Error: --namespaces entry '%s': unknown kind '%s'. Use 'pods' or 'components'.${_C_RESET}\n" "$_entry" "$_kind" >&2
+        return 1
+      fi
+      # '+' separator → spaces; the result is a space-separated item list that
+      # the validation + dispatch loops iterate with the default word-splitting.
+      _items_clean="${_items_str//+/ }"
+      _plan_ns+=("$_ns")
+      _plan_mode+=("$_kind")
+      _plan_items+=("$_items_clean")
+    else
+      _plan_ns+=("$_entry")
+      _plan_mode+=("all")
+      _plan_items+=("")
+    fi
+  done
+
+  if [[ ${#_plan_ns[@]} -eq 0 ]]; then
+    printf "${_C_ERR}Error: --namespaces requires at least one namespace.${_C_RESET}\n" >&2
+    return 1
+  fi
+
+  # ─── Duplicate-namespace check (error, not silent dedupe) ───
+  local _i _j
+  for _i in "${!_plan_ns[@]}"; do
+    for _j in "${!_plan_ns[@]}"; do
+      if (( _j > _i )) && [[ "${_plan_ns[$_i]}" == "${_plan_ns[$_j]}" ]]; then
+        printf "${_C_ERR}Error: --namespaces contains duplicate entry '%s'.${_C_RESET}\n" "${_plan_ns[$_i]}" >&2
+        return 1
+      fi
+    done
+  done
+
+  # ─── Discovery + per-entry validation (fail-fast) ───
+  local _mode _items _name _bucket _known _hit _existing _line
+  local _valid_components="$AGENT_COMPONENT_BUCKETS"
+  local -a _all_pods_ns=()
+
+  for _i in "${!_plan_ns[@]}"; do
+    _ns="${_plan_ns[$_i]}"
+    _mode="${_plan_mode[$_i]}"
+    _items="${_plan_items[$_i]}"
+
+    resetDiscoveryVars
+    namespace="$_ns"
+    podNames=()
+    discoverComponents
+    if ! has_sysdig_components; then
+      printf "${_C_ERR}Error: no Sysdig components found in namespace '%s'.${_C_RESET}\n" "$_ns" >&2
+      return 1
+    fi
+
+    case "$_mode" in
+      all)
+        ;;
+      components)
+        for _name in $_items; do
+          _known=0
+          for _bucket in $_valid_components; do
+            [[ "$_name" == "$_bucket" ]] && _known=1 && break
+          done
+          if (( ! _known )); then
+            printf "${_C_ERR}Error: --namespaces: namespace '%s' references unknown component '%s'.${_C_RESET}\n" "$_ns" "$_name" >&2
+            printf "  Accepted: %s.\n" "${_valid_components// /, }" >&2
+            if _looks_like_pod_name "$_name"; then
+              printf "  Hint: '%s' looks like a pod name. Did you mean '%s:pods=%s'?\n" "$_name" "$_ns" "$_name" >&2
+            fi
+            return 1
+          fi
+        done
+        ;;
+      pods)
+        _all_pods_ns=()
+        while IFS= read -r _line; do
+          [[ -n "$_line" ]] && _all_pods_ns+=("$_line")
+        done < <($k8sCmd get pods -n "$_ns" --no-headers 2>/dev/null | awk '{print $1}')
+
+        for _name in $_items; do
+          _hit=0
+          for _existing in "${_all_pods_ns[@]+"${_all_pods_ns[@]}"}"; do
+            [[ "$_existing" == "$_name" ]] && _hit=1 && break
+          done
+          if (( ! _hit )); then
+            printf "${_C_ERR}Error: --namespaces: pod '%s' not found in namespace '%s'.${_C_RESET}\n" "$_name" "$_ns" >&2
+            if _is_known_component_name "$_name"; then
+              printf "  Hint: '%s' matches a known component bucket. Did you mean '%s:components=%s'?\n" "$_name" "$_ns" "$_name" >&2
+            fi
+            return 1
+          fi
+          if [[ -z "$(_component_for_pod "$_name")" ]]; then
+            printf "${_C_ERR}Error: --namespaces: pod '%s' in namespace '%s' is not a Sysdig component pod.${_C_RESET}\n" "$_name" "$_ns" >&2
+            return 1
+          fi
+        done
+        ;;
+    esac
+  done
+
+  # ─── Setup output path ───
+  if ! _cli_setup_output_path "$_output_dir"; then
+    printf "${_C_ERR}Error: could not create output directory '%s'.${_C_RESET}\n" "${_output_dir:-$(pwd)}" >&2
+    return 1
+  fi
+  log_activity "CLI: collect agent multi-namespace (entries=${#_plan_ns[@]}, max_jobs=$MAX_JOBS)"
+
+  # ─── Per-namespace collection ───
+  local base_support_dir="$SYSDIG_SUPPORT_DIR"
+  local primary_ns="${_plan_ns[0]}"
+  local _p
+  local -a _dispatch_pods
+
+  for _i in "${!_plan_ns[@]}"; do
+    _ns="${_plan_ns[$_i]}"
+    _mode="${_plan_mode[$_i]}"
+    _items="${_plan_items[$_i]}"
+
+    printf "\n  ── Namespace: %s (mode=%s) ──\n" "$_ns" "$_mode"
+    log_activity "Collecting for namespace: $_ns (mode=$_mode)"
+    namespace="$_ns"
+    SYSDIG_SUPPORT_DIR="$base_support_dir/$_ns"
+    mkdir -p "$DEST_DIR/$SYSDIG_SUPPORT_DIR"
+
+    # Re-run discovery — the previous namespace's prefixes / instance labels
+    # must not leak into this namespace's collection.
+    resetDiscoveryVars
+    discoverComponents
+    podName=""
+
+    if [[ "$_ns" == "$primary_ns" ]]; then
+      collectArtifacts
+    else
+      collectArtifactsNamespaceOnly
+    fi
+
+    # Build the dispatch pod list according to this namespace's plan entry.
+    _dispatch_pods=()
+    _all_pods_ns=()
+    while IFS= read -r _line; do
+      [[ -n "$_line" ]] && _all_pods_ns+=("$_line")
+    done < <($k8sCmd get pods -n "$namespace" --no-headers 2>/dev/null | awk '{print $1}')
+
+    case "$_mode" in
+      all)
+        # All pods in the namespace; the _phase1_collect_one_pod_logs early-exit
+        # filters out anything that isn't classified by _component_for_pod.
+        _dispatch_pods=("${_all_pods_ns[@]+"${_all_pods_ns[@]}"}")
+        ;;
+      pods)
+        for _name in $_items; do
+          _dispatch_pods+=("$_name")
+        done
+        ;;
+      components)
+        for _p in "${_all_pods_ns[@]+"${_all_pods_ns[@]}"}"; do
+          _bucket=$(_component_for_pod "$_p")
+          [[ -z "$_bucket" ]] && continue
+          for _name in $_items; do
+            if [[ "$_bucket" == "$_name" ]]; then
+              _dispatch_pods+=("$_p"); break
+            fi
+          done
+        done
+        if [[ ${#_dispatch_pods[@]} -eq 0 ]]; then
+          printf "  ${_C_WARN}Warning: namespace '%s' has no pods matching components: %s${_C_RESET}\n" "$_ns" "$_items"
+          log_activity "Namespace $_ns: no pods matched components ($_items); skipping log dispatch."
+          continue
+        fi
+        ;;
+    esac
+
+    # Hoist one-shot per-cluster agent artifacts from the first in-scope agent.
+    _hoist_agent_oneshot_artifacts "${_dispatch_pods[@]+"${_dispatch_pods[@]}"}"
+
+    # Parallel log workers, MAX_JOBS bounded.
+    printf "Dispatching log collection for %d pods in namespace '%s' (%d parallel collector workers)...\n" "${#_dispatch_pods[@]}" "$_ns" "$MAX_JOBS"
+    _dispatch_pod_log_collection "${_dispatch_pods[@]+"${_dispatch_pods[@]}"}"
+  done
+
+  podName=""
+  SYSDIG_SUPPORT_DIR="$base_support_dir"
+  createArchiveAll
+}
+
+# Top-level dispatcher for `collect`. Routes to a per-target collector:
+#   collect agent       — agent-side support bundle (logs, configs, manifests)
+#   collect platform    — platform/backend support bundle
+function cli_collect() {
+  case "${1:-}" in
+    ""|-h|--help)
+      print_help_collect
+      return 0
+      ;;
+    agent)
+      shift
+      cli_collect_agent "$@"
+      ;;
+    platform)
+      shift
+      cli_collect_platform "$@"
+      ;;
+    *)
+      printf "${_C_ERR}Error: unknown target for 'collect': %s${_C_RESET}\n" "$1" >&2
+      printf "  Run 'sysdig-log-collector collect --help' for usage.\n" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Help for the top-level `collect` command.
+function print_help_collect() {
+  cat <<'EOF'
+Collect a Sysdig support archive.
+
+Usage:
+  sysdig-log-collector collect <target> [flags]
+
+Available targets:
+  agent       Agent / Shield collection. Works for any cluster running the
+              Sysdig agent — SaaS or on-prem. Covers all installation forms:
+                - Shield chart
+                - sysdig-deploy chart
+                - Standalone agent sub-chart
+  platform    On-Prem Platform collection (sysdigcloud-* services + datastores
+              + optional API-backed data). On-prem only. Use --healthcheck for
+              a faster variant that skips per-container logs.
+
+Flags:
+  -h, --help    Show help and exit.
+
+Use "sysdig-log-collector collect <target> --help" for target-specific flags.
+EOF
+}
+
+function print_help_collect_platform() {
+  cat <<'EOF'
+Collect a Sysdig On-Prem Platform support bundle from a Kubernetes namespace.
+
+Usage:
+  sysdig-log-collector collect platform -n <namespace> [flags]
+
+Scope (pick one; default = everything in target namespace):
+  -n, --namespace <ns>     Platform namespace (required).
+  -A, --all                Default - Collect every platform pod in targeted namespace.
+      --components <list>  Collect specific platform components. <list> or --from-file.
+                           Run `sysdig-log-collector list platform components -n <ns>`
+                           to discover available components in your namespace.
+      --pods <list>        Collect specific pods. <list> or --from-file.
+
+Common:
+  -c, --context <name>     Kubectl context (defaults to current-context).
+  -o, --output-dir <path>  Bundle output directory (default: current directory).
+  -j, --max-jobs <N>       Parallel collector worker count (1-16; default 4).
+      --from-file <path>   File of pod or component names, one per line.
+                           Pairs with --pods or --components.
+      --since <duration>   kubectl logs --since= window (e.g. '1h', '24h', '30m').
+      --debug              Verbose worker output.
+      --healthcheck        Skip per-container log collection. Datastore telemetry,
+                           manifests, describes, cluster-info dump, and API
+                           data are still collected.
+  -h, --help               Show help and exit.
+
+Upload:
+  -u, --url <url>          Presigned S3 PUT URL. Archive is uploaded after
+                           collection. Pre-flight expiry check rejects stale URLs.
+                           Wrap the URL in single quotes (e.g., --url='https://...').
+      --no-save            Delete the local archive after a successful upload.
+                           Requires --url.
+
+API data (optional — collected alongside the bundle when set):
+  -a,  --api-key <key>     Sysdig Monitor SuperUser API key. Collects Monitor
+                           API data (license, alerts, users, teams, SSO, etc.).
+  -sa, --secure-api-key <key>
+                           Sysdig Secure SuperUser API key. Collects Secure API
+                           data (scanning v1/v2 results, etc.).
+  -la, --local-api         Use kubectl port-forward to reach the Sysdig API
+                           instead of the discovered URL. For airgapped or
+                           restricted environments. Requires --api-key or --secure-api-key.
+
+Examples:
+  sysdig-log-collector collect platform -n sysdigcloud
+  sysdig-log-collector collect platform -n sysdigcloud --components=cassandra,elasticsearch
+  sysdig-log-collector collect platform -n sysdigcloud --pods --from-file=pods.txt
+  sysdig-log-collector collect platform -n sysdigcloud --since=1h --healthcheck
+  sysdig-log-collector collect platform -n sysdigcloud --api-key XYZ --secure-api-key ABC
+  sysdig-log-collector collect platform -n sysdigcloud --url='<presigned-url>'
+EOF
+}
+
+# CLI entry point for `collect platform`. Default scope mirrors
+# interactive option 4 (automatic_platform_collector): everything in the
+# namespace. --components / --pods enable narrow scope (option 5's manual
+# narrow modes) — narrow scope skips cluster-info dump, describe-nodes,
+# storage, full namespace manifest dump, and container-density; uses
+# collectPlatformComponentRelated for workload-derived artifacts instead.
+# Datastore telemetry is automatically narrowed via _manual_datastore_in_scope.
+function cli_collect_platform() {
+  local ns_arg="" output_dir_arg="" context_arg=""
+  local max_jobs_arg="$MAX_JOBS_DEFAULT"
+  local since_arg="" debug_arg=0
+  local healthcheck_arg=0           # 1 = skip per-container logs (sets MANUAL_SKIP_LOGS)
+  local url_arg="" no_save=0
+  local mode="all"                  # all | components | pods
+  local components_arg="" pods_csv=""
+  local from_file=""
+  local _saw_all=0 _saw_components=0 _saw_pods=0
+  local api_key_arg="" secure_api_key_arg="" local_api=0   # legacy -a / -sa / -la equivalents
+
+  while (( $# > 0 )); do
+    case "$1" in
+      -h|--help)            print_help_collect_platform; return 0 ;;
+      -n|--namespace)
+        _require_value "$1" "${2:-}" || return 1
+        ns_arg="$2"; shift 2 ;;
+      --namespace=*)        ns_arg="${1#--namespace=}"; shift ;;
+      -n=*)                 ns_arg="${1#-n=}"; shift ;;
+      -c|--context)
+        _require_value "$1" "${2:-}" || return 1
+        context_arg="$2"; shift 2 ;;
+      --context=*)          context_arg="${1#--context=}"; shift ;;
+      -c=*)                 context_arg="${1#-c=}"; shift ;;
+      -o|--output-dir)
+        _require_value "$1" "${2:-}" || return 1
+        output_dir_arg="$2"; shift 2 ;;
+      --output-dir=*)       output_dir_arg="${1#--output-dir=}"; shift ;;
+      -o=*)                 output_dir_arg="${1#-o=}"; shift ;;
+      -j|--max-jobs)
+        _require_value "$1" "${2:-}" || return 1
+        max_jobs_arg="$2"; shift 2 ;;
+      --max-jobs=*)         max_jobs_arg="${1#--max-jobs=}"; shift ;;
+      -j=*)                 max_jobs_arg="${1#-j=}"; shift ;;
+      --since)
+        _require_value "$1" "${2:-}" || return 1
+        since_arg="$2"; shift 2 ;;
+      --since=*)            since_arg="${1#--since=}"; shift ;;
+      --debug)              debug_arg=1; shift ;;
+      # Healthcheck = skip per-container logs only. Datastore telemetry,
+      # manifests, describes, API data all still get collected (matches
+      # legacy get_support_bundle.sh's --skip-logs semantics).
+      --healthcheck)        healthcheck_arg=1; shift ;;
+      -u|--url)
+        if [[ -z "${2:-}" ]] || _looks_like_flag "$2"; then
+          _prompt_s3_url_cli url_arg "$1" || return 1
+          shift
+        else
+          url_arg="$2"; shift 2
+        fi
+        ;;
+      --url=*)
+        url_arg="${1#--url=}"
+        [[ -z "$url_arg" ]] && { _prompt_s3_url_cli url_arg "--url" || return 1; }
+        shift ;;
+      -u=*)
+        url_arg="${1#-u=}"
+        [[ -z "$url_arg" ]] && { _prompt_s3_url_cli url_arg "-u" || return 1; }
+        shift ;;
+      --no-save)            no_save=1; shift ;;
+      -A|--all)             mode="all"; _saw_all=1; shift ;;
+      --components)
+        if [[ -z "${2:-}" || "${2:0:1}" == "-" ]]; then
+          mode="components"; _saw_components=1; shift
+        else
+          components_arg="$2"; mode="components"; _saw_components=1; shift 2
+        fi ;;
+      --components=*)       components_arg="${1#--components=}"; mode="components"; _saw_components=1; shift ;;
+      --pods)
+        if [[ -z "${2:-}" || "${2:0:1}" == "-" ]]; then
+          mode="pods"; _saw_pods=1; shift
+        else
+          pods_csv="$2"; mode="pods"; _saw_pods=1; shift 2
+        fi ;;
+      --pods=*)             pods_csv="${1#--pods=}"; mode="pods"; _saw_pods=1; shift ;;
+      --from-file)
+        _require_value "$1" "${2:-}" || return 1
+        from_file="$2"; shift 2 ;;
+      --from-file=*)        from_file="${1#--from-file=}"; shift ;;
+      -a|--api-key)
+        _require_value "$1" "${2:-}" || return 1
+        api_key_arg="$2"; shift 2 ;;
+      --api-key=*)          api_key_arg="${1#--api-key=}"; shift ;;
+      -sa|--secure-api-key)
+        _require_value "$1" "${2:-}" || return 1
+        secure_api_key_arg="$2"; shift 2 ;;
+      --secure-api-key=*)   secure_api_key_arg="${1#--secure-api-key=}"; shift ;;
+      -la|--local-api)      local_api=1; shift ;;
+      *)
+        printf "${_C_ERR}Error: unknown flag for 'collect platform': %s${_C_RESET}\n" "$1" >&2
+        printf "  Run 'sysdig-log-collector collect platform --help' for usage.\n" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  # Validation
+  if [[ -z "$ns_arg" ]]; then
+    printf "${_C_ERR}Error: -n/--namespace is required.${_C_RESET}\n" >&2
+    printf "  Run 'sysdig-log-collector collect platform --help' for usage.\n" >&2
+    return 1
+  fi
+
+  # Scope mutex: -A/--all, --components, --pods are mutually exclusive.
+  local _scope_count=$(( _saw_all + _saw_components + _saw_pods ))
+  if (( _scope_count > 1 )); then
+    printf "${_C_ERR}Error: -A/--all, --components, and --pods are mutually exclusive.${_C_RESET}\n" >&2
+    printf "  Run 'sysdig-log-collector collect platform --help' for usage.\n" >&2
+    return 1
+  fi
+
+  # --from-file processing (same shape as agent CLI). Reads one name per line,
+  # rejects blank lines, joins into the inline-CSV form for downstream handling.
+  if [[ -n "$from_file" ]]; then
+    local _joined
+    _joined=$(_cli_read_from_file_csv "$mode" "$from_file" "$pods_csv" "$components_arg") || return 1
+    case "$mode" in
+      pods)       pods_csv="$_joined" ;;
+      components) components_arg="$_joined" ;;
+    esac
+  fi
+
+  if [[ "$mode" == "pods" && -z "$pods_csv" ]]; then
+    printf "${_C_ERR}Error: --pods requires a value (inline CSV or --from-file).${_C_RESET}\n" >&2
+    return 1
+  fi
+  if [[ "$mode" == "components" && -z "$components_arg" ]]; then
+    printf "${_C_ERR}Error: --components requires a value (inline CSV or --from-file).${_C_RESET}\n" >&2
+    return 1
+  fi
+
+  # Delivery validation (same shape as agent CLI).
+  _cli_validate_url_delivery "$url_arg" "$no_save" || return 1
+
+  # Wire kubectl context. _apply_kube_context builds $k8sCmd; downstream Phase-2
+  # functions inherit it automatically.
+  BASE_K8S_CMD="${BASE_K8S_CMD:-kubectl}"
+  K8S_CONTEXT="$context_arg"
+  _apply_kube_context
+
+  MAX_JOBS="$max_jobs_arg"
+  _validate_max_jobs
+
+  # Reset Phase-2 tunables that the interactive picker would otherwise set.
+  # Defaults match automatic_platform_collector (option 4): scope=all, no
+  # since filter, debug off, no skip-logs. Honor --since / --debug / --healthcheck.
+  MANUAL_COMPONENTS=""
+  MANUAL_PODS_FILTER=()
+  MANUAL_SCOPE_MODE=""
+  MANUAL_SINCE=""
+  MANUAL_SINCE_OPTS=""
+  MANUAL_SKIP_LOGS=false
+  (( healthcheck_arg )) && MANUAL_SKIP_LOGS=true
+  MANUAL_DEBUG=false
+  FAILED_PODS=()
+  if [[ -n "$since_arg" ]]; then
+    MANUAL_SINCE="$since_arg"
+    MANUAL_SINCE_OPTS="--since=$since_arg"
+  fi
+  (( debug_arg )) && MANUAL_DEBUG=true
+
+  # Sysdig Support team default — skip API-key prompts. The Professional
+  # Services API-key path is interactive-only for now.
+  REQUESTING_TEAM="support"
+  log_activity "CLI: Sysdig Support team requesting; skipping API key prompts."
+
+  # Namespace + platform validation (non-interactive equivalent of
+  # prepare_platform_context, minus the prompt loop).
+  namespace="$ns_arg"
+  if ! has_sysdig_platform; then
+    printf "${_C_ERR}Error: namespace '%s' is not a Sysdig on-prem platform namespace ('sysdigcloud-api' deployment not found).${_C_RESET}\n" "$namespace" >&2
+    return 1
+  fi
+  detect_platform_backend_version
+
+  # ── Narrow-scope resolution ──
+  # For --components: validate names against PLATFORM_COMPONENTS (discovered
+  # from the live namespace; the picker's exact source). Resolve to a pod
+  # filter for downstream MANUAL_PODS_FILTER.
+  # For --pods: validate names against the namespace's pod list, then use
+  # them directly as MANUAL_PODS_FILTER.
+  if [[ "$mode" == "components" || "$mode" == "pods" ]]; then
+    _discover_platform_components
+  fi
+
+  if [[ "$mode" == "components" ]]; then
+    local -a _wanted_comp=()
+    local _csv_comps _c _bucket _known _i _pods_in_comp _p
+    IFS=',' read -ra _csv_comps <<< "$components_arg"
+    for _c in "${_csv_comps[@]}"; do
+      _c="${_c//[[:space:]]/}"
+      [[ -z "$_c" ]] && continue
+      _known=0
+      for _bucket in "${PLATFORM_COMPONENTS[@]+"${PLATFORM_COMPONENTS[@]}"}"; do
+        [[ "$_c" == "$_bucket" ]] && _known=1 && break
+      done
+      if (( ! _known )); then
+        printf "${_C_ERR}Error: unknown platform component '%s' in namespace '%s'.${_C_RESET}\n" "$_c" "$namespace" >&2
+        printf "  Discovered: %s.\n" "${PLATFORM_COMPONENTS[*]:-<none>}" >&2
+        if _looks_like_pod_name "$_c"; then
+          printf "  Hint: '%s' looks like a pod name. Did you mean --pods instead of --components?\n" "$_c" >&2
+        fi
+        return 1
+      fi
+      _wanted_comp+=("$_c")
+    done
+    if [[ ${#_wanted_comp[@]} -eq 0 ]]; then
+      printf "${_C_ERR}Error: --components list was empty after parsing.${_C_RESET}\n" >&2
+      return 1
+    fi
+    # Resolve component → pods via the parallel arrays from _discover_platform_components.
+    MANUAL_PODS_FILTER=()
+    for _c in "${_wanted_comp[@]}"; do
+      for _i in "${!PLATFORM_COMPONENTS[@]}"; do
+        if [[ "${PLATFORM_COMPONENTS[$_i]}" == "$_c" ]]; then
+          _pods_in_comp="${PLATFORM_COMPONENT_PODS_STR[$_i]}"
+          for _p in $_pods_in_comp; do
+            MANUAL_PODS_FILTER+=("$_p")
+          done
+          break
+        fi
+      done
+    done
+    MANUAL_SCOPE_MODE="components"
+    MANUAL_COMPONENTS="${_wanted_comp[*]}"
+    MANUAL_COMPONENTS="${MANUAL_COMPONENTS// /,}"
+    log_activity "CLI narrow scope: components=$MANUAL_COMPONENTS (${#MANUAL_PODS_FILTER[@]} pods)"
+  fi
+
+  if [[ "$mode" == "pods" ]]; then
+    # Validate each pod against the full namespace pod list.
+    local -a _wanted_pods=() _all_ns_pods=()
+    local _line _hit _ap _csv_pods _p
+    while IFS= read -r _line; do
+      [[ -n "$_line" ]] && _all_ns_pods+=("$_line")
+    done < <($k8sCmd get pods -n "$namespace" --no-headers \
+      -o custom-columns="NAME:metadata.name,OWNER:metadata.ownerReferences[0].kind" 2>/dev/null \
+      | awk '$2 != "Job" { print $1 }')
+    IFS=',' read -ra _csv_pods <<< "$pods_csv"
+    for _p in "${_csv_pods[@]}"; do
+      _p="${_p//[[:space:]]/}"
+      [[ -z "$_p" ]] && continue
+      _hit=0
+      for _ap in "${_all_ns_pods[@]+"${_all_ns_pods[@]}"}"; do
+        [[ "$_ap" == "$_p" ]] && _hit=1 && break
+      done
+      if (( ! _hit )); then
+        printf "${_C_ERR}Error: pod '%s' not found in namespace '%s'.${_C_RESET}\n" "$_p" "$namespace" >&2
+        # Hint: if name matches a discovered component bucket, suggest --components.
+        local _c
+        for _c in "${PLATFORM_COMPONENTS[@]+"${PLATFORM_COMPONENTS[@]}"}"; do
+          if [[ "$_c" == "$_p" ]]; then
+            printf "  Hint: '%s' matches a discovered platform component. Did you mean --components instead of --pods?\n" "$_p" >&2
+            break
+          fi
+        done
+        return 1
+      fi
+      _wanted_pods+=("$_p")
+    done
+    if [[ ${#_wanted_pods[@]} -eq 0 ]]; then
+      printf "${_C_ERR}Error: --pods list was empty after parsing.${_C_RESET}\n" >&2
+      return 1
+    fi
+    MANUAL_PODS_FILTER=("${_wanted_pods[@]}")
+    MANUAL_SCOPE_MODE="pods"
+    log_activity "CLI narrow scope: pods=${MANUAL_PODS_FILTER[*]}"
+  fi
+
+  _populate_sysdigcloud_pods
+  if [[ ${#SYSDIGCLOUD_PODS[@]} -eq 0 ]]; then
+    printf "${_C_ERR}Error: no collectable pods found in namespace '%s' (Job pods are excluded).${_C_RESET}\n" "$namespace" >&2
+    return 1
+  fi
+
+  # Legacy -a / -sa / -la equivalent. --local-api alone is meaningless;
+  # require at least one key. _cli_setup_api_keys returns 0 as a no-op when
+  # neither key (nor env-var fallback) is set, so the existing pipeline's
+  # "skipped" branch fires naturally.
+  if (( local_api )) && [[ -z "$api_key_arg" && -z "$secure_api_key_arg" && -z "${SYSDIG_API_KEY:-}" && -z "${SYSDIG_SECURE_API_KEY:-}" ]]; then
+    printf "${_C_ERR}Error: --local-api requires --api-key or --secure-api-key.${_C_RESET}\n" >&2
+    return 1
+  fi
+  if ! _cli_setup_api_keys "$api_key_arg" "$secure_api_key_arg" "$local_api"; then
+    return 1
+  fi
+
+  # Output path + activity.log (validation done — safe to materialize the dir).
+  if ! _cli_setup_output_path "$output_dir_arg"; then
+    printf "${_C_ERR}Error: could not create output directory '%s'.${_C_RESET}\n" "${output_dir_arg:-$(pwd)}" >&2
+    stop_platform_portforward
+    return 1
+  fi
+
+  # Working subdir — same shape automatic_platform_collector uses.
+  PLATFORM_LOG_DIR=$(mktemp -d "${DEST_DIR}/${SYSDIG_SUPPORT_DIR}/sysdigcloud-support-bundle-XXXX") || {
+    printf "${_C_ERR}Error: could not create platform working directory.${_C_RESET}\n" >&2
+    log_activity "Failed to create PLATFORM_LOG_DIR."
+    return 1
+  }
+  log_activity "PLATFORM_LOG_DIR: $PLATFORM_LOG_DIR  MAX_JOBS: $MAX_JOBS  SINCE: $MANUAL_SINCE  SKIP_LOGS: $MANUAL_SKIP_LOGS  DEBUG: $MANUAL_DEBUG"
+  printf "\n  Working directory: %s  (%d parallel collector workers)\n\n" "$PLATFORM_LOG_DIR" "$MAX_JOBS"
+
+  PLATFORM_FAIL_DIR="$PLATFORM_LOG_DIR/.failed_containers"
+  mkdir -p "$PLATFORM_FAIL_DIR"
+  export MANUAL_SINCE_OPTS MANUAL_DEBUG PLATFORM_FAIL_DIR
+
+  _cli_run_platform_collection_pipeline
+}
+
+# Shared platform-collection pipeline. Called by cli_collect_platform after
+# its arg parser has set up the MANUAL_* globals + PLATFORM_LOG_DIR. The
+# pipeline branches on the scope
+# mode (narrow vs wide) and honors MANUAL_SKIP_LOGS for the log-collection step.
+function _cli_run_platform_collection_pipeline() {
+  log_activity "CLI: collect platform (namespace=$namespace, mode=${MANUAL_SCOPE_MODE:-all}, skip_logs=${MANUAL_SKIP_LOGS:-false}, max_jobs=$MAX_JOBS)"
+
+  collectPlatformBackendVersion
+  collectPlatformRunningPods
+
+  if _manual_scope_is_narrow; then
+    log_activity "Narrow scope: skipping cluster-info dump / nodes / storage / full manifests / container-density."
+  else
+    printf "Starting cluster-info dump in background\n"
+    log_activity "Starting cluster-info dump (background)."
+    run_bg "cluster-info-dump" $k8sCmd cluster-info dump --namespaces="kube-system,$namespace" --output-directory="$PLATFORM_LOG_DIR/kubectl-cluster-dump"
+  fi
+
+  # collectPlatformPodsLogs is the per-container log + support-files step.
+  # It honors MANUAL_SKIP_LOGS internally — healthcheck mode flips this to skip
+  # the per-pod log collection entirely while keeping every other artifact.
+  collectPlatformPodsLogs
+  wait_all
+  if ! _manual_scope_is_narrow; then
+    printf "${_C_OK}Cluster-info dump complete.${_C_RESET}\n"
+    log_activity "Cluster-info dump complete."
+  fi
+  log_activity "Per-container log + support-files collection complete."
+  _emit_platform_pod_logs_summary
+
+  collectPlatformPodsDescribe
+  if ! _manual_scope_is_narrow; then
+    collectPlatformNodes
+    wait_all
+    printf "${_C_OK}Describe-nodes + per-node JSON collected.${_C_RESET}\n"
+    log_activity "Describe-nodes + per-node JSON collection complete."
+    collectPlatformStorage
+    collectPlatformManifests
+    wait_all
+    printf "${_C_OK}Manifest collection complete.${_C_RESET}\n"
+    log_activity "Manifest collection complete."
+    collectPlatformContainerDensity
+  else
+    collectPlatformComponentRelated
+  fi
+  collectPlatformConfigMap
+
+  log_activity "Scheduling datastore telemetry (parallelized, narrow-scope-aware)."
+  _dispatch_datastore_collectors
+  wait_all
+  log_activity "Datastore telemetry complete."
+
+  # API data collection. _cli_setup_api_keys (called earlier by the caller)
+  # populates MONITOR_API_KEY / SECURE_API_KEY / SYSDIG_PRODUCT when the user
+  # passed --api-key / --secure-api-key (or set the env-var fallback); without
+  # those, this block falls into the "skipped" branch and the bundle is
+  # produced without API artifacts — same shape interactive option 4 takes
+  # when the user picks the Sysdig Support team.
+  if [[ -n "$MONITOR_API_KEY" || -n "$SECURE_API_KEY" ]]; then
+    case "$SYSDIG_PRODUCT" in
+      monitor)  collectPlatformMonitorApi ;;
+      secure)   collectPlatformSecureApi ;;
+      platform) collectPlatformMonitorApi; collectPlatformSecureApi ;;
+    esac
+  else
+    log_activity "No API keys provided; API collection skipped entirely."
+  fi
+  stop_platform_portforward
+  # Wipe key material from memory; the archive does not contain it.
+  MONITOR_API_KEY=""
+  SECURE_API_KEY=""
+
+  createPlatformArchive
+  log_activity "CLI: collect platform complete."
+}
+
+# ─────────────────────────────────────────────
+#  Entry point
+# ─────────────────────────────────────────────
+
+# Global signal traps. Apply to every phase + every screen, including the
+# very first disclaimer prompt. Ctrl+C, Ctrl+Z, `kill <pid>`, and terminal
+# close all funnel through the same cleanup. (Conventional Unix Ctrl+Z
+# suspension is intentionally overridden — for an interactive support utility,
+# accidental suspension is more confusing than useful.) Registered before
+# disclaimer / initVar so the user can always exit cleanly with Ctrl+C.
+trap '_cleanup_on_signal INT'  INT
+trap '_cleanup_on_signal TERM' TERM
+trap '_cleanup_on_signal TSTP' TSTP
+trap '_cleanup_on_signal HUP'  HUP
+
+# ─────────────────────────────────────────────────────────────────────────────
+# `list` command — discovery helper. Prints component / pod names for a
+# given target+namespace so operators can pipe to a file and feed it to
+# `collect <target> --from-file=…`. Reads from the live cluster but writes
+# nothing; no archive is produced.
+# ─────────────────────────────────────────────────────────────────────────────
+
+function print_help_list() {
+  cat <<'EOF'
+List component or pod names in the live cluster — useful for building
+--from-file inputs for `collect`.
+
+Usage:
+  sysdig-log-collector list <target> [kind] [flags]
+
+Available targets:
+  agent       Agent-side components / pods. Supports single-namespace listing
+              via -n, or multi-namespace inventory via --namespaces=ns1,ns2,...
+  platform    On-Prem Platform components / pods. Single namespace only.
+
+Run 'sysdig-log-collector list <target> --help' for target-specific flags and examples.
+EOF
+}
+
+function print_help_list_agent() {
+  cat <<'EOF'
+List Sysdig agent-side components / pods in one or more namespaces.
+
+Usage:
+  sysdig-log-collector list agent [kind] [flags]
+
+Kinds (optional; default 'components'):
+  components  Show distinct component buckets (agent, kspm-collector, etc.).
+  pods        Show every Sysdig-classified pod, with its component bucket.
+
+Single-namespace flags:
+  -n, --namespace <ns>     Target namespace (required unless --namespaces is used).
+      --no-headers         Strip headers; emit bare names only — pipe-friendly
+                           output suitable for redirecting into --from-file.
+      --status <state>     (pods only) filter by pod status, e.g. Running or
+                           CrashLoopBackOff. Comma-separate to include multiple
+                           states.
+      --components <list>  (pods only) filter pods by component bucket, comma-
+                           separated. Use this to preview which pods a
+                           `collect agent --components=...` run would target.
+
+Multi-namespace mode:
+      --namespaces <list>  Comma-separated list of namespaces; iterate the listing
+                           across each. Mutually exclusive with -n/--namespace.
+                           Output is sectioned per namespace. --no-headers is NOT
+                           allowed in this mode.
+
+Shared flags:
+  -c, --context <name>     Kubectl context (defaults to current-context).
+  -h, --help               Show help and exit.
+
+Examples:
+  sysdig-log-collector list agent components -n sysdig-agent
+  sysdig-log-collector list agent pods       -n sysdig-agent --status=CrashLoopBackOff
+  sysdig-log-collector list agent pods       -n sysdig-agent --no-headers > /tmp/pods.txt
+  sysdig-log-collector collect agent -n sysdig-agent --pods --from-file=/tmp/pods.txt
+  sysdig-log-collector list agent components --namespaces=sysdig-agent,sysdig-admission-controller
+EOF
+}
+
+function print_help_list_platform() {
+  cat <<'EOF'
+List Sysdig on-prem platform components / pods in the platform namespace.
+
+Usage:
+  sysdig-log-collector list platform [kind] [flags]
+
+Kinds (optional; default 'components'):
+  components  Show distinct component buckets (cassandra, postgres, neo4j, etc.).
+  pods        Show every platform pod, with its component bucket.
+
+Flags:
+  -n, --namespace <ns>     Platform namespace (required).
+  -c, --context <name>     Kubectl context (defaults to current-context).
+      --no-headers         Strip headers; emit bare names only — pipe-friendly
+                           output suitable for redirecting into --from-file.
+      --status <state>     (pods only) filter by pod status, e.g. Running or
+                           CrashLoopBackOff. Comma-separate to include multiple
+                           states.
+      --components <list>  (pods only) filter pods by component bucket, comma-
+                           separated. Use this to preview which pods a
+                           `collect platform --components=...` run would target.
+  -h, --help               Show help and exit.
+
+Note:
+  --namespaces is intentionally not available for the platform target — on-prem
+  Sysdig platform components always live in a single namespace.
+
+Examples:
+  sysdig-log-collector list platform components -n sysdigcloud
+  sysdig-log-collector list platform pods       -n sysdigcloud --status=CrashLoopBackOff
+  sysdig-log-collector list platform pods       -n sysdigcloud --no-headers > /tmp/pods.txt
+  sysdig-log-collector collect platform -n sysdigcloud --pods --from-file=/tmp/pods.txt
+EOF
+}
+
+# Top-level `list` dispatcher. Routes to per-target helpers.
+function cli_list() {
+  case "${1:-}" in
+    ""|-h|--help) print_help_list; return 0 ;;
+    agent)        shift; cli_list_agent "$@" ;;
+    platform)     shift; cli_list_platform "$@" ;;
+    *)
+      printf "${_C_ERR}Error: unknown target for 'list': %s${_C_RESET}\n" "$1" >&2
+      printf "  Run 'sysdig-log-collector list --help' for usage.\n" >&2
+      return 1 ;;
+  esac
+}
+
+# Shared arg parser for `list <target> [kind]`. Sets:
+#   _LIST_KIND            components | pods   (default: components)
+#   _LIST_NS              namespace            (single-ns mode)
+#   _LIST_NAMESPACES_CSV  CSV of namespaces    (multi-ns agent mode)
+#   _LIST_CONTEXT         kubectl context      (optional)
+#   _LIST_NO_HEADERS      0 | 1
+#   _LIST_STATUS          comma-separated state filter (pods only; empty = no filter)
+#   _LIST_COMPONENTS      comma-separated bucket filter (pods only; empty = no filter)
+function _cli_list_parse_args() {
+  _LIST_KIND="components"
+  _LIST_NS=""
+  _LIST_NAMESPACES_CSV=""
+  _LIST_CONTEXT=""
+  _LIST_NO_HEADERS=0
+  _LIST_STATUS=""
+  _LIST_COMPONENTS=""
+  # First positional arg (if not a flag) is the kind.
+  if [[ -n "${1:-}" && "$1" != -* && "$1" != "--"* ]]; then
+    case "$1" in
+      components|pods) _LIST_KIND="$1"; shift ;;
+      *) printf "${_C_ERR}Error: unknown kind '%s' (expected 'components' or 'pods').${_C_RESET}\n" "$1" >&2; return 1 ;;
+    esac
+  fi
+  while (( $# > 0 )); do
+    case "$1" in
+      -h|--help)            return 99 ;;  # caller prints help
+      -n|--namespace)
+        [[ -z "${2:-}" || "$2" == -* ]] && { printf "${_C_ERR}Error: %s requires a value.${_C_RESET}\n" "$1" >&2; return 1; }
+        _LIST_NS="$2"; shift 2 ;;
+      --namespace=*)        _LIST_NS="${1#--namespace=}"; shift ;;
+      -n=*)                 _LIST_NS="${1#-n=}"; shift ;;
+      --namespaces)
+        [[ -z "${2:-}" || "$2" == -* ]] && { printf "${_C_ERR}Error: %s requires a value.${_C_RESET}\n" "$1" >&2; return 1; }
+        _LIST_NAMESPACES_CSV="$2"; shift 2 ;;
+      --namespaces=*)       _LIST_NAMESPACES_CSV="${1#--namespaces=}"; shift ;;
+      -c|--context)
+        [[ -z "${2:-}" || "$2" == -* ]] && { printf "${_C_ERR}Error: %s requires a value.${_C_RESET}\n" "$1" >&2; return 1; }
+        _LIST_CONTEXT="$2"; shift 2 ;;
+      --context=*)          _LIST_CONTEXT="${1#--context=}"; shift ;;
+      -c=*)                 _LIST_CONTEXT="${1#-c=}"; shift ;;
+      --no-headers)         _LIST_NO_HEADERS=1; shift ;;
+      --status)
+        [[ -z "${2:-}" || "$2" == -* ]] && { printf "${_C_ERR}Error: %s requires a value.${_C_RESET}\n" "$1" >&2; return 1; }
+        _LIST_STATUS="$2"; shift 2 ;;
+      --status=*)           _LIST_STATUS="${1#--status=}"; shift ;;
+      --components)
+        [[ -z "${2:-}" || "$2" == -* ]] && { printf "${_C_ERR}Error: %s requires a value.${_C_RESET}\n" "$1" >&2; return 1; }
+        _LIST_COMPONENTS="$2"; shift 2 ;;
+      --components=*)       _LIST_COMPONENTS="${1#--components=}"; shift ;;
+      *)
+        printf "${_C_ERR}Error: unknown flag for 'list': %s${_C_RESET}\n" "$1" >&2
+        return 1 ;;
+    esac
+  done
+  if [[ -n "$_LIST_NS" && -n "$_LIST_NAMESPACES_CSV" ]]; then
+    printf "${_C_ERR}Error: -n/--namespace and --namespaces are mutually exclusive.${_C_RESET}\n" >&2
+    return 1
+  fi
+  if [[ -n "$_LIST_NAMESPACES_CSV" && $_LIST_NO_HEADERS -eq 1 ]]; then
+    printf "${_C_ERR}Error: --no-headers is not supported with --namespaces.${_C_RESET}\n" >&2
+    printf "  --no-headers exists to feed --from-file, which only works with a single namespace.\n" >&2
+    printf "  For multi-namespace inventory, use the default table output.\n" >&2
+    return 1
+  fi
+  if [[ -z "$_LIST_NS" && -z "$_LIST_NAMESPACES_CSV" ]]; then
+    printf "${_C_ERR}Error: -n/--namespace (or --namespaces) is required.${_C_RESET}\n" >&2
+    return 1
+  fi
+  if [[ -n "$_LIST_COMPONENTS" && "$_LIST_KIND" != "pods" ]]; then
+    printf "${_C_ERR}Error: --components is only valid with the 'pods' kind.${_C_RESET}\n" >&2
+    printf "  For the 'components' kind, listing already shows distinct buckets — no filter is needed.\n" >&2
+    return 1
+  fi
+  return 0
+}
+
+# Returns 0 if a pod's status passes the --status filter (or no filter set).
+function _list_status_match() {
+  local _have="$1"
+  [[ -z "$_LIST_STATUS" ]] && return 0
+  local _want
+  IFS=',' read -ra _want <<<"$_LIST_STATUS"
+  local _s
+  for _s in "${_want[@]}"; do
+    [[ "$_have" == "$_s" ]] && return 0
+  done
+  return 1
+}
+
+# Returns 0 if a pod's component bucket passes the --components filter (or no filter set).
+function _list_components_match() {
+  local _have="$1"
+  [[ -z "$_LIST_COMPONENTS" ]] && return 0
+  local _want
+  IFS=',' read -ra _want <<<"$_LIST_COMPONENTS"
+  local _c
+  for _c in "${_want[@]}"; do
+    [[ "$_have" == "$_c" ]] && return 0
+  done
+  return 1
+}
+
+# Resolve a pod's display status for the `list` --status filter. A pod that has
+# run at least one container surfaces a container waiting/terminated reason
+# (CrashLoopBackOff, Error, OOMKilled, Completed, ...) — exactly the states an
+# operator can still pull logs from; a pod that never started a container has no
+# such reason and falls back to .status.phase (Pending/Running/...). This is
+# deliberately NOT a full reproduction of kubectl's STATUS column — a log
+# collector only needs enough fidelity to tell "ran, has logs" from "never
+# started". The _list_platform_buckets_raw awk path mirrors this same rule
+# inline (keep the two in sync). Waiting wins over terminated so a crash-looping
+# pod reports CrashLoopBackOff rather than its last terminated reason (Error).
+# The reason fields arrive as kubectl custom-columns values: a comma-joined list
+# across containers, or the literal "<none>" when no container has that state.
+# Args: phase waiting_csv terminated_csv. Echoes a single status token.
+function _derive_pod_status() {
+  local _phase="$1" _wait="$2" _term="$3" _field _tok
+  for _field in "$_wait" "$_term"; do
+    [[ -z "$_field" || "$_field" == "<none>" ]] && continue
+    local _IFS_save="$IFS"; IFS=','
+    for _tok in $_field; do
+      if [[ -n "$_tok" && "$_tok" != "<none>" ]]; then
+        IFS="$_IFS_save"; echo "$_tok"; return 0
+      fi
+    done
+    IFS="$_IFS_save"
+  done
+  echo "$_phase"
+}
+
+function cli_list_agent() {
+  _cli_list_parse_args "$@"
+  local _rc=$?
+  (( _rc == 99 )) && { print_help_list_agent; return 0; }
+  (( _rc != 0 )) && return $_rc
+  BASE_K8S_CMD="${BASE_K8S_CMD:-kubectl}"
+  [[ -n "$_LIST_CONTEXT" ]] && k8sCmd="$BASE_K8S_CMD --context=$_LIST_CONTEXT" || k8sCmd="$BASE_K8S_CMD"
+
+  # Reuse Phase-1 discovery to populate the SYSDIG_*_PREFIX values and
+  # the SYSDIG_AGENT_IS_SHIELD_HOST flag. Suppress its stdout chatter so
+  # only our table reaches the terminal.
+  if [[ -n "$_LIST_NAMESPACES_CSV" ]]; then
+    local _ns_list _ns _first=1
+    IFS=',' read -ra _ns_list <<<"$_LIST_NAMESPACES_CSV"
+    for _ns in "${_ns_list[@]}"; do
+      _ns="${_ns// /}"
+      [[ -z "$_ns" ]] && continue
+      namespace="$_ns"
+      resetDiscoveryVars
+      discoverComponents >/dev/null 2>&1
+      (( _first == 0 )) && echo ""
+      printf "── Namespace: %s ──\n" "$_ns"
+      _first=0
+      if [[ "$_LIST_KIND" == "components" ]]; then
+        _list_agent_components
+      else
+        _list_agent_pods
+      fi
+    done
+  else
+    namespace="$_LIST_NS"
+    resetDiscoveryVars
+    discoverComponents >/dev/null 2>&1
+    if [[ "$_LIST_KIND" == "components" ]]; then
+      _list_agent_components
+    else
+      _list_agent_pods
+    fi
+  fi
+}
+
+# Render `sort | uniq -c` output (lines of "<count> <name...>") read on stdin as
+# a left-aligned COMPONENTS / PODS table with auto-sized name column.
+function _print_component_count_table() {
+  awk '
+    { name=$2; for (i=3;i<=NF;i++) name=name" "$i; cnt[NR]=$1; nm[NR]=name; if (length(name) > maxw) maxw=length(name) }
+    END {
+      hdr="COMPONENTS"
+      if (length(hdr) > maxw) maxw=length(hdr)
+      printf "%-*s  %s\n", maxw, hdr, "PODS"
+      for (i=1;i<=NR;i++) printf "%-*s  %s\n", maxw, nm[i], cnt[i]
+    }'
+}
+
+# Render tab-separated "pod<TAB>component<TAB>status" rows read on stdin as a
+# POD NAME / COMPONENT / STATUS table with auto-sized columns.
+function _print_pod_table() {
+  awk -F'\t' '
+    { pod[NR]=$1; comp[NR]=$2; st[NR]=$3
+      if (length($1) > maxp) maxp=length($1)
+      if (length($2) > maxc) maxc=length($2) }
+    END {
+      hp="POD NAME"; hc="COMPONENT"
+      if (length(hp) > maxp) maxp=length(hp)
+      if (length(hc) > maxc) maxc=length(hc)
+      printf "%-*s  %-*s  %s\n", maxp, hp, maxc, hc, "STATUS"
+      for (i=1;i<=NR;i++) printf "%-*s  %-*s  %s\n", maxp, pod[i], maxc, comp[i], st[i]
+    }'
+}
+
+function _list_agent_components() {
+  # Build a list of one component-name per matched pod, then sort | uniq -c.
+  # Avoids `declare -A` because the script must run on macOS bash 3.2.
+  local _pods _p _comp _bucket_list
+  _pods=$($k8sCmd get pods -n "$namespace" --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null)
+  _bucket_list=""
+  for _p in $_pods; do
+    _comp=$(_component_for_pod "$_p")
+    [[ -z "$_comp" ]] && continue
+    _bucket_list+="$_comp"$'\n'
+  done
+  if [[ -z "$_bucket_list" ]]; then
+    [[ $_LIST_NO_HEADERS -eq 0 ]] && printf "${_C_WARN}No Sysdig agent-side components found in namespace '%s'.${_C_RESET}\n" "$namespace"
+    return 0
+  fi
+  if (( _LIST_NO_HEADERS )); then
+    printf '%s' "$_bucket_list" | sort -u
+  else
+    printf '%s' "$_bucket_list" | sort | uniq -c | _print_component_count_table
+  fi
+}
+
+function _list_agent_pods() {
+  # POD NAME | COMPONENT | STATUS — only pods classified as Sysdig (image regex match).
+  # STATUS is derived (container reason → phase) by _derive_pod_status so the
+  # --status filter can target collectable failure states (CrashLoopBackOff, ...)
+  # rather than just the coarse pod phase. Columns: NAME PHASE WAIT TERM.
+  local _rows _name _phase _wait _term _status _comp _emitted=0 _filtered=""
+  _rows=$($k8sCmd get pods -n "$namespace" --no-headers \
+    -o custom-columns="NAME:.metadata.name,PHASE:.status.phase,WAIT:.status.containerStatuses[*].state.waiting.reason,TERM:.status.containerStatuses[*].state.terminated.reason" 2>/dev/null)
+  # --no-headers mode: stream bare pod names, no buffering needed.
+  if (( _LIST_NO_HEADERS )); then
+    while IFS=$' \t' read -r _name _phase _wait _term; do
+      [[ -z "$_name" ]] && continue
+      _comp=$(_component_for_pod "$_name")
+      [[ -z "$_comp" ]] && continue
+      _status=$(_derive_pod_status "$_phase" "$_wait" "$_term")
+      _list_components_match "$_comp" || continue
+      _list_status_match "$_status" || continue
+      printf "%s\n" "$_name"
+    done <<<"$_rows"
+    return 0
+  fi
+  # Table mode: buffer matching rows, then let awk compute per-column widths.
+  while IFS=$' \t' read -r _name _phase _wait _term; do
+    [[ -z "$_name" ]] && continue
+    _comp=$(_component_for_pod "$_name")
+    [[ -z "$_comp" ]] && continue
+    _status=$(_derive_pod_status "$_phase" "$_wait" "$_term")
+    _list_components_match "$_comp" || continue
+    _list_status_match "$_status" || continue
+    _filtered+="$_name"$'\t'"$_comp"$'\t'"$_status"$'\n'
+    _emitted=1
+  done <<<"$_rows"
+  if (( _emitted == 0 )); then
+    printf "${_C_WARN}No matching Sysdig agent-side pods in namespace '%s'.${_C_RESET}\n" "$namespace"
+    return 0
+  fi
+  printf '%s' "$_filtered" | _print_pod_table
+}
+
+function cli_list_platform() {
+  _cli_list_parse_args "$@"
+  local _rc=$?
+  (( _rc == 99 )) && { print_help_list_platform; return 0; }
+  (( _rc != 0 )) && return $_rc
+  if [[ -n "$_LIST_NAMESPACES_CSV" ]]; then
+    printf "${_C_ERR}Error: --namespaces is not supported for the 'platform' target.${_C_RESET}\n" >&2
+    printf "  On-prem Sysdig platform components always live in a single namespace.\n" >&2
+    printf "  Use -n/--namespace <ns> instead (typically 'sysdigcloud').\n" >&2
+    return 1
+  fi
+  namespace="$_LIST_NS"
+  BASE_K8S_CMD="${BASE_K8S_CMD:-kubectl}"
+  [[ -n "$_LIST_CONTEXT" ]] && k8sCmd="$BASE_K8S_CMD --context=$_LIST_CONTEXT" || k8sCmd="$BASE_K8S_CMD"
+
+  if [[ "$_LIST_KIND" == "components" ]]; then
+    _list_platform_components
+  else
+    _list_platform_pods
+  fi
+}
+
+# Platform component bucketing: role label OR owner-workload (stripped of ReplicaSet
+# hash) OR "(unlabeled)". Mirrors _discover_platform_components but skips Phase-1
+# workloads (agent/shield etc.) so they don't appear here.
+function _list_platform_buckets_raw() {
+  local _agent_re='agent-slim|agent$|cluster-shield|kspm-analyzer|host-scanner|runtime-scanner|host-analyzer|node-image-analyzer|compliance-benchmark-runner|eveclient-api|kspm-collector|admission-controller|secure-admission-controller|inline-scan-service|runtime-status-integrator|image-sbom-extractor|rapid-response-host-component'
+  # Columns: NAME ROLE OWNER_KIND OWNER_NAME PHASE WAIT TERM IMAGE. STATUS is
+  # derived (container reason → phase) by the derive_status() awk function, which
+  # mirrors the shell _derive_pod_status helper — keep the two in sync.
+  $k8sCmd get pods -n "$namespace" --no-headers \
+    -o custom-columns="NAME:metadata.name,ROLE:metadata.labels.role,OWNER_KIND:metadata.ownerReferences[0].kind,OWNER_NAME:metadata.ownerReferences[0].name,PHASE:status.phase,WAIT:status.containerStatuses[*].state.waiting.reason,TERM:status.containerStatuses[*].state.terminated.reason,IMAGE:spec.containers[0].image" 2>/dev/null \
+    | awk -v aw="$_agent_re" '
+      function derive_status(ph, w, t,   a, n, i) {
+        if (w != "<none>" && w != "") { n=split(w,a,","); for(i=1;i<=n;i++) if(a[i]!="" && a[i]!="<none>") return a[i] }
+        if (t != "<none>" && t != "") { n=split(t,a,","); for(i=1;i<=n;i++) if(a[i]!="" && a[i]!="<none>") return a[i] }
+        return ph
+      }
+      $3 != "Job" && $8 !~ aw {
+        pod=$1; role=$2; ok=$3; on=$4; st=derive_status($5,$6,$7)
+        if (role != "<none>" && role != "") comp=role
+        else if (ok=="ReplicaSet") { sub(/-[a-z0-9]{8,10}$/,"",on); sub(/-deployment$/,"",on); comp=on }
+        else if (ok=="StatefulSet" || ok=="DaemonSet") { sub(/-deployment$/,"",on); comp=on }
+        else comp="(unlabeled)"
+        print comp "\t" pod "\t" st
+      }' | sort
+}
+
+function _list_platform_components() {
+  local _bucket_list=""
+  local _comp _pod _st
+  while IFS=$'\t' read -r _comp _pod _st; do
+    [[ -z "$_comp" ]] && continue
+    _bucket_list+="$_comp"$'\n'
+  done < <(_list_platform_buckets_raw)
+  if [[ -z "$_bucket_list" ]]; then
+    [[ $_LIST_NO_HEADERS -eq 0 ]] && printf "${_C_WARN}No Sysdig platform components found in namespace '%s'.${_C_RESET}\n" "$namespace"
+    return 0
+  fi
+  if (( _LIST_NO_HEADERS )); then
+    printf '%s' "$_bucket_list" | sort -u
+  else
+    printf '%s' "$_bucket_list" | sort | uniq -c | _print_component_count_table
+  fi
+}
+
+function _list_platform_pods() {
+  local _comp _pod _st _emitted=0 _filtered=""
+  # --no-headers mode: stream bare pod names, no buffering needed.
+  if (( _LIST_NO_HEADERS )); then
+    while IFS=$'\t' read -r _comp _pod _st; do
+      [[ -z "$_pod" ]] && continue
+      _list_components_match "$_comp" || continue
+      _list_status_match "$_st" || continue
+      printf "%s\n" "$_pod"
+    done < <(_list_platform_buckets_raw)
+    return 0
+  fi
+  # Table mode: buffer matching rows, then let awk compute per-column widths.
+  while IFS=$'\t' read -r _comp _pod _st; do
+    [[ -z "$_pod" ]] && continue
+    _list_components_match "$_comp" || continue
+    _list_status_match "$_st" || continue
+    _filtered+="$_pod"$'\t'"$_comp"$'\t'"$_st"$'\n'
+    _emitted=1
+  done < <(_list_platform_buckets_raw)
+  if (( _emitted == 0 )); then
+    printf "${_C_WARN}No matching Sysdig platform pods in namespace '%s'.${_C_RESET}\n" "$namespace"
+    return 0
+  fi
+  printf '%s' "$_filtered" | _print_pod_table
+}
+
+# CLI entry point for `version` (Phase 3). Prints the tool version and exits.
+# Intentionally flag-free — there's nothing to configure, so any extra
+# arguments are ignored. Reads SLC_VERSION, the single source of truth.
+function cli_version() {
+  printf 'Sysdig Log Collector version %s\n' "$SLC_VERSION"
+}
+
+case "${1:-}" in
+  ""|-h|--help)
+    print_help_root
+    exit 0
+    ;;
+  -i|--interactive|interactive)
+    clear
+    display_banner
+    disclaimer
+    initVar
+
+    while true; do
+      select_deployment_type
+      [[ "$DEPLOYMENT_TYPE" == "onprem" ]] && select_sysdig_product
+      select_orchestration_cli && break
+      # User picked "Back" in CLI selection → loop back to platform mode picker
+    done
+    select_kube_context || true   # Failure here just means no context flag; rare.
+    main_menu
+    ;;
+  collect)
+    shift
+    cli_collect "$@"
+    exit $?
+    ;;
+  list)
+    shift
+    cli_list "$@"
+    exit $?
+    ;;
+  upload)
+    shift
+    cli_upload "$@"
+    exit $?
+    ;;
+  autocomplete)
+    shift
+    cli_autocomplete "$@"
+    exit $?
+    ;;
+  version)
+    cli_version
+    exit 0
+    ;;
+  *)
+    printf "Unknown command: %s\n  Run 'sysdig-log-collector --help' for usage.\n" "$1" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## CSI-1006

Adds the `sysdig-log-collector` tool (`sysdig-log-collector/`) to this repository — a single read-only Bash script that collects a **Sysdig support bundle** from a Kubernetes cluster and optionally uploads it to Sysdig Support. The tool was developed and reviewed in the internal repository and is being published here.

### What it does
- **Agent / Shield:** collects logs and configs on any cluster (SaaS or on-prem).
- **On-prem Platform:** collects backend logs and configs.
- **Read-only:** never creates, modifies, or deletes cluster resources; it only writes a local archive and logs everything it does to the bundle's `activity.log`.
- **Secret redaction:** masks secrets in collected files before archiving.
- **Upload:** optional upload to a Sysdig-provided presigned S3 URL.

### Contents
- `sysdig-log-collector/sysdig-log-collector` — the tool (v1.0.1).
- `sysdig-log-collector/README.md` — install and usage docs.